### PR TITLE
M0: CI on pull requests, archive path-traversal fixes and release reproducibility

### DIFF
--- a/.github/scripts/build/macos.sh
+++ b/.github/scripts/build/macos.sh
@@ -109,12 +109,18 @@ cat > "$STAGING_DIR/readme.txt" <<'INSTRUCTIONS'
 qUnleashed for macOS
 ====================
 
-qUnleashed uses Apple's official application signing and notarization process.
-Temporary certification or notarization issues may occasionally cause macOS to
-place the application in quarantine or report that it is damaged.
+This build is NOT signed with an Apple Developer ID and is NOT notarized by
+Apple. macOS quarantines it on download and will refuse to open it, usually
+reporting that the application is damaged. That message is expected here and
+does not mean the download failed.
+
+Clearing the quarantine flag is therefore required to run this build. Do it
+only for a DMG you downloaded yourself from the official releases page:
+
+  https://github.com/DarkFlippers/qUnleashed/releases
 
 1. Drag qUnleashed.app to the Applications folder.
-2. If macOS prevents the application from opening, open Terminal and run:
+2. Open Terminal and run:
 
    sudo xattr -dr com.apple.quarantine "/Applications/qUnleashed.app"
    open "/Applications/qUnleashed.app"
@@ -143,13 +149,18 @@ does not disable Gatekeeper or other macOS security protections system-wide.
 qUnleashed для macOS
 ====================
 
-qUnleashed использует официальный процесс подписи и нотаризации приложений
-Apple. Иногда временные сложности с сертификацией или нотаризацией могут
-привести к тому, что macOS поместит приложение в карантин или сообщит, что оно
-повреждено.
+Эта сборка НЕ подписана Apple Developer ID и НЕ прошла нотаризацию Apple.
+macOS помещает её в карантин при загрузке и откажется открывать приложение,
+обычно с сообщением о том, что оно повреждено. Здесь это ожидаемое поведение,
+а не признак сбоя загрузки.
+
+Поэтому для запуска этой сборки необходимо снять атрибут карантина. Делайте
+это только для DMG, который вы сами скачали со страницы официальных релизов:
+
+  https://github.com/DarkFlippers/qUnleashed/releases
 
 1. Перетащите qUnleashed.app в папку Applications.
-2. Если macOS не позволяет открыть приложение, запустите Terminal и выполните:
+2. Запустите Terminal и выполните:
 
    sudo xattr -dr com.apple.quarantine "/Applications/qUnleashed.app"
    open "/Applications/qUnleashed.app"

--- a/.github/scripts/stub_firebase_config.sh
+++ b/.github/scripts/stub_firebase_config.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Writes a placeholder firebase_options.dart so `flutter analyze` and
+# `flutter test` can run on a checkout that has no Firebase secrets — a pull
+# request from a fork, or a clone by a contributor.
+#
+# This is deliberately NOT part of restore_firebase_config.sh: a release must
+# keep failing loudly when the real configuration is missing, and must never
+# fall back to a stub that ships an app whose push notifications throw.
+set -Eeuo pipefail
+
+TARGET="lib/services/notifications/firebase_options.dart"
+
+if [ -s "$TARGET" ]; then
+  echo "$TARGET already exists, leaving it alone."
+  exit 0
+fi
+
+mkdir -p "$(dirname "$TARGET")"
+cat > "$TARGET" <<'DART'
+// GENERATED PLACEHOLDER - not the real Firebase configuration.
+//
+// Written by .github/scripts/stub_firebase_config.sh so static analysis and
+// tests can run without repository secrets. Release builds restore the real
+// file from a secret instead; see .github/scripts/restore_firebase_config.sh.
+import 'package:firebase_core/firebase_core.dart' show FirebaseOptions;
+
+class DefaultFirebaseOptions {
+  const DefaultFirebaseOptions._();
+
+  static FirebaseOptions get currentPlatform => throw UnsupportedError(
+    'This build carries no Firebase configuration.',
+  );
+}
+DART
+
+echo "Wrote a placeholder $TARGET."

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -156,7 +156,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -243,7 +243,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -348,7 +348,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download release assets
         uses: actions/download-artifact@v4
@@ -428,7 +428,7 @@ jobs:
 
     steps:
       - name: Checkout default branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event.repository.default_branch }}
 

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -36,18 +36,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Set up Java
-        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: "17"
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        uses: subosito/flutter-action@v2
         with:
           flutter-version: 3.47.1
           channel: stable
@@ -139,7 +139,7 @@ jobs:
         run: .github/scripts/build/linux.sh
 
       - name: Upload Android and Linux release assets
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: release-assets-android-linux
           path: |
@@ -156,12 +156,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        uses: subosito/flutter-action@v2
         with:
           flutter-version: 3.47.1
           channel: stable
@@ -226,7 +226,7 @@ jobs:
         run: ./.github/scripts/build/windows.ps1
 
       - name: Upload Windows release asset
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: release-assets-windows
           path: |
@@ -243,12 +243,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        uses: subosito/flutter-action@v2
         with:
           flutter-version: 3.47.1
           channel: stable
@@ -328,7 +328,7 @@ jobs:
         run: .github/scripts/build/ios.sh
 
       - name: Upload macOS and iOS release assets
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: release-assets-macos
           path: |
@@ -348,10 +348,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@v4
 
       - name: Download release assets
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        uses: actions/download-artifact@v4
         with:
           path: dist
           pattern: release-assets-*
@@ -381,7 +381,7 @@ jobs:
           fi
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
@@ -398,7 +398,7 @@ jobs:
             dist/qunleashed_*_windows_x64.exe
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
@@ -428,7 +428,7 @@ jobs:
 
     steps:
       - name: Checkout default branch
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.repository.default_branch }}
 

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -36,19 +36,20 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           submodules: recursive
 
       - name: Set up Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4
         with:
           distribution: temurin
           java-version: "17"
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
+          flutter-version: 3.47.1
           channel: stable
           cache: true
 
@@ -138,7 +139,7 @@ jobs:
         run: .github/scripts/build/linux.sh
 
       - name: Upload Android and Linux release assets
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-assets-android-linux
           path: |
@@ -155,13 +156,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           submodules: recursive
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
+          flutter-version: 3.47.1
           channel: stable
           cache: true
 
@@ -224,7 +226,7 @@ jobs:
         run: ./.github/scripts/build/windows.ps1
 
       - name: Upload Windows release asset
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-assets-windows
           path: |
@@ -241,13 +243,14 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           submodules: recursive
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@v2
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
         with:
+          flutter-version: 3.47.1
           channel: stable
           cache: true
 
@@ -325,7 +328,7 @@ jobs:
         run: .github/scripts/build/ios.sh
 
       - name: Upload macOS and iOS release assets
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: release-assets-macos
           path: |
@@ -345,10 +348,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Download release assets
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: dist
           pattern: release-assets-*
@@ -378,7 +381,7 @@ jobs:
           fi
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
@@ -395,7 +398,7 @@ jobs:
             dist/qunleashed_*_windows_x64.exe
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.12"
 
@@ -425,7 +428,7 @@ jobs:
 
     steps:
       - name: Checkout default branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
         with:
           ref: ${{ github.event.repository.default_branch }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        uses: subosito/flutter-action@v2
         with:
           flutter-version: 3.47.1
           channel: stable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze and test
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          submodules: recursive
+
+      - name: Set up Flutter
+        uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2
+        with:
+          flutter-version: 3.47.1
+          channel: stable
+          cache: true
+
+      - name: Install Flutter dependencies
+        run: flutter pub get
+
+      # firebase_options.dart is generated, gitignored and restored from a
+      # secret only for releases. A placeholder keeps analysis and tests
+      # working on forks, where no secret is available.
+      - name: Stub the Firebase configuration
+        run: .github/scripts/stub_firebase_config.sh
+
+      # lib/services/localization/gen/ is gitignored, so the localization
+      # classes have to be generated before anything references them.
+      - name: Generate localizations
+        run: flutter gen-l10n
+
+      - name: Analyze
+        run: flutter analyze
+
+      - name: Test
+        run: flutter test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ permissions:
 
 concurrency:
   group: ci-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   analyze:
@@ -36,15 +36,10 @@ jobs:
         run: flutter pub get
 
       # firebase_options.dart is generated, gitignored and restored from a
-      # secret only for releases. A placeholder keeps analysis and tests
-      # working on forks, where no secret is available.
+      # secret only for releases. CI never restores the real config, so the
+      # placeholder is always written, fork or not.
       - name: Stub the Firebase configuration
         run: .github/scripts/stub_firebase_config.sh
-
-      # lib/services/localization/gen/ is gitignored, so the localization
-      # classes have to be generated before anything references them.
-      - name: Generate localizations
-        run: flutter gen-l10n
 
       - name: Analyze
         run: flutter analyze

--- a/.github/workflows/crowdin-rx.yml
+++ b/.github/workflows/crowdin-rx.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download translations
         uses: crowdin/github-action@v2

--- a/.github/workflows/crowdin-rx.yml
+++ b/.github/workflows/crowdin-rx.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Download translations
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@8f01d54f70f1713ee3f09d82c2bbb2daeac28689 # v2
         with:
           config: crowdin.yml
           upload_sources: false

--- a/.github/workflows/crowdin-rx.yml
+++ b/.github/workflows/crowdin-rx.yml
@@ -20,10 +20,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@v4
 
       - name: Download translations
-        uses: crowdin/github-action@8f01d54f70f1713ee3f09d82c2bbb2daeac28689 # v2
+        uses: crowdin/github-action@v2
         with:
           config: crowdin.yml
           upload_sources: false

--- a/.github/workflows/crowdin-tx.yml
+++ b/.github/workflows/crowdin-tx.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Upload sources
         uses: crowdin/github-action@v2

--- a/.github/workflows/crowdin-tx.yml
+++ b/.github/workflows/crowdin-tx.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Upload sources
-        uses: crowdin/github-action@v2
+        uses: crowdin/github-action@8f01d54f70f1713ee3f09d82c2bbb2daeac28689 # v2
         with:
           config: crowdin.yml
           upload_sources: true

--- a/.github/workflows/crowdin-tx.yml
+++ b/.github/workflows/crowdin-tx.yml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        uses: actions/checkout@v4
 
       - name: Upload sources
-        uses: crowdin/github-action@8f01d54f70f1713ee3f09d82c2bbb2daeac28689 # v2
+        uses: crowdin/github-action@v2
         with:
           config: crowdin.yml
           upload_sources: true

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply labels
-        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
+        uses: actions/labeler@v5
         with:
           configuration-path: .github/labeler.yml
           sync-labels: false

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,5 +1,14 @@
 name: Labeler
 
+# pull_request_target runs against the base repository, so this workflow can
+# label pull requests opened from forks. It also means the job runs with a
+# write-scoped token in the context of the target repo.
+#
+# Do NOT add actions/checkout, and do NOT run anything from the pull request
+# (scripts, build steps, dependency installs) in this workflow. Only the
+# labeler, which reads changed paths through the API, may run here. Anything
+# that needs the contributor's code belongs in ci.yml, which is triggered by
+# pull_request and has no write permissions.
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
@@ -18,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Apply labels
-        uses: actions/labeler@v5
+        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9 # v5
         with:
           configuration-path: .github/labeler.yml
           sync-labels: false

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,7 +3,7 @@ include: package:flutter_lints/flutter.yaml
 analyzer:
   exclude:
     - build/**
-    - lib/modules/flipperlib/lib/generated/**
+    - lib/modules/flipperlib/lib/src/proto/generated/**
     - android/**
     - ios/**
     - web/**

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,3 +4,9 @@ analyzer:
   exclude:
     - build/**
     - lib/modules/flipperlib/lib/generated/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**

--- a/lib/components/path.dart
+++ b/lib/components/path.dart
@@ -11,24 +11,23 @@ String pathJoin(Iterable<String> parts) {
   return out.join(sep);
 }
 
-/// Strips characters no filesystem accepts in a single path segment.
+/// Replaces the characters Windows rejects in a path segment with `_`.
 String sanitizePathSegment(String input) {
   return input.replaceAll(RegExp(r'[<>:"/\\|?*]'), '_').trim();
 }
 
-/// Resolves an archive entry name under [rootPath], or `null` when the entry
-/// would land outside it.
+/// Resolves an archive entry name under [rootPath]. Returns `null` when the
+/// entry would escape it, and equally when cleaning leaves nothing to write
+/// (`''`, `'/'`, `'./.'`) — callers skip both cases alike.
 ///
 /// Entry names come out of an archive downloaded from somewhere else, so a
 /// `..` segment is a hostile entry rather than a path to repair: it is refused
-/// instead of being normalized away, and the caller skips the entry. Absolute
-/// names are read as relative to [rootPath], since a leading separator only
-/// ever means the archive was packed from the filesystem root. Everything that
-/// survives goes through [sanitizePathSegment], so an entry that is merely
-/// illegal on Windows still unpacks.
+/// instead of being normalized away. A Windows drive prefix is not a
+/// separator and survives splitting, so `C:` is defused by
+/// [sanitizePathSegment] into a plain `C_` rather than reaching another volume.
 ///
-/// [separator] defaults to the host separator; an isolate that already carries
-/// one in its spawn arguments passes it instead.
+/// The containment check is lexical: it does not resolve symlinks, so a caller
+/// that turns entries into links can still escape [rootPath].
 String? resolveArchivePath(
   String rootPath,
   String entryName, {
@@ -39,12 +38,31 @@ String? resolveArchivePath(
     final part = raw.trim();
     if (part.isEmpty || part == '.') continue;
     if (part == '..') return null;
-    final safe = sanitizePathSegment(part);
-    if (safe.isEmpty) continue;
-    segments.add(safe);
+    segments.add(sanitizePathSegment(part));
   }
   if (segments.isEmpty) return null;
   return [rootPath, ...segments].join(separator ?? io.Platform.pathSeparator);
+}
+
+/// Resolves an archive entry that sits inside a single wrapper folder — the
+/// shape GitHub's source archives come in — under [rootPath].
+///
+/// The wrapper is whatever the first segment happens to be rather than a name
+/// worth checking, so it is stripped and an entry sitting beside it at the
+/// archive root is skipped. Containment is [resolveArchivePath]'s.
+String? resolveWrappedArchivePath(
+  String rootPath,
+  String entryName, {
+  String? separator,
+}) {
+  final name = entryName.replaceAll('\\', '/');
+  final slash = name.indexOf('/');
+  if (slash < 0) return null;
+  return resolveArchivePath(
+    rootPath,
+    name.substring(slash + 1),
+    separator: separator,
+  );
 }
 
 /// Last segment of a `/`-separated path, e.g. `/ext/apps/foo.fap` -> `foo.fap`.

--- a/lib/components/path.dart
+++ b/lib/components/path.dart
@@ -16,6 +16,37 @@ String sanitizePathSegment(String input) {
   return input.replaceAll(RegExp(r'[<>:"/\\|?*]'), '_').trim();
 }
 
+/// Resolves an archive entry name under [rootPath], or `null` when the entry
+/// would land outside it.
+///
+/// Entry names come out of an archive downloaded from somewhere else, so a
+/// `..` segment is a hostile entry rather than a path to repair: it is refused
+/// instead of being normalized away, and the caller skips the entry. Absolute
+/// names are read as relative to [rootPath], since a leading separator only
+/// ever means the archive was packed from the filesystem root. Everything that
+/// survives goes through [sanitizePathSegment], so an entry that is merely
+/// illegal on Windows still unpacks.
+///
+/// [separator] defaults to the host separator; an isolate that already carries
+/// one in its spawn arguments passes it instead.
+String? resolveArchivePath(
+  String rootPath,
+  String entryName, {
+  String? separator,
+}) {
+  final segments = <String>[];
+  for (final raw in entryName.split(RegExp(r'[/\\]'))) {
+    final part = raw.trim();
+    if (part.isEmpty || part == '.') continue;
+    if (part == '..') return null;
+    final safe = sanitizePathSegment(part);
+    if (safe.isEmpty) continue;
+    segments.add(safe);
+  }
+  if (segments.isEmpty) return null;
+  return [rootPath, ...segments].join(separator ?? io.Platform.pathSeparator);
+}
+
 /// Last segment of a `/`-separated path, e.g. `/ext/apps/foo.fap` -> `foo.fap`.
 String basename(String path) {
   final slash = path.lastIndexOf('/');

--- a/lib/pages/apps/data/atp/atp_source.dart
+++ b/lib/pages/apps/data/atp/atp_source.dart
@@ -236,9 +236,11 @@ class AtpArchive {
         final start = parts.indexWhere((e) => e.startsWith('artifacts-'));
         final relative = parts.sublist(start >= 0 ? start + 1 : 0);
         if (relative.isEmpty) continue;
-        final out = io.File(
-          pathJoin([dir.path, ...relative.map(sanitizePathSegment)]),
-        );
+        // The pack is a third-party download, so an entry that points out of
+        // the pack directory is dropped rather than written.
+        final outPath = resolveArchivePath(dir.path, relative.join('/'));
+        if (outPath == null) continue;
+        final out = io.File(outPath);
         await out.parent.create(recursive: true);
         await out.writeAsBytes(file.readBytes() ?? const [], flush: true);
         written++;

--- a/lib/pages/apps/data/atp/atp_source.dart
+++ b/lib/pages/apps/data/atp/atp_source.dart
@@ -175,6 +175,9 @@ class AtpArchive {
     void Function(int received, int? total)? onProgress,
   }) async {
     final file = await fapFile(entry, tag);
+    if (file == null) {
+      throw StateError('"${entry.archivePath}" is not a path the pack can hold');
+    }
     if (!await file.exists()) {
       final key = '$tag/${entry.pack}';
       await (_unpacking[key] ??= _unpack(entry.pack, url, tag, onProgress)
@@ -199,18 +202,13 @@ class AtpArchive {
     );
   }
 
-  Future<io.File> fapFile(AtpEntry entry, String tag) async {
+  /// Where [_unpack] would have written this entry, resolved the same way, so
+  /// the reader never looks somewhere the writer could not put a file.
+  /// `null` when the entry names no path the unpacker would accept.
+  Future<io.File?> fapFile(AtpEntry entry, String tag) async {
     final dir = await _packDirectory(entry.pack, tag);
-    return io.File(
-      pathJoin([
-        dir.path,
-        ...entry.folder
-            .split('/')
-            .where((e) => e.isNotEmpty)
-            .map(sanitizePathSegment),
-        '${entry.appId}.fap',
-      ]),
-    );
+    final path = resolveArchivePath(dir.path, entry.archivePath);
+    return path == null ? null : io.File(path);
   }
 
   Future<void> _unpack(
@@ -232,13 +230,14 @@ class AtpArchive {
       var written = 0;
       for (final file in archive.files) {
         if (!file.isFile || !file.name.endsWith('.fap')) continue;
-        final parts = file.name.split('/').where((e) => e.isNotEmpty).toList();
+        final parts = file.name.split('/');
         final start = parts.indexWhere((e) => e.startsWith('artifacts-'));
-        final relative = parts.sublist(start >= 0 ? start + 1 : 0);
-        if (relative.isEmpty) continue;
         // The pack is a third-party download, so an entry that points out of
         // the pack directory is dropped rather than written.
-        final outPath = resolveArchivePath(dir.path, relative.join('/'));
+        final outPath = resolveArchivePath(
+          dir.path,
+          parts.sublist(start >= 0 ? start + 1 : 0).join('/'),
+        );
         if (outPath == null) continue;
         final out = io.File(outPath);
         await out.parent.create(recursive: true);

--- a/lib/pages/apps/manager/install_page.dart
+++ b/lib/pages/apps/manager/install_page.dart
@@ -143,7 +143,7 @@ class _AtpInstallPageState extends State<AtpInstallPage> {
   Future<FapInfo?> _readFap(AtpEntry entry) async {
     try {
       final file = await AtpArchive.instance.fapFile(entry, _atp.tag);
-      if (!await file.exists()) return null;
+      if (file == null || !await file.exists()) return null;
       return FapInfo.parse(await file.readAsBytes());
     } catch (_) {
       return null;

--- a/lib/pages/devices/firmware/installer.dart
+++ b/lib/pages/devices/firmware/installer.dart
@@ -270,6 +270,9 @@ class FirmwareInstaller {
       if (!f.isFile) continue;
       final parts = f.name.split('/').where((p) => p.isNotEmpty).toList();
       if (parts.length < 2) continue;
+      // The archive root is later joined onto `/ext/update` as a directory on
+      // the device, so a relative segment here would walk out of it.
+      if (parts.first == '.' || parts.first == '..') continue;
       dirName ??= parts.first;
       if (parts.first != dirName) continue;
       final basename = parts.last;

--- a/lib/pages/tools/infrared/local_repo.dart
+++ b/lib/pages/tools/infrared/local_repo.dart
@@ -219,18 +219,9 @@ class IrLibLocalRepo {
       send.send(_UnpackProgress(extracted, totalFiles, false));
 
       for (final entry in archive.files) {
-        var name = entry.name.replaceAll('\\', '/');
-        final slash = name.indexOf('/');
-        if (slash < 0) continue;
-        // The GitHub zipball wraps everything in one <repo>-<branch> folder,
-        // which is not part of the library layout.
-        name = name.substring(slash + 1);
-        if (name.isEmpty) continue;
-        // The archive is a third-party download, so an entry that points out
-        // of the library root is dropped rather than written.
-        final outPath = resolveArchivePath(
+        final outPath = resolveWrappedArchivePath(
           args.rootPath,
-          name,
+          entry.name,
           separator: args.sep,
         );
         if (outPath == null) continue;

--- a/lib/pages/tools/infrared/local_repo.dart
+++ b/lib/pages/tools/infrared/local_repo.dart
@@ -6,6 +6,7 @@ import 'dart:isolate';
 import 'package:archive/archive_io.dart';
 import 'package:path_provider/path_provider.dart';
 
+import '../../../components/path.dart';
 import '../../../services/http/app_http.dart';
 import '../../../services/storage/paths.dart';
 
@@ -221,10 +222,18 @@ class IrLibLocalRepo {
         var name = entry.name.replaceAll('\\', '/');
         final slash = name.indexOf('/');
         if (slash < 0) continue;
+        // The GitHub zipball wraps everything in one <repo>-<branch> folder,
+        // which is not part of the library layout.
         name = name.substring(slash + 1);
         if (name.isEmpty) continue;
-        final outPath =
-            '${args.rootPath}${args.sep}${name.replaceAll('/', args.sep)}';
+        // The archive is a third-party download, so an entry that points out
+        // of the library root is dropped rather than written.
+        final outPath = resolveArchivePath(
+          args.rootPath,
+          name,
+          separator: args.sep,
+        );
+        if (outPath == null) continue;
         if (entry.isFile) {
           final file = io.File(outPath);
           file.parent.createSync(recursive: true);

--- a/lib/services/archive/storage.dart
+++ b/lib/services/archive/storage.dart
@@ -299,7 +299,7 @@ class ArchiveStorage {
       await resolveRootDir();
       final file = _fapIconFile(deviceName, remotePath);
       if (!await file.exists()) return null;
-      return file.readAsBytes();
+      return await file.readAsBytes();
     } catch (_) {
       return null;
     }

--- a/lib/services/http/app_http.dart
+++ b/lib/services/http/app_http.dart
@@ -121,6 +121,10 @@ class AppHttp {
       return _decodeCachedBody(cached.body);
     }
 
+    // Only the fetch is guarded, and the body is decoded after it: falling back
+    // to a stale copy is the answer to a network failure, not to a response
+    // that arrived and will not parse.
+    final String body;
     try {
       final etag = cached?.etag ?? '';
       final res = await get(uri, headers: {
@@ -131,27 +135,29 @@ class AppHttp {
       if (res.statusCode == io.HttpStatus.notModified && cached != null) {
         await res.drain<void>();
         if (file != null) await cached.refresh(file);
-        return await _decodeCachedBody(cached.body);
+        body = cached.body;
+      } else {
+        final text = await res.transform(utf8.decoder).join();
+        if (res.statusCode < 200 || res.statusCode >= 300) {
+          throw AppHttpException(res.statusCode, uri.toString(), text);
+        }
+        if (file != null) {
+          final entry = _JsonCacheEntry(
+            etag: res.headers.value(io.HttpHeaders.etagHeader) ?? '',
+            fetchedAt: DateTime.now(),
+            body: text,
+          );
+          try {
+            await entry.write(file);
+          } catch (_) {}
+        }
+        body = text;
       }
-      final text = await res.transform(utf8.decoder).join();
-      if (res.statusCode < 200 || res.statusCode >= 300) {
-        throw AppHttpException(res.statusCode, uri.toString(), text);
-      }
-      if (file != null) {
-        final entry = _JsonCacheEntry(
-          etag: res.headers.value(io.HttpHeaders.etagHeader) ?? '',
-          fetchedAt: DateTime.now(),
-          body: text,
-        );
-        try {
-          await entry.write(file);
-        } catch (_) {}
-      }
-      return await _decodeCachedBody(text);
     } catch (_) {
       if (cached != null) return _decodeCachedBody(cached.body);
       rethrow;
     }
+    return _decodeCachedBody(body);
   }
 
   static Future<dynamic> _decodeCachedBody(String text) {

--- a/lib/services/http/app_http.dart
+++ b/lib/services/http/app_http.dart
@@ -131,7 +131,7 @@ class AppHttp {
       if (res.statusCode == io.HttpStatus.notModified && cached != null) {
         await res.drain<void>();
         if (file != null) await cached.refresh(file);
-        return _decodeCachedBody(cached.body);
+        return await _decodeCachedBody(cached.body);
       }
       final text = await res.transform(utf8.decoder).join();
       if (res.statusCode < 200 || res.statusCode >= 300) {
@@ -147,7 +147,7 @@ class AppHttp {
           await entry.write(file);
         } catch (_) {}
       }
-      return _decodeCachedBody(text);
+      return await _decodeCachedBody(text);
     } catch (_) {
       if (cached != null) return _decodeCachedBody(cached.body);
       rethrow;

--- a/lib/services/storage/fap_icons.dart
+++ b/lib/services/storage/fap_icons.dart
@@ -25,7 +25,7 @@ Future<bool> hasFapIcon(String appId) async {
   if (id.isEmpty) return false;
   try {
     final dir = await fapIconRepoDirectory();
-    return _fapIconRepoFile(dir, id).exists();
+    return await _fapIconRepoFile(dir, id).exists();
   } catch (_) {
     return false;
   }
@@ -38,7 +38,7 @@ Future<Uint8List?> readFapIcon(String appId) async {
     final dir = await fapIconRepoDirectory();
     final file = _fapIconRepoFile(dir, id);
     if (!await file.exists()) return null;
-    return file.readAsBytes();
+    return await file.readAsBytes();
   } catch (_) {
     return null;
   }

--- a/test/archive_path_test.dart
+++ b/test/archive_path_test.dart
@@ -1,9 +1,45 @@
-import 'package:qunleashed/components/path.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:qunleashed/components/path.dart';
 
 /// A fixed separator keeps the expectations readable and makes the suite
 /// behave the same on every host.
-String? resolve(String name) => resolveArchivePath('/root', name, separator: '/');
+String? resolve(String name) =>
+    resolveArchivePath('/root', name, separator: '/');
+
+String? resolveWrapped(String name) =>
+    resolveWrappedArchivePath('/root', name, separator: '/');
+
+/// Entry names an archive has no business carrying, each with the exact result
+/// it must produce. Spelling out the `null`s is the point: an implementation
+/// that "repaired" a traversal by popping a segment instead of refusing it
+/// would still keep every result inside the root, so only pinning the refusal
+/// catches it.
+const Map<String, String?> hostileNames = {
+  '../evil': null,
+  '../../evil': null,
+  'a/../../evil': null,
+  'a/b/../../../../../evil': null,
+  './../evil': null,
+  'a/./../../evil': null,
+  r'..\evil': null,
+  r'a\..\..\evil': null,
+  'a/..\\../evil': null,
+  ' .. /evil': null,
+  'a/ ..  /evil': null,
+  '/../evil': null,
+  '//../../evil': null,
+  '..': null,
+  '../': null,
+  'a/b/..': null,
+  '': null,
+  '/': null,
+  './.': null,
+  // Not traversals: they stay inside the root as literal names.
+  r'C:\Windows\evil': '/root/C_/Windows/evil',
+  r'\\server\share\evil': '/root/server/share/evil',
+  '....//....//evil': '/root/..../..../evil',
+  'a/...../../../evil': null,
+};
 
 void main() {
   group('resolveArchivePath', () {
@@ -54,11 +90,55 @@ void main() {
       expect(resolve(r'C:\Windows\evil'), '/root/C_/Windows/evil');
     });
 
-    test('defaults to the host separator when none is given', () {
-      final joined = resolveArchivePath('/root', 'a/b');
-      expect(joined, isNotNull);
-      expect(joined, startsWith('/root'));
-      expect(joined, endsWith('b'));
+    test('builds the path with the separator it is given', () {
+      // The IRDB unpacker runs in an isolate and passes the host separator
+      // through its spawn arguments, so this parameter is load-bearing on
+      // Windows rather than a testing convenience.
+      expect(
+        resolveArchivePath(r'C:\root', 'Samsung/TV.ir', separator: r'\'),
+        r'C:\root\Samsung\TV.ir',
+      );
+    });
+
+    test('resolves every hostile name to exactly the documented result', () {
+      hostileNames.forEach((name, expected) {
+        expect(resolve(name), expected, reason: 'entry: "$name"');
+      });
+    });
+  });
+
+  group('resolveWrappedArchivePath', () {
+    test('strips the wrapper folder the source archive adds', () {
+      expect(
+        resolveWrapped('Flipper-IRDB-main/Samsung/TV.ir'),
+        '/root/Samsung/TV.ir',
+      );
+    });
+
+    test('skips an entry sitting beside the wrapper folder', () {
+      expect(resolveWrapped('README.md'), isNull);
+    });
+
+    test('skips the wrapper folder itself', () {
+      expect(resolveWrapped('Flipper-IRDB-main/'), isNull);
+    });
+
+    // The regression this guards: before the containment check, the unpacker
+    // joined the stripped name straight onto the root, so these wrote outside
+    // the IR library entirely.
+    test('refuses an entry escaping the library root', () {
+      expect(resolveWrapped('Flipper-IRDB-main/../../evil'), isNull);
+      expect(resolveWrapped(r'Flipper-IRDB-main\..\..\evil'), isNull);
+    });
+
+    test('applies the same refusals once the wrapper is stripped', () {
+      hostileNames.forEach((name, expected) {
+        expect(
+          resolveWrapped('Flipper-IRDB-main/$name'),
+          expected,
+          reason: 'entry: "$name"',
+        );
+      });
     });
   });
 }

--- a/test/archive_path_test.dart
+++ b/test/archive_path_test.dart
@@ -1,0 +1,64 @@
+import 'package:qunleashed/components/path.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// A fixed separator keeps the expectations readable and makes the suite
+/// behave the same on every host.
+String? resolve(String name) => resolveArchivePath('/root', name, separator: '/');
+
+void main() {
+  group('resolveArchivePath', () {
+    test('joins a plain relative entry under the root', () {
+      expect(resolve('Samsung/TV.ir'), '/root/Samsung/TV.ir');
+    });
+
+    test('accepts backslash separated entries', () {
+      expect(resolve(r'Samsung\TV.ir'), '/root/Samsung/TV.ir');
+    });
+
+    test('drops empty and current-directory segments', () {
+      expect(resolve('.//Samsung/./TV.ir'), '/root/Samsung/TV.ir');
+    });
+
+    test('reads an absolute entry as relative to the root', () {
+      expect(resolve('/etc/passwd'), '/root/etc/passwd');
+    });
+
+    test('refuses a parent-directory segment', () {
+      expect(resolve('../evil'), isNull);
+      expect(resolve('Samsung/../../evil'), isNull);
+      expect(resolve('a/b/../../../../evil'), isNull);
+    });
+
+    test('refuses a parent-directory segment written with backslashes', () {
+      expect(resolve(r'..\..\evil'), isNull);
+      expect(resolve(r'Samsung\..\..\evil'), isNull);
+    });
+
+    test('refuses a parent-directory segment padded with whitespace', () {
+      expect(resolve('Samsung/ .. /evil'), isNull);
+    });
+
+    test('refuses an entry with nothing left to write', () {
+      expect(resolve(''), isNull);
+      expect(resolve('/'), isNull);
+      expect(resolve('./.'), isNull);
+    });
+
+    test('sanitizes characters no filesystem accepts', () {
+      expect(resolve('So?ny/T*V.ir'), '/root/So_ny/T_V.ir');
+    });
+
+    test('neutralizes a Windows drive prefix into a plain segment', () {
+      // The colon cannot survive as a drive letter, so the entry stays inside
+      // the root instead of being redirected to another volume.
+      expect(resolve(r'C:\Windows\evil'), '/root/C_/Windows/evil');
+    });
+
+    test('defaults to the host separator when none is given', () {
+      final joined = resolveArchivePath('/root', 'a/b');
+      expect(joined, isNotNull);
+      expect(joined, startsWith('/root'));
+      expect(joined, endsWith('b'));
+    });
+  });
+}

--- a/test/remote_layout_test.dart
+++ b/test/remote_layout_test.dart
@@ -218,9 +218,6 @@ void main() {
                 layout.wide
                     ? RemoteActionBar(
                         size: layout.actionsSize,
-                        showSession: false,
-                        sessionBusy: false,
-                        onRequestSession: () {},
                         gifState: state,
                         gifElapsedMs: 12300,
                         justUnlocked: false,

--- a/test/remote_session_test.dart
+++ b/test/remote_session_test.dart
@@ -83,33 +83,4 @@ void main() {
     await Future<void>.delayed(const Duration(milliseconds: 50));
     expect(client.startStreamCalls, 1, reason: 'nothing automatic behind it');
   });
-
-  test('requestSession re-opens the stream and reports its progress', () async {
-    final client = _FakeClient()..failCalls = true;
-    final session = RemoteSession(client: client);
-    addTearDown(session.dispose);
-
-    await Future<void>.delayed(Duration.zero);
-    expect(session.sessionBusy, isFalse);
-
-    final future = session.requestSession();
-    expect(session.sessionBusy, isTrue, reason: 'drives the spinner');
-    await future;
-
-    expect(session.sessionBusy, isFalse);
-    expect(client.startStreamCalls, 2, reason: 'asked again on demand');
-  });
-
-  test('a concurrent request is ignored while one is in flight', () async {
-    final client = _FakeClient();
-    final session = RemoteSession(client: client);
-    addTearDown(session.dispose);
-
-    await Future<void>.delayed(Duration.zero);
-    final first = session.requestSession();
-    final second = session.requestSession();
-    await Future.wait([first, second]);
-
-    expect(client.startStreamCalls, 2, reason: 'the open plus one request');
-  });
 }


### PR DESCRIPTION
Closes #16.

Turns on CI, then fixes what turning it on revealed. First milestone of the release-engineering roadmap; independent of every open decision (version scheme, build-server hosting, Windows packaging).

## CI

`.github/workflows/ci.yml` runs `flutter analyze` and `flutter test` on pull requests and pushes to `main`. Nothing ran the 26 test files before, and nothing blocked a merge that failed to analyze.

One thing stood in the way of a clean checkout: `push_service.dart` imports `firebase_options.dart`, which is gitignored and restored from a secret that fork PRs never see. `stub_firebase_config.sh` writes a placeholder for analysis and tests only. It is deliberately **not** part of `restore_firebase_config.sh` — a release still fails loudly without the real config, so this cannot silently ship a build whose push notifications throw.

Flutter is pinned to 3.47.1, which is what makes a build reproducible between two tags of the same source. Actions stay on their major tags: SHA pinning was tried and reverted — a 40-character SHA on every `uses:` line costs more readability than the mutable-tag risk is worth here, and a bump becomes an opaque diff nobody can review.

## What CI found

`flutter analyze` exited 1 on a fresh checkout, with 9 errors and 5 warnings that had been sitting on `main`:

- **Two test files no longer compiled.** `2d21335` replaced the manual remote session button with automatic restart on connect and never updated the tests. The orphaned cases and three stale `RemoteActionBar` params are removed rather than rewritten against an API that no longer exists.
- **Five `Future`s returned from inside a `try` whose `catch` was meant to swallow IO errors.** The catch never saw them, so the intended `return null` fallback never happened. Four are one-word `await` fixes; the fifth is below.

## Archive path traversal

`resolveArchivePath` refuses an entry that would escape its destination instead of normalizing the traversal away, and `resolveWrappedArchivePath` layers on the single-wrapper-folder strip that GitHub source archives need. Three call sites now go through them:

- **IRDB unpacker** (`local_repo.dart`) — no containment check at all, any file type. The archive comes from a repository the user can point anywhere.
- **all-the-plugins unpacker** (`atp_source.dart`) — `sanitizePathSegment` leaves `..` intact, so this was live: an entry named `../../../evil.fap` wrote outside the pack directory.
- **Firmware installer** (`installer.dart`) — the archive root is joined onto `/ext/update` as a directory on the device, so a relative segment walked out of it on the SD card.

`AtpArchive.fapFile` now resolves the same way the unpacker writes, so the reader can no longer look somewhere the writer could not put a file.

## Correctness

The DMG readme claimed the build "uses Apple's official application signing and notarization process" while telling users to `sudo xattr -dr com.apple.quarantine`. The project builds with `CODE_SIGN_IDENTITY = "-"` and has no `notarytool` step, so it was teaching users to strip Gatekeeper from an unsigned binary while asserting it was notarized. Both language blocks now say what is true. Real signing is M5.

## Review

Eight agents reviewed this across two passes. The substantive corrections they produced, all folded in:

- The `await` added to `app_http`'s cached GET widened the catch over the decode, so a response that arrived and would not parse quietly served a stale copy. The `try` now covers only the fetch — which also drops a second `compute` isolate the catch used to spawn.
- The hostile-name table asserted nothing on the 20 entries that resolve to `null`, and its comment claimed it would catch a `..`-popping refactor. It would not: that refactor keeps every result inside the root. Each name is now pinned to its exact expected result.
- The wrapper-strip helper was a pure string function living in a page module, which dragged the l10n codegen into a test that touches no IO.

## Notes

- **No format gate.** The repo is not `dart format`-clean (6 test files); reformatting would have buried this diff. Worth its own issue.
- **`flutter pub get` runs without `--enforce-lockfile`.** It should have it, but `--enforce-lockfile` currently fails with "Would change 5 dependencies" — the committed lockfile predates the pinned SDK. Filed separately, since the fix commits a dependency bump.
- `analysis_options.yaml` gained platform excludes that `flutter analyze` wrote itself, and its `flipperlib` exclude pointed at a path that does not exist — now corrected to the generated protobuf directory.

Verified locally: `flutter analyze` clean, 226 tests pass.
