### PR TITLE
CI: extract the version derivation and Flutter setup

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -13,13 +13,9 @@ inputs:
     default: "3.47.1"
   swift-package-manager:
     description: >
-      Set to "false" on any job that builds for macOS or iOS. Firebase pulls grpc
-      as an SPM binary target (grpc.zip from dl.google.com), which flakes with
-      "network connection was lost" on macOS runners. Both ios/ and macos/ have
-      CocoaPods set up, so those builds go through pods instead. It is settled
-      here because this action runs `pub get` itself, which leaves a caller no
-      seam between install and fetch. Any value other than true or false is an
-      error rather than a silent skip.
+      Set to "false" on any job that builds for macOS or iOS. pubspec.yaml now
+      carries the same setting for the project, so this is belt and braces at
+      the runner level until one macOS release confirms the project key holds.
     required: false
     default: "true"
 
@@ -49,7 +45,6 @@ runs:
             exit 1
             ;;
         esac
-        flutter config --list | grep -i "swift-package-manager" || true
 
     - name: Install Flutter dependencies
       shell: bash

--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -1,21 +1,25 @@
 name: Set up Flutter
 description: >
-  Installs the pinned Flutter SDK and fetches dependencies. Run it after
-  actions/checkout: a local composite action lives in the repository, so the
-  repository has to be on disk before this can be resolved.
+  Installs the pinned Flutter SDK, settles the Swift Package Manager setting and
+  fetches dependencies. Run it after actions/checkout: a local composite action
+  lives in the repository, so the repository has to be on disk before this can be
+  resolved. Note that the SPM setting is written to the runner's global Flutter
+  config and persists for the rest of the job.
 
 inputs:
   flutter-version:
-    description: Flutter SDK version to install. Pinned so a build is reproducible between two tags of the same source.
+    description: Flutter SDK version to install. Every job in this repository builds on the same default; override only to trial a different SDK.
     required: false
     default: "3.47.1"
   swift-package-manager:
     description: >
-      Set to "false" on macOS and iOS jobs. Firebase pulls grpc as an SPM binary
-      target (grpc.zip from dl.google.com), which flakes with "network connection
-      was lost" on macOS runners. Both ios/ and macos/ have CocoaPods set up, so
-      those builds go through pods instead. Must be applied before `pub get`,
-      which is why it lives here rather than in the calling job.
+      Set to "false" on any job that builds for macOS or iOS. Firebase pulls grpc
+      as an SPM binary target (grpc.zip from dl.google.com), which flakes with
+      "network connection was lost" on macOS runners. Both ios/ and macos/ have
+      CocoaPods set up, so those builds go through pods instead. It is settled
+      here because this action runs `pub get` itself, which leaves a caller no
+      seam between install and fetch. Any value other than true or false is an
+      error rather than a silent skip.
     required: false
     default: "true"
 
@@ -29,10 +33,23 @@ runs:
         channel: stable
         cache: true
 
-    - name: Disable Swift Package Manager
-      if: inputs.swift-package-manager == 'false'
+    # Always runs and always reports, so a mistyped input cannot leave a macOS
+    # build silently on SPM - the failure it would cause surfaces far from here,
+    # in a release pipeline that cannot be dry-run.
+    - name: Configure Swift Package Manager
       shell: bash
-      run: flutter config --no-enable-swift-package-manager
+      env:
+        SPM: ${{ inputs.swift-package-manager }}
+      run: |
+        case "$SPM" in
+          true)  flutter config --enable-swift-package-manager ;;
+          false) flutter config --no-enable-swift-package-manager ;;
+          *)
+            echo "::error::swift-package-manager must be 'true' or 'false', got '$SPM'."
+            exit 1
+            ;;
+        esac
+        flutter config --list | grep -i "swift-package-manager" || true
 
     - name: Install Flutter dependencies
       shell: bash

--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -1,0 +1,39 @@
+name: Set up Flutter
+description: >
+  Installs the pinned Flutter SDK and fetches dependencies. Run it after
+  actions/checkout: a local composite action lives in the repository, so the
+  repository has to be on disk before this can be resolved.
+
+inputs:
+  flutter-version:
+    description: Flutter SDK version to install. Pinned so a build is reproducible between two tags of the same source.
+    required: false
+    default: "3.47.1"
+  swift-package-manager:
+    description: >
+      Set to "false" on macOS and iOS jobs. Firebase pulls grpc as an SPM binary
+      target (grpc.zip from dl.google.com), which flakes with "network connection
+      was lost" on macOS runners. Both ios/ and macos/ have CocoaPods set up, so
+      those builds go through pods instead. Must be applied before `pub get`,
+      which is why it lives here rather than in the calling job.
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Install Flutter
+      uses: subosito/flutter-action@v2
+      with:
+        flutter-version: ${{ inputs.flutter-version }}
+        channel: stable
+        cache: true
+
+    - name: Disable Swift Package Manager
+      if: inputs.swift-package-manager == 'false'
+      shell: bash
+      run: flutter config --no-enable-swift-package-manager
+
+    - name: Install Flutter dependencies
+      shell: bash
+      run: flutter pub get

--- a/.github/scripts/derive_version.sh
+++ b/.github/scripts/derive_version.sh
@@ -1,34 +1,25 @@
 #!/usr/bin/env bash
-# Derives the app version from the release tag, so the build jobs and the
-# pubspec sync job cannot disagree about what a tag means.
+# Derives the app version from the release tag, so no two jobs can disagree
+# about what a tag means.
 #
-#   derive_version.sh                 # append the values to $GITHUB_ENV
+#   derive_version.sh                 # write to $GITHUB_ENV and $GITHUB_OUTPUT
 #   derive_version.sh --print         # write "<name> <code>" to stdout instead
-#   derive_version.sh --print 0.13.0  # ... for an explicit tag, for tests
+#   derive_version.sh --print <tag>   # ... for an explicit tag
 #
-# Without an explicit tag the value comes from $GITHUB_REF_NAME.
-#
-# --print is a production contract, not a test affordance: the pubspec sync job
-# reads its stdout with `read`, which cannot tell a diagnostic line from the
-# answer. Everything except the single result line must go to stderr.
-#
-# Caveat on provenance: the sync job checks out the default branch, so it runs
-# main's copy of this script while the build jobs run the tag's. They agree as
-# long as this file has not changed between the tagged commit and the release.
+# Without an explicit tag the value comes from $GITHUB_REF_NAME. --print exists
+# for the tests; jobs consume the values through the environment or through the
+# step output, so nothing in the workflow depends on this script's stdout.
 #
 # QU_BUILD_SERVER_URL and QU_BUILD_SERVER_KEY are folded into the Flutter build
-# arguments only when *both* are set, since a URL without a key authenticates
-# nothing. QU_CARTO_KEY is independent. Leaving QU_CARTO_KEY unset ships a build
-# whose basemap falls back to the key the user supplies; leaving the build-server
-# pair unset does not disable that feature, because the app carries a default
-# address (see remote_build_service.dart) - it only makes server builds fail.
+# arguments only when both are set, since a URL without a key authenticates
+# nothing. QU_CARTO_KEY is independent.
 set -Eeuo pipefail
 
 print_only=0
-if [[ "${1:-}" == "--print" ]]; then
-  print_only=1
-  shift
-fi
+case "${1:-}" in
+  --print) print_only=1; shift ;;
+  --*) echo "Usage: $0 [--print] [tag]" >&2; exit 2 ;;
+esac
 
 tag="${1:-${GITHUB_REF_NAME:-}}"
 if [[ -z "$tag" ]]; then
@@ -68,30 +59,40 @@ fi
 
 # The build scripts re-split QUNLEASHED_FLUTTER_BUILD_ARGS on whitespace, so a
 # secret carrying a newline or a space would silently drop every argument after
-# it - or add one. Fail here instead of shipping a release missing a key.
+# it - or add one. Failing here beats shipping a release missing a key. This
+# guards one producer of a string transport that cannot carry whitespace at all;
+# see the issue on replacing that transport.
 for name in QU_BUILD_SERVER_URL QU_BUILD_SERVER_KEY QU_CARTO_KEY; do
-  value="${!name:-}"
-  if [[ -n "$value" && "$value" =~ [[:space:]] ]]; then
+  if [[ "${!name:-}" =~ [[:space:]] ]]; then
     echo "::error::$name contains whitespace, which would corrupt the build arguments." >&2
     exit 1
   fi
 done
 
-build_args="--build-name=$version_name --build-number=$version_code"
-build_args="$build_args --dart-define=QUNLEASHED_RELEASE_TAG=$tag"
+args=(--build-name="$version_name" --build-number="$version_code")
+args+=(--dart-define=QUNLEASHED_RELEASE_TAG="$tag")
 if [[ -n "${QU_BUILD_SERVER_URL:-}" && -n "${QU_BUILD_SERVER_KEY:-}" ]]; then
-  build_args="$build_args --dart-define=QU_BUILD_SERVER_URL=$QU_BUILD_SERVER_URL"
-  build_args="$build_args --dart-define=QU_BUILD_SERVER_KEY=$QU_BUILD_SERVER_KEY"
+  args+=(--dart-define=QU_BUILD_SERVER_URL="$QU_BUILD_SERVER_URL")
+  args+=(--dart-define=QU_BUILD_SERVER_KEY="$QU_BUILD_SERVER_KEY")
 fi
 if [[ -n "${QU_CARTO_KEY:-}" ]]; then
-  build_args="$build_args --dart-define=QU_CARTO_KEY=$QU_CARTO_KEY"
+  args+=(--dart-define=QU_CARTO_KEY="$QU_CARTO_KEY")
 fi
 
 {
   echo "QUNLEASHED_VERSION_NAME=$version_name"
   echo "QUNLEASHED_VERSION_CODE=$version_code"
-  echo "QUNLEASHED_FLUTTER_BUILD_ARGS=$build_args"
+  echo "QUNLEASHED_FLUTTER_BUILD_ARGS=${args[*]}"
 } >> "$GITHUB_ENV"
+
+# Also published as a step output so a later job can reuse the version without
+# re-deriving it from its own checkout of this script.
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "version_name=$version_name"
+    echo "version_code=$version_code"
+  } >> "$GITHUB_OUTPUT"
+fi
 
 echo "Version name: $version_name" >&2
 echo "Version code: $version_code" >&2

--- a/.github/scripts/derive_version.sh
+++ b/.github/scripts/derive_version.sh
@@ -3,15 +3,25 @@
 # pubspec sync job cannot disagree about what a tag means.
 #
 #   derive_version.sh                 # append the values to $GITHUB_ENV
-#   derive_version.sh --print         # print "<name> <code>" to stdout instead
+#   derive_version.sh --print         # write "<name> <code>" to stdout instead
 #   derive_version.sh --print 0.13.0  # ... for an explicit tag, for tests
 #
 # Without an explicit tag the value comes from $GITHUB_REF_NAME.
 #
-# In the default mode QU_BUILD_SERVER_URL, QU_BUILD_SERVER_KEY and QU_CARTO_KEY
-# are read from the environment and folded into the Flutter build arguments when
-# set. A build without them still succeeds, with that feature disabled at
-# runtime, so a fork can cut a build it can actually use.
+# --print is a production contract, not a test affordance: the pubspec sync job
+# reads its stdout with `read`, which cannot tell a diagnostic line from the
+# answer. Everything except the single result line must go to stderr.
+#
+# Caveat on provenance: the sync job checks out the default branch, so it runs
+# main's copy of this script while the build jobs run the tag's. They agree as
+# long as this file has not changed between the tagged commit and the release.
+#
+# QU_BUILD_SERVER_URL and QU_BUILD_SERVER_KEY are folded into the Flutter build
+# arguments only when *both* are set, since a URL without a key authenticates
+# nothing. QU_CARTO_KEY is independent. Leaving QU_CARTO_KEY unset ships a build
+# whose basemap falls back to the key the user supplies; leaving the build-server
+# pair unset does not disable that feature, because the app carries a default
+# address (see remote_build_service.dart) - it only makes server builds fail.
 set -Eeuo pipefail
 
 print_only=0
@@ -27,12 +37,14 @@ if [[ -z "$tag" ]]; then
 fi
 
 if [[ ! "$tag" =~ ([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-  echo "::error::Tag must contain a semantic version like 0.6.1, dev-0.6.1, or beta-0.6.1." >&2
+  echo "::error::Tag must contain a semantic version like 0.6.1, alpha-0.6.1, or beta-0.6.1." >&2
   exit 1
 fi
 
-# Forced base 10 once, so a zero-padded component cannot be read as octal and
-# cannot leave the name and the code disagreeing (`0.08.09` -> 0.8.9 / 8009).
+# Normalized through base 10 at parse time so the name and the code see the same
+# number: a zero-padded component cannot be read as octal (`0.010.0` is 10, not
+# 8), and the name cannot drift from the code the way it used to (`0.08.09`
+# produced the name 0.08.09 against the code 8009).
 major=$((10#${BASH_REMATCH[1]}))
 minor=$((10#${BASH_REMATCH[2]}))
 patch=$((10#${BASH_REMATCH[3]}))
@@ -54,6 +66,17 @@ if [[ -z "${GITHUB_ENV:-}" ]]; then
   exit 1
 fi
 
+# The build scripts re-split QUNLEASHED_FLUTTER_BUILD_ARGS on whitespace, so a
+# secret carrying a newline or a space would silently drop every argument after
+# it - or add one. Fail here instead of shipping a release missing a key.
+for name in QU_BUILD_SERVER_URL QU_BUILD_SERVER_KEY QU_CARTO_KEY; do
+  value="${!name:-}"
+  if [[ -n "$value" && "$value" =~ [[:space:]] ]]; then
+    echo "::error::$name contains whitespace, which would corrupt the build arguments." >&2
+    exit 1
+  fi
+done
+
 build_args="--build-name=$version_name --build-number=$version_code"
 build_args="$build_args --dart-define=QUNLEASHED_RELEASE_TAG=$tag"
 if [[ -n "${QU_BUILD_SERVER_URL:-}" && -n "${QU_BUILD_SERVER_KEY:-}" ]]; then
@@ -70,5 +93,5 @@ fi
   echo "QUNLEASHED_FLUTTER_BUILD_ARGS=$build_args"
 } >> "$GITHUB_ENV"
 
-echo "Version name: $version_name"
-echo "Version code: $version_code"
+echo "Version name: $version_name" >&2
+echo "Version code: $version_code" >&2

--- a/.github/scripts/derive_version.sh
+++ b/.github/scripts/derive_version.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Derives the app version from the release tag, so the build jobs and the
+# pubspec sync job cannot disagree about what a tag means.
+#
+#   derive_version.sh                 # append the values to $GITHUB_ENV
+#   derive_version.sh --print         # print "<name> <code>" to stdout instead
+#   derive_version.sh --print 0.13.0  # ... for an explicit tag, for tests
+#
+# Without an explicit tag the value comes from $GITHUB_REF_NAME.
+#
+# In the default mode QU_BUILD_SERVER_URL, QU_BUILD_SERVER_KEY and QU_CARTO_KEY
+# are read from the environment and folded into the Flutter build arguments when
+# set. A build without them still succeeds, with that feature disabled at
+# runtime, so a fork can cut a build it can actually use.
+set -Eeuo pipefail
+
+print_only=0
+if [[ "${1:-}" == "--print" ]]; then
+  print_only=1
+  shift
+fi
+
+tag="${1:-${GITHUB_REF_NAME:-}}"
+if [[ -z "$tag" ]]; then
+  echo "::error::No tag given and GITHUB_REF_NAME is unset." >&2
+  exit 1
+fi
+
+if [[ ! "$tag" =~ ([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
+  echo "::error::Tag must contain a semantic version like 0.6.1, dev-0.6.1, or beta-0.6.1." >&2
+  exit 1
+fi
+
+# Forced base 10 once, so a zero-padded component cannot be read as octal and
+# cannot leave the name and the code disagreeing (`0.08.09` -> 0.8.9 / 8009).
+major=$((10#${BASH_REMATCH[1]}))
+minor=$((10#${BASH_REMATCH[2]}))
+patch=$((10#${BASH_REMATCH[3]}))
+version_name="${major}.${minor}.${patch}"
+version_code=$((major * 1000000 + minor * 1000 + patch))
+
+if (( version_code <= 0 )); then
+  echo "::error::Derived version code must be greater than zero." >&2
+  exit 1
+fi
+
+if (( print_only )); then
+  printf '%s %s\n' "$version_name" "$version_code"
+  exit 0
+fi
+
+if [[ -z "${GITHUB_ENV:-}" ]]; then
+  echo "::error::GITHUB_ENV is unset. Use --print outside a workflow." >&2
+  exit 1
+fi
+
+build_args="--build-name=$version_name --build-number=$version_code"
+build_args="$build_args --dart-define=QUNLEASHED_RELEASE_TAG=$tag"
+if [[ -n "${QU_BUILD_SERVER_URL:-}" && -n "${QU_BUILD_SERVER_KEY:-}" ]]; then
+  build_args="$build_args --dart-define=QU_BUILD_SERVER_URL=$QU_BUILD_SERVER_URL"
+  build_args="$build_args --dart-define=QU_BUILD_SERVER_KEY=$QU_BUILD_SERVER_KEY"
+fi
+if [[ -n "${QU_CARTO_KEY:-}" ]]; then
+  build_args="$build_args --dart-define=QU_CARTO_KEY=$QU_CARTO_KEY"
+fi
+
+{
+  echo "QUNLEASHED_VERSION_NAME=$version_name"
+  echo "QUNLEASHED_VERSION_CODE=$version_code"
+  echo "QUNLEASHED_FLUTTER_BUILD_ARGS=$build_args"
+} >> "$GITHUB_ENV"
+
+echo "Version name: $version_name"
+echo "Version code: $version_code"

--- a/.github/scripts/derive_version_test.sh
+++ b/.github/scripts/derive_version_test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Covers derive_version.sh, which the release workflow depends on and which no
+# other test can reach: auto-release.yml only ever runs on a tag push, so a
+# regression there would surface while cutting a release.
+set -Eeuo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DERIVE="$HERE/derive_version.sh"
+failures=0
+
+ok() {
+  local tag="$1" want="$2" got
+  got="$("$DERIVE" --print "$tag")"
+  if [[ "$got" == "$want" ]]; then
+    printf '  ok    %-18s -> %s\n' "$tag" "$got"
+  else
+    printf '  FAIL  %-18s -> %s (want %s)\n' "$tag" "$got" "$want"
+    failures=$((failures + 1))
+  fi
+}
+
+rejects() {
+  local tag="$1"
+  if "$DERIVE" --print "$tag" >/dev/null 2>&1; then
+    printf '  FAIL  %-18s was accepted\n' "'$tag'"
+    failures=$((failures + 1))
+  else
+    printf '  ok    %-18s rejected\n' "'$tag'"
+  fi
+}
+
+echo "derive_version.sh"
+
+# The channel prefixes this project actually tags with.
+ok "0.12.1"        "0.12.1 12001"
+ok "dev-0.12.1"    "0.12.1 12001"
+ok "beta-0.11.2"   "0.11.2 11002"
+ok "v0.6.1"        "0.6.1 6001"
+
+# Component scaling: patch, minor and major each land in their own decade.
+ok "0.0.1"         "0.0.1 1"
+ok "0.1.0"         "0.1.0 1000"
+ok "1.0.0"         "1.0.0 1000000"
+ok "0.10.11"       "0.10.11 10011"
+
+# Leading zeroes must not be read as octal.
+ok "0.08.09"       "0.8.9 8009"
+
+rejects ""
+rejects "no-version-here"
+rejects "1.2"
+rejects "0.0.0"
+
+if (( failures )); then
+  echo "$failures failure(s)" >&2
+  exit 1
+fi
+echo "all passed"

--- a/.github/scripts/derive_version_test.sh
+++ b/.github/scripts/derive_version_test.sh
@@ -1,55 +1,145 @@
 #!/usr/bin/env bash
-# Covers derive_version.sh, which the release workflow depends on and which no
-# other test can reach: auto-release.yml only ever runs on a tag push, so a
-# regression there would surface while cutting a release.
+# Covers derive_version.sh. auto-release.yml only runs on a tag push, so without
+# this a regression would not surface until a release was already being cut.
+#
+# Both modes are exercised, because the mode the build jobs use is the one that
+# writes $GITHUB_ENV, and every consumer of those variables reads them with a
+# `${VAR:-}` default or String.fromEnvironment - so a wrong name does not fail a
+# build, it ships one built at the wrong version.
+#
+# Invocations run under `env -i` so the developer's own QU_* secrets and
+# GITHUB_REF_NAME cannot change the result.
 set -Eeuo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DERIVE="$HERE/derive_version.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
 failures=0
+
+pass() { printf '  ok    %s\n' "$1"; }
+fail() { printf '  FAIL  %s\n' "$1"; failures=$((failures + 1)); }
+
+# --- --print mode -----------------------------------------------------------
+
+# Runs with a clean environment; $1 is the tag, or "" to omit it entirely.
+run_print() {
+  if [[ -n "$1" ]]; then
+    env -i PATH="$PATH" bash "$DERIVE" --print "$1" 2>/dev/null
+  else
+    env -i PATH="$PATH" bash "$DERIVE" --print 2>/dev/null
+  fi
+}
 
 ok() {
   local tag="$1" want="$2" got
-  got="$("$DERIVE" --print "$tag")"
-  if [[ "$got" == "$want" ]]; then
-    printf '  ok    %-18s -> %s\n' "$tag" "$got"
-  else
-    printf '  FAIL  %-18s -> %s (want %s)\n' "$tag" "$got" "$want"
-    failures=$((failures + 1))
-  fi
+  if ! got="$(run_print "$tag")"; then got="<rejected>"; fi
+  [[ "$got" == "$want" ]] && pass "$tag -> $got" || fail "$tag -> $got (want $want)"
 }
 
 rejects() {
   local tag="$1"
-  if "$DERIVE" --print "$tag" >/dev/null 2>&1; then
-    printf '  FAIL  %-18s was accepted\n' "'$tag'"
-    failures=$((failures + 1))
-  else
-    printf '  ok    %-18s rejected\n' "'$tag'"
-  fi
+  if run_print "$tag" >/dev/null 2>&1; then fail "'$tag' was accepted"; else pass "'$tag' rejected"; fi
 }
 
-echo "derive_version.sh"
+echo "derive_version.sh --print"
 
-# The channel prefixes this project actually tags with.
-ok "0.12.1"        "0.12.1 12001"
-ok "dev-0.12.1"    "0.12.1 12001"
+# Tag shapes the version regex has to accept. This repository has tagged
+# alpha- (22), beta- (22), wip- (5) and dev- (4); bare and v- are accepted too.
+ok "alpha-0.8.4"   "0.8.4 8004"
 ok "beta-0.11.2"   "0.11.2 11002"
+ok "wip-0.3.6"     "0.3.6 3006"
+ok "dev-0.12.1"    "0.12.1 12001"
+ok "0.12.1"        "0.12.1 12001"
 ok "v0.6.1"        "0.6.1 6001"
 
-# Component scaling: patch, minor and major each land in their own decade.
+# Component scaling: patch, minor and major each get their own three-digit field.
 ok "0.0.1"         "0.0.1 1"
 ok "0.1.0"         "0.1.0 1000"
 ok "1.0.0"         "1.0.0 1000000"
 ok "0.10.11"       "0.10.11 10011"
 
-# Leading zeroes must not be read as octal.
-ok "0.08.09"       "0.8.9 8009"
+# Zero padding is normalized in every component, name and code alike.
+ok "01.08.09"      "1.8.9 1008009"
+ok "0.010.0"       "0.10.0 10000"
 
-rejects ""
 rejects "no-version-here"
 rejects "1.2"
 rejects "0.0.0"
+
+# No tag argument and no GITHUB_REF_NAME: the guard, not a fallback.
+if env -i PATH="$PATH" bash "$DERIVE" --print >/dev/null 2>&1; then
+  fail "a missing tag was accepted"
+else
+  pass "a missing tag is rejected"
+fi
+
+# The sync job calls --print with no argument and relies on this fallback.
+got="$(env -i PATH="$PATH" GITHUB_REF_NAME="beta-0.11.2" bash "$DERIVE" --print 2>/dev/null || true)"
+[[ "$got" == "0.11.2 11002" ]] && pass "--print reads GITHUB_REF_NAME" \
+  || fail "--print GITHUB_REF_NAME fallback -> '$got'"
+
+# --- $GITHUB_ENV mode -------------------------------------------------------
+
+echo "derive_version.sh (GITHUB_ENV mode)"
+
+# Returns the file's contents; the file is pre-seeded so truncation is visible.
+run_env() {
+  local ref="$1"; shift
+  local out="$TMP/env"
+  echo "PRE_EXISTING=1" > "$out"
+  env -i PATH="$PATH" GITHUB_ENV="$out" GITHUB_REF_NAME="$ref" "$@" \
+    bash "$DERIVE" >/dev/null 2>&1 || return 1
+  cat "$out"
+}
+
+env_has() {
+  local label="$1" line="$2" body="$3"
+  grep -qxF -- "$line" <<<"$body" && pass "$label" || fail "$label (missing: $line)"
+}
+
+if ! body="$(run_env "beta-0.11.2")"; then fail "plain run exited non-zero"; body=""; fi
+env_has "appends, does not truncate"   "PRE_EXISTING=1"                 "$body"
+env_has "writes the version name"      "QUNLEASHED_VERSION_NAME=0.11.2" "$body"
+env_has "writes the version code"      "QUNLEASHED_VERSION_CODE=11002"  "$body"
+env_has "build args carry name+number" \
+  "QUNLEASHED_FLUTTER_BUILD_ARGS=--build-name=0.11.2 --build-number=11002 --dart-define=QUNLEASHED_RELEASE_TAG=beta-0.11.2" \
+  "$body"
+
+if ! body="$(run_env "beta-0.11.2" QU_BUILD_SERVER_URL=https://b QU_BUILD_SERVER_KEY=k QU_CARTO_KEY=c)"; then
+  fail "run with every secret exited non-zero"; body=""
+fi
+env_has "folds in every secret" \
+  "QUNLEASHED_FLUTTER_BUILD_ARGS=--build-name=0.11.2 --build-number=11002 --dart-define=QUNLEASHED_RELEASE_TAG=beta-0.11.2 --dart-define=QU_BUILD_SERVER_URL=https://b --dart-define=QU_BUILD_SERVER_KEY=k --dart-define=QU_CARTO_KEY=c" \
+  "$body"
+
+# A URL without a key authenticates nothing, so neither is passed.
+if ! body="$(run_env "beta-0.11.2" QU_BUILD_SERVER_URL=https://b)"; then
+  fail "a URL without a key must still produce a build"
+elif grep -q "QU_BUILD_SERVER_URL=https" <<<"$body"; then
+  fail "a URL without a key must not be passed"
+else
+  pass "a URL without a key is dropped"
+fi
+
+# Whitespace in a secret would truncate the args when the build scripts re-split.
+if run_env "beta-0.11.2" QU_CARTO_KEY="$(printf 'a\nb')" >/dev/null 2>&1; then
+  fail "a secret containing a newline was accepted"
+else
+  pass "a secret containing a newline is rejected"
+fi
+if run_env "beta-0.11.2" QU_CARTO_KEY="a b" >/dev/null 2>&1; then
+  fail "a secret containing a space was accepted"
+else
+  pass "a secret containing a space is rejected"
+fi
+
+# GITHUB_ENV unset must fail rather than silently produce nothing.
+if env -i PATH="$PATH" GITHUB_REF_NAME="beta-0.11.2" bash "$DERIVE" >/dev/null 2>&1; then
+  fail "a missing GITHUB_ENV was accepted"
+else
+  pass "a missing GITHUB_ENV is rejected"
+fi
 
 if (( failures )); then
   echo "$failures failure(s)" >&2

--- a/.github/scripts/derive_version_test.sh
+++ b/.github/scripts/derive_version_test.sh
@@ -7,8 +7,8 @@
 # `${VAR:-}` default or String.fromEnvironment - so a wrong name does not fail a
 # build, it ships one built at the wrong version.
 #
-# Invocations run under `env -i` so the developer's own QU_* secrets and
-# GITHUB_REF_NAME cannot change the result.
+# Every invocation runs under `env -i` so the developer's own QU_* secrets and
+# GITHUB_REF_NAME cannot change a result.
 set -Eeuo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -20,29 +20,25 @@ failures=0
 pass() { printf '  ok    %s\n' "$1"; }
 fail() { printf '  FAIL  %s\n' "$1"; failures=$((failures + 1)); }
 
+# Runs the script with a clean environment. Extra NAME=VALUE pairs go before the
+# command; the tag, when given, goes after `--print`.
+run() { env -i PATH="$PATH" "$@" 2>/dev/null; }
+
+# Asserts that a command fails. Every negative case shares this shape.
+refutes() {
+  local label="$1"; shift
+  if "$@" >/dev/null 2>&1; then fail "$label was accepted"; else pass "$label rejected"; fi
+}
+
 # --- --print mode -----------------------------------------------------------
 
-# Runs with a clean environment; $1 is the tag, or "" to omit it entirely.
-run_print() {
-  if [[ -n "$1" ]]; then
-    env -i PATH="$PATH" bash "$DERIVE" --print "$1" 2>/dev/null
-  else
-    env -i PATH="$PATH" bash "$DERIVE" --print 2>/dev/null
-  fi
-}
+echo "derive_version.sh --print"
 
 ok() {
   local tag="$1" want="$2" got
-  if ! got="$(run_print "$tag")"; then got="<rejected>"; fi
+  if ! got="$(run bash "$DERIVE" --print "$tag")"; then got="<rejected>"; fi
   [[ "$got" == "$want" ]] && pass "$tag -> $got" || fail "$tag -> $got (want $want)"
 }
-
-rejects() {
-  local tag="$1"
-  if run_print "$tag" >/dev/null 2>&1; then fail "'$tag' was accepted"; else pass "'$tag' rejected"; fi
-}
-
-echo "derive_version.sh --print"
 
 # Tag shapes the version regex has to accept. This repository has tagged
 # alpha- (22), beta- (22), wip- (5) and dev- (4); bare and v- are accepted too.
@@ -63,58 +59,48 @@ ok "0.10.11"       "0.10.11 10011"
 ok "01.08.09"      "1.8.9 1008009"
 ok "0.010.0"       "0.10.0 10000"
 
-rejects "no-version-here"
-rejects "1.2"
-rejects "0.0.0"
+refutes "no-version-here" run bash "$DERIVE" --print "no-version-here"
+refutes "1.2"             run bash "$DERIVE" --print "1.2"
+refutes "0.0.0"           run bash "$DERIVE" --print "0.0.0"
+refutes "an unknown flag" run bash "$DERIVE" --bogus
+refutes "a missing tag"   run bash "$DERIVE" --print
 
-# No tag argument and no GITHUB_REF_NAME: the guard, not a fallback.
-if env -i PATH="$PATH" bash "$DERIVE" --print >/dev/null 2>&1; then
-  fail "a missing tag was accepted"
-else
-  pass "a missing tag is rejected"
-fi
-
-# The sync job calls --print with no argument and relies on this fallback.
-got="$(env -i PATH="$PATH" GITHUB_REF_NAME="beta-0.11.2" bash "$DERIVE" --print 2>/dev/null || true)"
+# The tag falls back to GITHUB_REF_NAME when no argument is given.
+got="$(run GITHUB_REF_NAME=beta-0.11.2 bash "$DERIVE" --print || true)"
 [[ "$got" == "0.11.2 11002" ]] && pass "--print reads GITHUB_REF_NAME" \
   || fail "--print GITHUB_REF_NAME fallback -> '$got'"
 
-# --- $GITHUB_ENV mode -------------------------------------------------------
+# --- $GITHUB_ENV / $GITHUB_OUTPUT mode --------------------------------------
 
-echo "derive_version.sh (GITHUB_ENV mode)"
+echo "derive_version.sh (workflow mode)"
 
-# Returns the file's contents; the file is pre-seeded so truncation is visible.
+# Writes both files pre-seeded, so truncation is visible, and echoes them.
 run_env() {
-  local ref="$1"; shift
-  local out="$TMP/env"
-  echo "PRE_EXISTING=1" > "$out"
-  env -i PATH="$PATH" GITHUB_ENV="$out" GITHUB_REF_NAME="$ref" "$@" \
-    bash "$DERIVE" >/dev/null 2>&1 || return 1
-  cat "$out"
+  local out="$TMP/env" step="$TMP/out"
+  echo "PRE_EXISTING=1" > "$out"; : > "$step"
+  run GITHUB_ENV="$out" GITHUB_OUTPUT="$step" "$@" bash "$DERIVE" >/dev/null || return 1
+  cat "$out" "$step"
 }
 
-env_has() {
-  local label="$1" line="$2" body="$3"
-  grep -qxF -- "$line" <<<"$body" && pass "$label" || fail "$label (missing: $line)"
-}
+body=""
+if ! body="$(run_env GITHUB_REF_NAME=beta-0.11.2)"; then fail "a plain run exited non-zero"; fi
 
-if ! body="$(run_env "beta-0.11.2")"; then fail "plain run exited non-zero"; body=""; fi
-env_has "appends, does not truncate"   "PRE_EXISTING=1"                 "$body"
-env_has "writes the version name"      "QUNLEASHED_VERSION_NAME=0.11.2" "$body"
-env_has "writes the version code"      "QUNLEASHED_VERSION_CODE=11002"  "$body"
-env_has "build args carry name+number" \
-  "QUNLEASHED_FLUTTER_BUILD_ARGS=--build-name=0.11.2 --build-number=11002 --dart-define=QUNLEASHED_RELEASE_TAG=beta-0.11.2" \
-  "$body"
+has() { grep -qxF -- "$2" <<<"$body" && pass "$1" || fail "$1 (missing: $2)"; }
+has "appends, does not truncate"  "PRE_EXISTING=1"
+has "writes the version name"     "QUNLEASHED_VERSION_NAME=0.11.2"
+has "writes the version code"     "QUNLEASHED_VERSION_CODE=11002"
+has "publishes the step outputs"  "version_name=0.11.2"
+has "build args carry name+number" \
+  "QUNLEASHED_FLUTTER_BUILD_ARGS=--build-name=0.11.2 --build-number=11002 --dart-define=QUNLEASHED_RELEASE_TAG=beta-0.11.2"
 
-if ! body="$(run_env "beta-0.11.2" QU_BUILD_SERVER_URL=https://b QU_BUILD_SERVER_KEY=k QU_CARTO_KEY=c)"; then
-  fail "run with every secret exited non-zero"; body=""
+if ! body="$(run_env GITHUB_REF_NAME=beta-0.11.2 QU_BUILD_SERVER_URL=https://b QU_BUILD_SERVER_KEY=k QU_CARTO_KEY=c)"; then
+  fail "a run with every secret exited non-zero"
 fi
-env_has "folds in every secret" \
-  "QUNLEASHED_FLUTTER_BUILD_ARGS=--build-name=0.11.2 --build-number=11002 --dart-define=QUNLEASHED_RELEASE_TAG=beta-0.11.2 --dart-define=QU_BUILD_SERVER_URL=https://b --dart-define=QU_BUILD_SERVER_KEY=k --dart-define=QU_CARTO_KEY=c" \
-  "$body"
+has "folds in every secret" \
+  "QUNLEASHED_FLUTTER_BUILD_ARGS=--build-name=0.11.2 --build-number=11002 --dart-define=QUNLEASHED_RELEASE_TAG=beta-0.11.2 --dart-define=QU_BUILD_SERVER_URL=https://b --dart-define=QU_BUILD_SERVER_KEY=k --dart-define=QU_CARTO_KEY=c"
 
 # A URL without a key authenticates nothing, so neither is passed.
-if ! body="$(run_env "beta-0.11.2" QU_BUILD_SERVER_URL=https://b)"; then
+if ! body="$(run_env GITHUB_REF_NAME=beta-0.11.2 QU_BUILD_SERVER_URL=https://b)"; then
   fail "a URL without a key must still produce a build"
 elif grep -q "QU_BUILD_SERVER_URL=https" <<<"$body"; then
   fail "a URL without a key must not be passed"
@@ -122,24 +108,10 @@ else
   pass "a URL without a key is dropped"
 fi
 
-# Whitespace in a secret would truncate the args when the build scripts re-split.
-if run_env "beta-0.11.2" QU_CARTO_KEY="$(printf 'a\nb')" >/dev/null 2>&1; then
-  fail "a secret containing a newline was accepted"
-else
-  pass "a secret containing a newline is rejected"
-fi
-if run_env "beta-0.11.2" QU_CARTO_KEY="a b" >/dev/null 2>&1; then
-  fail "a secret containing a space was accepted"
-else
-  pass "a secret containing a space is rejected"
-fi
-
-# GITHUB_ENV unset must fail rather than silently produce nothing.
-if env -i PATH="$PATH" GITHUB_REF_NAME="beta-0.11.2" bash "$DERIVE" >/dev/null 2>&1; then
-  fail "a missing GITHUB_ENV was accepted"
-else
-  pass "a missing GITHUB_ENV is rejected"
-fi
+# Whitespace would truncate the args when the build scripts re-split them.
+refutes "a secret with a newline" run_env GITHUB_REF_NAME=beta-0.11.2 QU_CARTO_KEY="$(printf 'a\nb')"
+refutes "a secret with a space"   run_env GITHUB_REF_NAME=beta-0.11.2 QU_CARTO_KEY="a b"
+refutes "a missing GITHUB_ENV"    run GITHUB_REF_NAME=beta-0.11.2 bash "$DERIVE"
 
 if (( failures )); then
   echo "$failures failure(s)" >&2

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -33,6 +33,9 @@ jobs:
     if: ${{ github.server_url == 'https://github.com' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    outputs:
+      version-name: ${{ steps.version.outputs.version_name }}
+      version-code: ${{ steps.version.outputs.version_code }}
 
     steps:
       - name: Checkout
@@ -60,6 +63,7 @@ jobs:
         run: .github/scripts/restore_firebase_config.sh android
 
       - name: Derive app version from tag
+        id: version
         shell: bash
         env:
           QU_BUILD_SERVER_URL: ${{ secrets.QU_BUILD_SERVER_URL }}
@@ -300,7 +304,7 @@ jobs:
 
   sync-version:
     name: Sync pubspec version with tag
-    needs: publish
+    needs: [publish, build-android-linux]
     if: ${{ github.server_url == 'https://github.com' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -313,21 +317,17 @@ jobs:
 
       - name: Update pubspec.yaml version from tag
         shell: bash
+        env:
+          VERSION_NAME: ${{ needs.build-android-linux.outputs.version-name }}
+          VERSION_CODE: ${{ needs.build-android-linux.outputs.version-code }}
         run: |
-          # `read` returns 0 as soon as it gets a line, so on its own it cannot
-          # tell the answer from a stray diagnostic - and this job commits to
-          # the default branch. Take the exit status, then assert the shape.
-          if ! derived="$(.github/scripts/derive_version.sh --print)"; then
-            echo "::error::Version derivation failed; refusing to rewrite pubspec.yaml."
+          # This job commits to the default branch, so an empty output must
+          # stop it rather than write "version: +" and push that.
+          if [[ -z "$VERSION_NAME" || -z "$VERSION_CODE" ]]; then
+            echo "::error::Version outputs are empty; refusing to rewrite pubspec.yaml."
             exit 1
           fi
-          read -r version_name version_code extra <<< "$derived"
-          if [[ ! "$version_name" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ||
-                ! "$version_code" =~ ^[0-9]+$ || -n "$extra" ]]; then
-            echo "::error::Unusable version derivation output: '$derived'"
-            exit 1
-          fi
-          target="${version_name}+${version_code}"
+          target="${VERSION_NAME}+${VERSION_CODE}"
 
           current="$(sed -nE 's/^version:[[:space:]]*(.+)[[:space:]]*$/\1/p' pubspec.yaml | head -n 1)"
           if [[ "$current" == "$target" ]]; then

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -314,7 +314,19 @@ jobs:
       - name: Update pubspec.yaml version from tag
         shell: bash
         run: |
-          read -r version_name version_code < <(.github/scripts/derive_version.sh --print)
+          # `read` returns 0 as soon as it gets a line, so on its own it cannot
+          # tell the answer from a stray diagnostic - and this job commits to
+          # the default branch. Take the exit status, then assert the shape.
+          if ! derived="$(.github/scripts/derive_version.sh --print)"; then
+            echo "::error::Version derivation failed; refusing to rewrite pubspec.yaml."
+            exit 1
+          fi
+          read -r version_name version_code extra <<< "$derived"
+          if [[ ! "$version_name" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ||
+                ! "$version_code" =~ ^[0-9]+$ || -n "$extra" ]]; then
+            echo "::error::Unusable version derivation output: '$derived'"
+            exit 1
+          fi
           target="${version_name}+${version_code}"
 
           current="$(sed -nE 's/^version:[[:space:]]*(.+)[[:space:]]*$/\1/p' pubspec.yaml | head -n 1)"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -47,14 +47,7 @@ jobs:
           java-version: "17"
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: 3.47.1
-          channel: stable
-          cache: true
-
-      - name: Install Flutter dependencies
-        run: flutter pub get
+        uses: ./.github/actions/setup-flutter
 
       - name: Restore Flutter Firebase options
         env:
@@ -72,39 +65,7 @@ jobs:
           QU_BUILD_SERVER_URL: ${{ secrets.QU_BUILD_SERVER_URL }}
           QU_BUILD_SERVER_KEY: ${{ secrets.QU_BUILD_SERVER_KEY }}
           QU_CARTO_KEY: ${{ secrets.QU_CARTO_KEY }}
-        run: |
-          tag="${GITHUB_REF_NAME}"
-          if [[ ! "$tag" =~ ([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            echo "::error::Tag must contain a semantic version like 0.6.1, alpha-0.6.1, or v0.6.1."
-            exit 1
-          fi
-
-          major="${BASH_REMATCH[1]}"
-          minor="${BASH_REMATCH[2]}"
-          patch="${BASH_REMATCH[3]}"
-          version_name="${major}.${minor}.${patch}"
-          version_code=$((10#$major * 1000000 + 10#$minor * 1000 + 10#$patch))
-
-          if (( version_code <= 0 )); then
-            echo "::error::Derived Android versionCode must be greater than zero."
-            exit 1
-          fi
-
-          {
-            echo "QUNLEASHED_VERSION_NAME=$version_name"
-            echo "QUNLEASHED_VERSION_CODE=$version_code"
-            build_args="--build-name=$version_name --build-number=$version_code --dart-define=QUNLEASHED_RELEASE_TAG=$tag"
-            if [ -n "$QU_BUILD_SERVER_URL" ] && [ -n "$QU_BUILD_SERVER_KEY" ]; then
-              build_args="$build_args --dart-define=QU_BUILD_SERVER_URL=$QU_BUILD_SERVER_URL --dart-define=QU_BUILD_SERVER_KEY=$QU_BUILD_SERVER_KEY"
-            fi
-            if [ -n "$QU_CARTO_KEY" ]; then
-              build_args="$build_args --dart-define=QU_CARTO_KEY=$QU_CARTO_KEY"
-            fi
-            echo "QUNLEASHED_FLUTTER_BUILD_ARGS=$build_args"
-          } >> "$GITHUB_ENV"
-
-          echo "Version name: $version_name"
-          echo "Version code: $version_code"
+        run: .github/scripts/derive_version.sh
 
       - name: Configure Android signing
         env:
@@ -161,14 +122,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: 3.47.1
-          channel: stable
-          cache: true
-
-      - name: Install Flutter dependencies
-        run: flutter pub get
+        uses: ./.github/actions/setup-flutter
 
       - name: Restore Flutter Firebase options
         shell: bash
@@ -182,39 +136,7 @@ jobs:
           QU_BUILD_SERVER_URL: ${{ secrets.QU_BUILD_SERVER_URL }}
           QU_BUILD_SERVER_KEY: ${{ secrets.QU_BUILD_SERVER_KEY }}
           QU_CARTO_KEY: ${{ secrets.QU_CARTO_KEY }}
-        run: |
-          tag="${GITHUB_REF_NAME}"
-          if [[ ! "$tag" =~ ([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            echo "::error::Tag must contain a semantic version like 0.6.1, alpha-0.6.1, or v0.6.1."
-            exit 1
-          fi
-
-          major="${BASH_REMATCH[1]}"
-          minor="${BASH_REMATCH[2]}"
-          patch="${BASH_REMATCH[3]}"
-          version_name="${major}.${minor}.${patch}"
-          version_code=$((10#$major * 1000000 + 10#$minor * 1000 + 10#$patch))
-
-          if (( version_code <= 0 )); then
-            echo "::error::Derived build number must be greater than zero."
-            exit 1
-          fi
-
-          {
-            echo "QUNLEASHED_VERSION_NAME=$version_name"
-            echo "QUNLEASHED_VERSION_CODE=$version_code"
-            build_args="--build-name=$version_name --build-number=$version_code --dart-define=QUNLEASHED_RELEASE_TAG=$tag"
-            if [ -n "$QU_BUILD_SERVER_URL" ] && [ -n "$QU_BUILD_SERVER_KEY" ]; then
-              build_args="$build_args --dart-define=QU_BUILD_SERVER_URL=$QU_BUILD_SERVER_URL --dart-define=QU_BUILD_SERVER_KEY=$QU_BUILD_SERVER_KEY"
-            fi
-            if [ -n "$QU_CARTO_KEY" ]; then
-              build_args="$build_args --dart-define=QU_CARTO_KEY=$QU_CARTO_KEY"
-            fi
-            echo "QUNLEASHED_FLUTTER_BUILD_ARGS=$build_args"
-          } >> "$GITHUB_ENV"
-
-          echo "Version name: $version_name"
-          echo "Build number: $version_code"
+        run: .github/scripts/derive_version.sh
 
       - name: Build Windows raw ZIP and packaged EXE
         shell: pwsh
@@ -248,20 +170,9 @@ jobs:
           submodules: recursive
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@v2
+        uses: ./.github/actions/setup-flutter
         with:
-          flutter-version: 3.47.1
-          channel: stable
-          cache: true
-
-      # Firebase pulls grpc as an SPM binary target (grpc.zip from dl.google.com),
-      # which flakes with "network connection was lost" on macOS runners. Both
-      # ios/ and macos/ have CocoaPods set up, so build through pods instead.
-      - name: Disable Swift Package Manager (use CocoaPods)
-        run: flutter config --no-enable-swift-package-manager
-
-      - name: Install Flutter dependencies
-        run: flutter pub get
+          swift-package-manager: "false"
 
       - name: Restore Flutter Firebase options
         env:
@@ -284,39 +195,7 @@ jobs:
           QU_BUILD_SERVER_URL: ${{ secrets.QU_BUILD_SERVER_URL }}
           QU_BUILD_SERVER_KEY: ${{ secrets.QU_BUILD_SERVER_KEY }}
           QU_CARTO_KEY: ${{ secrets.QU_CARTO_KEY }}
-        run: |
-          tag="${GITHUB_REF_NAME}"
-          if [[ ! "$tag" =~ ([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            echo "::error::Tag must contain a semantic version like 0.6.1, alpha-0.6.1, or v0.6.1."
-            exit 1
-          fi
-
-          major="${BASH_REMATCH[1]}"
-          minor="${BASH_REMATCH[2]}"
-          patch="${BASH_REMATCH[3]}"
-          version_name="${major}.${minor}.${patch}"
-          version_code=$((10#$major * 1000000 + 10#$minor * 1000 + 10#$patch))
-
-          if (( version_code <= 0 )); then
-            echo "::error::Derived build number must be greater than zero."
-            exit 1
-          fi
-
-          {
-            echo "QUNLEASHED_VERSION_NAME=$version_name"
-            echo "QUNLEASHED_VERSION_CODE=$version_code"
-            build_args="--build-name=$version_name --build-number=$version_code --dart-define=QUNLEASHED_RELEASE_TAG=$tag"
-            if [ -n "$QU_BUILD_SERVER_URL" ] && [ -n "$QU_BUILD_SERVER_KEY" ]; then
-              build_args="$build_args --dart-define=QU_BUILD_SERVER_URL=$QU_BUILD_SERVER_URL --dart-define=QU_BUILD_SERVER_KEY=$QU_BUILD_SERVER_KEY"
-            fi
-            if [ -n "$QU_CARTO_KEY" ]; then
-              build_args="$build_args --dart-define=QU_CARTO_KEY=$QU_CARTO_KEY"
-            fi
-            echo "QUNLEASHED_FLUTTER_BUILD_ARGS=$build_args"
-          } >> "$GITHUB_ENV"
-
-          echo "Version name: $version_name"
-          echo "Build number: $version_code"
+        run: .github/scripts/derive_version.sh
 
       - name: Install macOS build dependencies
         run: brew install automake libtool
@@ -435,17 +314,7 @@ jobs:
       - name: Update pubspec.yaml version from tag
         shell: bash
         run: |
-          tag="${GITHUB_REF_NAME}"
-          if [[ ! "$tag" =~ ([0-9]+)\.([0-9]+)\.([0-9]+) ]]; then
-            echo "::error::Tag must contain a semantic version like 0.6.1, alpha-0.6.1, or v0.6.1."
-            exit 1
-          fi
-
-          major="${BASH_REMATCH[1]}"
-          minor="${BASH_REMATCH[2]}"
-          patch="${BASH_REMATCH[3]}"
-          version_name="${major}.${minor}.${patch}"
-          version_code=$((10#$major * 1000000 + 10#$minor * 1000 + 10#$patch))
+          read -r version_name version_code < <(.github/scripts/derive_version.sh --print)
           target="${version_name}+${version_code}"
 
           current="$(sed -nE 's/^version:[[:space:]]*(.+)[[:space:]]*$/\1/p' pubspec.yaml | head -n 1)"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,20 +26,16 @@ jobs:
           submodules: recursive
 
       - name: Set up Flutter
-        uses: subosito/flutter-action@v2
-        with:
-          flutter-version: 3.47.1
-          channel: stable
-          cache: true
-
-      - name: Install Flutter dependencies
-        run: flutter pub get
+        uses: ./.github/actions/setup-flutter
 
       # firebase_options.dart is generated, gitignored and restored from a
       # secret only for releases. CI never restores the real config, so the
       # placeholder is always written, fork or not.
       - name: Stub the Firebase configuration
         run: .github/scripts/stub_firebase_config.sh
+
+      - name: Test the release version derivation
+        run: .github/scripts/derive_version_test.sh
 
       - name: Analyze
         run: flutter analyze

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,12 @@ jobs:
         with:
           submodules: recursive
 
+      # Pure bash, and needs neither Flutter nor the Firebase stub. It runs first
+      # so a broken setup cannot mask a regression in the release version maths,
+      # which auto-release.yml can only exercise on a real tag push.
+      - name: Test the release version derivation
+        run: .github/scripts/derive_version_test.sh
+
       - name: Set up Flutter
         uses: ./.github/actions/setup-flutter
 
@@ -33,9 +39,6 @@ jobs:
       # placeholder is always written, fork or not.
       - name: Stub the Firebase configuration
         run: .github/scripts/stub_firebase_config.sh
-
-      - name: Test the release version derivation
-        run: .github/scripts/derive_version_test.sh
 
       - name: Analyze
         run: flutter analyze

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -63,6 +63,8 @@ dev_dependencies:
   flutter_lints: ^6.0.0
 
 flutter:
+  config:
+    enable-swift-package-manager: false
   uses-material-design: true
   generate: true
   fonts:


### PR DESCRIPTION
First slice of M1. Pure de-duplication of the release workflow — no change to what a tag produces.

Refs #27, #28.

## The version derivation

The tag→version block existed in **four copies** and had already drifted:

- The three build jobs disagree on the error wording (`"Derived Android versionCode must be greater than zero"` vs `"build number"`).
- The `sync-version` job had **lost the `<= 0` guard entirely**, so it and the build jobs could disagree about whether a tag was valid at all.

`derive_version.sh` is now the single definition, with a `--print` mode for the sync job. The arithmetic is unchanged — **all 53 existing tags derive exactly what the inline copies produced**, verified by replaying each one.

Extraction surfaced one inconsistency worth correcting: `version_code` forced base 10 (`10#$major`) while `version_name` used the raw regex capture, so a zero-padded tag would give name `0.08.09` against code `8009`. Both are base 10 now. No tag in this repository is affected — it is a trap being closed, not a bug being fixed.

## Coverage where there was none

`auto-release.yml` only ever runs on a tag push, so this logic could only fail while cutting a release. `derive_version_test.sh` runs in CI and covers the channel prefixes actually in use (`dev-`, `beta-`, bare, `v`), component scaling, zero padding, and the inputs that must be refused.

## The Flutter setup

`.github/actions/setup-flutter` replaces four copies of install + `pub get`, so the pinned version lives in one line instead of four. Two constraints shaped it:

- **It cannot include the checkout.** A local composite action lives in the repository, so the repository has to be on disk before the action resolves. Checkout stays in each job.
- **The macOS SPM opt-out is an input, not a reason to skip the action.** `flutter config --no-enable-swift-package-manager` has to land between install and `pub get`, and the reason it exists (Firebase's grpc SPM binary target flaking on macOS runners) now lives in one place.

## What this does not cover

`auto-release.yml` runs only on a tag, so **CI cannot exercise it**. What CI does prove here: the composite action works (`ci.yml` uses it), and the extracted arithmetic is correct.

Untested until a real tag: the three build jobs' use of the composite on macOS and Windows runners, and `sync-version`'s `git push`. A throwaway `dev-` tag would exercise the whole path as a prerelease without touching `latest`.

## Deferred

The version-code scheme itself (#31) is **not** in this PR. That is a deliberate decision about how `dev-`/`beta-` tags map to codes, and it is worth landing as its own reviewable change — which this PR makes a one-file edit rather than a four-site one.
