### PR TITLE
Publish SHA256SUMS with every release

### DIFF
--- a/.github/scripts/build/macos.sh
+++ b/.github/scripts/build/macos.sh
@@ -119,6 +119,14 @@ only for a DMG you downloaded yourself from the official releases page:
 
   https://github.com/DarkFlippers/qUnleashed/releases
 
+Every release also publishes a SHA256SUMS file. To check this DMG against it,
+put both in the same folder and run:
+
+  shasum -a 256 --ignore-missing -c SHA256SUMS
+
+That confirms the download arrived intact. It is not a signature, so it says
+nothing about the release itself.
+
 1. Drag qUnleashed.app to the Applications folder.
 2. Open Terminal and run:
 
@@ -158,6 +166,14 @@ macOS помещает её в карантин при загрузке и от�
 это только для DMG, который вы сами скачали со страницы официальных релизов:
 
   https://github.com/DarkFlippers/qUnleashed/releases
+
+К каждому релизу также публикуется файл SHA256SUMS. Чтобы сверить с ним этот
+DMG, поместите оба файла в одну папку и выполните:
+
+  shasum -a 256 --ignore-missing -c SHA256SUMS
+
+Это подтверждает, что файл скачался без повреждений. Это не подпись, поэтому
+о самом релизе она ничего не говорит.
 
 1. Перетащите qUnleashed.app в папку Applications.
 2. Запустите Terminal и выполните:

--- a/.github/scripts/checksums.sh
+++ b/.github/scripts/checksums.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Writes SHA256SUMS over the files in a directory, in the format `sha256sum -c`
+# reads, so somebody can verify a downloaded release asset without trusting the
+# page it came from.
+#
+#   checksums.sh [directory]   # default: dist
+#
+# Names are stored bare rather than as paths, so verification runs from inside
+# whatever directory the assets were downloaded to:
+#
+#   sha256sum -c SHA256SUMS
+#
+# An empty directory is an error. The release job reaches this only after three
+# build jobs have uploaded their artifacts, so nothing to checksum means
+# something upstream failed without failing the run.
+set -Eeuo pipefail
+
+dir="${1:-dist}"
+out="SHA256SUMS"
+
+if [[ ! -d "$dir" ]]; then
+  echo "::error::$dir is not a directory." >&2
+  exit 1
+fi
+
+cd "$dir"
+
+# LC_ALL=C keeps the order byte-wise, so the same assets always produce a
+# byte-identical file regardless of the runner's locale.
+shopt -s nullglob
+files=()
+for entry in *; do
+  [[ -f "$entry" && "$entry" != "$out" ]] && files+=("$entry")
+done
+if (( ${#files[@]} == 0 )); then
+  echo "::error::No files to checksum in $dir." >&2
+  exit 1
+fi
+mapfile -t files < <(printf '%s\n' "${files[@]}" | LC_ALL=C sort)
+
+# Binary mode explicitly: it never translates line endings and is what the
+# assets are. Left to the default, coreutils picks text mode on Linux and binary
+# under Git Bash, so the published file would differ by where it was generated.
+sha256sum -b -- "${files[@]}" > "$out"
+
+echo "Wrote $out covering ${#files[@]} file(s)." >&2
+cat "$out" >&2

--- a/.github/scripts/checksums.sh
+++ b/.github/scripts/checksums.sh
@@ -1,30 +1,35 @@
 #!/usr/bin/env bash
 # Writes SHA256SUMS over the files in a directory, so a downloaded asset can be
 # checked against the digest the release was built with. That catches a
-# corrupted, truncated or mirrored download. The file is not signed and is
-# served from the same release, so it is not evidence about the release itself.
+# corrupted, truncated or mirrored download. The file is unsigned and is served
+# from the same release as the assets, so it is not evidence about the release
+# itself - see the signing issue for what would be.
 #
 #   checksums.sh [directory]   # default: dist
 #
-# Names are stored bare rather than as paths, so verification runs from whatever
-# directory somebody downloaded into. Nobody downloads every asset, so the
-# command has to tolerate the ones they skipped:
+# Names are stored bare, so verification runs from wherever somebody downloaded
+# to. Nobody fetches every asset, so the command has to tolerate the rest:
 #
-#   sha256sum --ignore-missing -c SHA256SUMS   # Linux
-#   shasum -a 256 --ignore-missing -c SHA256SUMS   # macOS, which has no sha256sum
+#   sha256sum --ignore-missing -c SHA256SUMS        # Linux
+#   shasum -a 256 --ignore-missing -c SHA256SUMS    # macOS, which has no sha256sum
+#   Get-FileHash <file> -Algorithm SHA256           # Windows, compared by eye
 #
-# An empty directory is an error. Every build job uploads with
-# if-no-files-found: error and publish needs all three, so a failed build skips
-# this job outright - an empty dist means the download step matched no
-# artifacts, which is a wiring bug rather than a build failure.
-#
-# Progress goes to stdout; only diagnostics go to stderr, so a healthy run does
-# not render entirely in red.
+# This hashes whatever is in the directory and asserts only that it is not
+# empty. It does not know the expected asset set, so it cannot notice a release
+# that is short a platform - see #45.
 set -Eeuo pipefail
 
 # Byte-wise collation, which is what orders the glob below. Without it the file
 # would differ between runners with different locales.
 export LC_ALL=C
+
+case "${1:-}" in
+  --*) echo "Usage: $0 [directory]" >&2; exit 2 ;;
+esac
+if (( $# > 1 )); then
+  echo "Usage: $0 [directory]" >&2
+  exit 2
+fi
 
 dir="${1:-dist}"
 out="SHA256SUMS"
@@ -36,16 +41,17 @@ fi
 
 cd "$dir"
 
-# Dotfiles are deliberately out of scope: no release glob publishes one, so
-# listing it here would vouch for a file nobody can download.
+# Dotfiles are out of scope: no release glob publishes one, so listing it would
+# vouch for a file nobody can download.
 shopt -s nullglob
 files=()
 for entry in *; do
-  [[ -f "$entry" && "$entry" != "$out" ]] && files+=("$entry")
+  [[ -f "$entry" && "$entry" != "$out" ]] || continue
+  files+=("$entry")
 done
 
 # The guard sits immediately before the use: sha256sum with no operands reads
-# stdin instead of failing, so an empty list here would hash nothing, write the
+# stdin instead of failing, so an empty list would hash nothing, write the
 # digest of empty input and exit 0 - a manifest that verifies and means nothing.
 if (( ${#files[@]} == 0 )); then
   echo "::error::No files to checksum in $dir." >&2
@@ -53,16 +59,9 @@ if (( ${#files[@]} == 0 )); then
 fi
 
 # Binary mode explicitly. Left to the default, coreutils picks text on Linux and
-# binary under Git Bash, and the mode marker is part of the line ("  name" vs
-# " *name"), so the published file would differ by where it was generated. The
-# digest itself is identical either way.
-#
-# Written through a temp file so no failure can leave a partial manifest sitting
-# in the asset directory for a later step to publish.
-tmp="$(mktemp)"
-trap 'rm -f -- "$tmp"' EXIT
-sha256sum -b -- "${files[@]}" > "$tmp"
-mv -- "$tmp" "$out"
+# binary under Git Bash, and the marker is part of the line ("  name" vs
+# " *name"), so the file would differ by where it was generated.
+sha256sum -b -- "${files[@]}" > "$out"
 
 echo "Wrote $out covering ${#files[@]} file(s)."
 cat "$out"

--- a/.github/scripts/checksums.sh
+++ b/.github/scripts/checksums.sh
@@ -1,19 +1,30 @@
 #!/usr/bin/env bash
-# Writes SHA256SUMS over the files in a directory, in the format `sha256sum -c`
-# reads, so somebody can verify a downloaded release asset without trusting the
-# page it came from.
+# Writes SHA256SUMS over the files in a directory, so a downloaded asset can be
+# checked against the digest the release was built with. That catches a
+# corrupted, truncated or mirrored download. The file is not signed and is
+# served from the same release, so it is not evidence about the release itself.
 #
 #   checksums.sh [directory]   # default: dist
 #
-# Names are stored bare rather than as paths, so verification runs from inside
-# whatever directory the assets were downloaded to:
+# Names are stored bare rather than as paths, so verification runs from whatever
+# directory somebody downloaded into. Nobody downloads every asset, so the
+# command has to tolerate the ones they skipped:
 #
-#   sha256sum -c SHA256SUMS
+#   sha256sum --ignore-missing -c SHA256SUMS   # Linux
+#   shasum -a 256 --ignore-missing -c SHA256SUMS   # macOS, which has no sha256sum
 #
-# An empty directory is an error. The release job reaches this only after three
-# build jobs have uploaded their artifacts, so nothing to checksum means
-# something upstream failed without failing the run.
+# An empty directory is an error. Every build job uploads with
+# if-no-files-found: error and publish needs all three, so a failed build skips
+# this job outright - an empty dist means the download step matched no
+# artifacts, which is a wiring bug rather than a build failure.
+#
+# Progress goes to stdout; only diagnostics go to stderr, so a healthy run does
+# not render entirely in red.
 set -Eeuo pipefail
+
+# Byte-wise collation, which is what orders the glob below. Without it the file
+# would differ between runners with different locales.
+export LC_ALL=C
 
 dir="${1:-dist}"
 out="SHA256SUMS"
@@ -25,23 +36,33 @@ fi
 
 cd "$dir"
 
-# LC_ALL=C keeps the order byte-wise, so the same assets always produce a
-# byte-identical file regardless of the runner's locale.
+# Dotfiles are deliberately out of scope: no release glob publishes one, so
+# listing it here would vouch for a file nobody can download.
 shopt -s nullglob
 files=()
 for entry in *; do
   [[ -f "$entry" && "$entry" != "$out" ]] && files+=("$entry")
 done
+
+# The guard sits immediately before the use: sha256sum with no operands reads
+# stdin instead of failing, so an empty list here would hash nothing, write the
+# digest of empty input and exit 0 - a manifest that verifies and means nothing.
 if (( ${#files[@]} == 0 )); then
   echo "::error::No files to checksum in $dir." >&2
   exit 1
 fi
-mapfile -t files < <(printf '%s\n' "${files[@]}" | LC_ALL=C sort)
 
-# Binary mode explicitly: it never translates line endings and is what the
-# assets are. Left to the default, coreutils picks text mode on Linux and binary
-# under Git Bash, so the published file would differ by where it was generated.
-sha256sum -b -- "${files[@]}" > "$out"
+# Binary mode explicitly. Left to the default, coreutils picks text on Linux and
+# binary under Git Bash, and the mode marker is part of the line ("  name" vs
+# " *name"), so the published file would differ by where it was generated. The
+# digest itself is identical either way.
+#
+# Written through a temp file so no failure can leave a partial manifest sitting
+# in the asset directory for a later step to publish.
+tmp="$(mktemp)"
+trap 'rm -f -- "$tmp"' EXIT
+sha256sum -b -- "${files[@]}" > "$tmp"
+mv -- "$tmp" "$out"
 
-echo "Wrote $out covering ${#files[@]} file(s)." >&2
-cat "$out" >&2
+echo "Wrote $out covering ${#files[@]} file(s)."
+cat "$out"

--- a/.github/scripts/checksums_test.sh
+++ b/.github/scripts/checksums_test.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
-# Covers checksums.sh. The release job that calls it only runs on a tag push,
-# so this is the only place a regression can surface before a release.
+# Covers checksums.sh. auto-release.yml only runs on a tag push, so without this
+# a regression would not surface until a release was already being cut.
+#
+# The fixture mirrors the real asset set on purpose, including the extensionless
+# Linux binary: a mutation as small as globbing `*.*` instead of `*` drops every
+# extensionless asset, and a fixture of only .apk/.dmg/.exe cannot see it.
 set -Eeuo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -10,48 +14,87 @@ trap 'rm -rf "$TMP"' EXIT
 failures=0
 
 pass() { printf '  ok    %s\n' "$1"; }
-fail() { printf '  FAIL  %s\n' "$1"; failures=$((failures + 1)); }
+fail() {
+  printf '  FAIL  %s\n' "$1"
+  [[ -n "${2:-}" ]] && printf '%s\n' "$2" | sed 's/^/          /'
+  failures=$((failures + 1))
+}
+
+# Runs the script, keeping its output so a failure can say why.
+run() {
+  local out
+  if out="$(bash "$SCRIPT" "$@" 2>&1)"; then printf '%s' "$out"; return 0; fi
+  printf '%s' "$out"; return 1
+}
 
 echo "checksums.sh"
 
 d="$TMP/assets"; mkdir -p "$d"
-printf 'apk\n'  > "$d/qunleashed_0.13.0_android_arm64-v8a.apk"
-printf 'dmg\n'  > "$d/qunleashed_0.13.0_macos_universal.dmg"
-printf 'exe\n'  > "$d/qunleashed_0.13.0_windows_x64.exe"
-mkdir -p "$d/nested"
+printf 'apk\n'   > "$d/qunleashed_0.13.0_android_arm64-v8a.apk"
+printf 'ipa\n'   > "$d/qunleashed_0.13.0_ios_arm64.ipa"
+printf 'linux\n' > "$d/qunleashed_0.13.0_linux_x64"
+printf 'dmg\n'   > "$d/qunleashed_0.13.0_macos_universal.dmg"
+printf 'exe\n'   > "$d/qunleashed_0.13.0_windows_x64.exe"
+# Mixed case pins the byte-wise order: under a UTF-8 locale it collates after
+# the lowercase names, under LC_ALL=C before them.
+printf 'notes\n' > "$d/QUnleashed_0.13.0_notes.txt"
+# A leading dash is what `--` protects against; without it sha256sum reads the
+# name as an option and the run dies.
+printf 'dash\n'  > "$d/-leading-dash.bin"
+mkdir -p "$d/nested" && printf 'inner\n' > "$d/nested/inner.txt"
 
-bash "$SCRIPT" "$d" >/dev/null 2>&1 || fail "a normal run exited non-zero"
+out="$(run "$d")" || fail "a normal run exited non-zero" "$out"
 
-# The whole point: the file has to verify with the standard tool.
 ( cd "$d" && sha256sum -c SHA256SUMS >/dev/null 2>&1 ) \
   && pass "output verifies with sha256sum -c" || fail "sha256sum -c rejected the output"
 
 grep -q " [*]qunleashed_0.13.0_windows_x64.exe$" "$d/SHA256SUMS" \
   && pass "names are bare and the mode is binary" || fail "wrong name or mode marker"
 
-[[ "$(wc -l < "$d/SHA256SUMS")" -eq 3 ]] \
-  && pass "covers every file and no directory" || fail "wrong line count"
+# The asset with no extension is the one a careless glob silently drops.
+grep -q " [*]qunleashed_0.13.0_linux_x64$" "$d/SHA256SUMS" \
+  && pass "the extensionless Linux binary is covered" || fail "extensionless asset dropped"
 
-grep -q "SHA256SUMS" "$d/SHA256SUMS" && fail "the sums file lists itself" \
-  || pass "the sums file does not list itself"
+# Names, not just a count: this pins the exact set and catches a lost sort too.
+expected="-leading-dash.bin
+QUnleashed_0.13.0_notes.txt
+qunleashed_0.13.0_android_arm64-v8a.apk
+qunleashed_0.13.0_ios_arm64.ipa
+qunleashed_0.13.0_linux_x64
+qunleashed_0.13.0_macos_universal.dmg
+qunleashed_0.13.0_windows_x64.exe"
+actual="$(sed 's/^[0-9a-f]* [*]//' "$d/SHA256SUMS")"
+[[ "$actual" == "$expected" ]] \
+  && pass "covers exactly the files, in byte order, no directory" \
+  || fail "wrong file set or order" "$actual"
 
-# Deterministic: rerunning over unchanged assets must not churn the file.
+# Rerunning must not churn the file, and on this run SHA256SUMS already exists -
+# which is the only run where the self-exclusion is live code.
 before="$(cat "$d/SHA256SUMS")"
-bash "$SCRIPT" "$d" >/dev/null 2>&1
+out="$(run "$d")" || fail "a rerun exited non-zero" "$out"
 [[ "$before" == "$(cat "$d/SHA256SUMS")" ]] \
   && pass "rerunning is byte-identical" || fail "output changed on rerun"
+grep -q "SHA256SUMS" "$d/SHA256SUMS" && fail "the sums file lists itself on rerun" \
+  || pass "the sums file excludes itself once it exists"
 
-# A tampered asset must be caught, which is the only reason the file exists.
+# The failure mode the file exists to catch.
 printf 'tampered\n' > "$d/qunleashed_0.13.0_macos_universal.dmg"
 ( cd "$d" && sha256sum -c SHA256SUMS >/dev/null 2>&1 ) \
   && fail "a tampered asset still verified" || pass "a tampered asset fails verification"
 
-empty="$TMP/empty"; mkdir -p "$empty"
-bash "$SCRIPT" "$empty" >/dev/null 2>&1 \
-  && fail "an empty directory was accepted" || pass "an empty directory is refused"
+# A partial download must not leave a manifest behind for a later step to ship.
+part="$TMP/partial"; mkdir -p "$part"; printf 'ok\n' > "$part/good.apk"
+ln -s "$TMP/absent" "$part/dangling.apk" 2>/dev/null || true
+rm -f "$part/SHA256SUMS"
 
-bash "$SCRIPT" "$TMP/does-not-exist" >/dev/null 2>&1 \
-  && fail "a missing directory was accepted" || pass "a missing directory is refused"
+empty="$TMP/empty"; mkdir -p "$empty"
+run "$empty" >/dev/null 2>&1 && fail "an empty directory was accepted" \
+  || pass "an empty directory is refused"
+[[ ! -e "$empty/SHA256SUMS" ]] \
+  && pass "a refused run writes no manifest" || fail "a refused run left a manifest"
+
+run "$TMP/does-not-exist" >/dev/null 2>&1 && fail "a missing directory was accepted" \
+  || pass "a missing directory is refused"
 
 if (( failures )); then
   echo "$failures failure(s)" >&2

--- a/.github/scripts/checksums_test.sh
+++ b/.github/scripts/checksums_test.sh
@@ -2,9 +2,9 @@
 # Covers checksums.sh. auto-release.yml only runs on a tag push, so without this
 # a regression would not surface until a release was already being cut.
 #
-# The fixture mirrors the real asset set on purpose, including the extensionless
-# Linux binary: a mutation as small as globbing `*.*` instead of `*` drops every
-# extensionless asset, and a fixture of only .apk/.dmg/.exe cannot see it.
+# The fixture is chosen for what each name pins rather than to mirror the
+# release: an extensionless binary, a mixed-case name, and a leading dash all
+# break a plausible simplification of the script.
 set -Eeuo pipefail
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -20,81 +20,59 @@ fail() {
   failures=$((failures + 1))
 }
 
-# Runs the script, keeping its output so a failure can say why.
-run() {
-  local out
-  if out="$(bash "$SCRIPT" "$@" 2>&1)"; then printf '%s' "$out"; return 0; fi
-  printf '%s' "$out"; return 1
-}
+run()    { bash "$SCRIPT" "$@" 2>&1; }
+check()  { local l="$1"; shift; if "$@" >/dev/null 2>&1; then pass "$l"; else fail "$l"; fi; }
+refute() { local l="$1"; shift; if "$@" >/dev/null 2>&1; then fail "$l"; else pass "$l"; fi; }
+verify() { ( cd "$1" && sha256sum -c SHA256SUMS ); }
 
 echo "checksums.sh"
 
+# In the byte order the script must emit, so the same list serves as fixture
+# and as expectation.
+names=(
+  -leading-dash.bin                       # `--` guards it; without that the run dies
+  QUnleashed_0.13.0_notes.txt             # mixed case pins LC_ALL=C collation
+  qunleashed_0.13.0_linux_x64             # extensionless: a `*.*` glob drops it
+  qunleashed_0.13.0_macos_universal.dmg   # the one the tamper case corrupts
+  qunleashed_0.13.0_windows_x64.exe       # the one the mode-marker case reads
+)
 d="$TMP/assets"; mkdir -p "$d"
-printf 'apk\n'   > "$d/qunleashed_0.13.0_android_arm64-v8a.apk"
-printf 'ipa\n'   > "$d/qunleashed_0.13.0_ios_arm64.ipa"
-printf 'linux\n' > "$d/qunleashed_0.13.0_linux_x64"
-printf 'dmg\n'   > "$d/qunleashed_0.13.0_macos_universal.dmg"
-printf 'exe\n'   > "$d/qunleashed_0.13.0_windows_x64.exe"
-# Mixed case pins the byte-wise order: under a UTF-8 locale it collates after
-# the lowercase names, under LC_ALL=C before them.
-printf 'notes\n' > "$d/QUnleashed_0.13.0_notes.txt"
-# A leading dash is what `--` protects against; without it sha256sum reads the
-# name as an option and the run dies.
-printf 'dash\n'  > "$d/-leading-dash.bin"
+for n in "${names[@]}"; do printf '%s\n' "$n" > "$d/$n"; done
 mkdir -p "$d/nested" && printf 'inner\n' > "$d/nested/inner.txt"
 
 out="$(run "$d")" || fail "a normal run exited non-zero" "$out"
 
-( cd "$d" && sha256sum -c SHA256SUMS >/dev/null 2>&1 ) \
-  && pass "output verifies with sha256sum -c" || fail "sha256sum -c rejected the output"
+check  "output verifies with sha256sum -c" verify "$d"
+check  "names are bare and the mode is binary" \
+       grep -q " [*]qunleashed_0.13.0_windows_x64.exe$" "$d/SHA256SUMS"
 
-grep -q " [*]qunleashed_0.13.0_windows_x64.exe$" "$d/SHA256SUMS" \
-  && pass "names are bare and the mode is binary" || fail "wrong name or mode marker"
-
-# The asset with no extension is the one a careless glob silently drops.
-grep -q " [*]qunleashed_0.13.0_linux_x64$" "$d/SHA256SUMS" \
-  && pass "the extensionless Linux binary is covered" || fail "extensionless asset dropped"
-
-# Names, not just a count: this pins the exact set and catches a lost sort too.
-expected="-leading-dash.bin
-QUnleashed_0.13.0_notes.txt
-qunleashed_0.13.0_android_arm64-v8a.apk
-qunleashed_0.13.0_ios_arm64.ipa
-qunleashed_0.13.0_linux_x64
-qunleashed_0.13.0_macos_universal.dmg
-qunleashed_0.13.0_windows_x64.exe"
 actual="$(sed 's/^[0-9a-f]* [*]//' "$d/SHA256SUMS")"
+expected="$(printf '%s\n' "${names[@]}")"
 [[ "$actual" == "$expected" ]] \
   && pass "covers exactly the files, in byte order, no directory" \
   || fail "wrong file set or order" "$actual"
 
-# Rerunning must not churn the file, and on this run SHA256SUMS already exists -
-# which is the only run where the self-exclusion is live code.
+# The rerun is the only run where the self-exclusion is live code, because the
+# glob happens before SHA256SUMS exists on a first run.
 before="$(cat "$d/SHA256SUMS")"
 out="$(run "$d")" || fail "a rerun exited non-zero" "$out"
 [[ "$before" == "$(cat "$d/SHA256SUMS")" ]] \
   && pass "rerunning is byte-identical" || fail "output changed on rerun"
-grep -q "SHA256SUMS" "$d/SHA256SUMS" && fail "the sums file lists itself on rerun" \
-  || pass "the sums file excludes itself once it exists"
+refute "the sums file excludes itself once it exists" \
+       grep -q "SHA256SUMS" "$d/SHA256SUMS"
 
 # The failure mode the file exists to catch.
 printf 'tampered\n' > "$d/qunleashed_0.13.0_macos_universal.dmg"
-( cd "$d" && sha256sum -c SHA256SUMS >/dev/null 2>&1 ) \
-  && fail "a tampered asset still verified" || pass "a tampered asset fails verification"
-
-# A partial download must not leave a manifest behind for a later step to ship.
-part="$TMP/partial"; mkdir -p "$part"; printf 'ok\n' > "$part/good.apk"
-ln -s "$TMP/absent" "$part/dangling.apk" 2>/dev/null || true
-rm -f "$part/SHA256SUMS"
+refute "a tampered asset fails verification" verify "$d"
 
 empty="$TMP/empty"; mkdir -p "$empty"
-run "$empty" >/dev/null 2>&1 && fail "an empty directory was accepted" \
-  || pass "an empty directory is refused"
-[[ ! -e "$empty/SHA256SUMS" ]] \
-  && pass "a refused run writes no manifest" || fail "a refused run left a manifest"
+refute "an empty directory is refused" run "$empty"
+refute "a refused run writes no manifest" test -e "$empty/SHA256SUMS"
+refute "a missing directory is refused" run "$TMP/does-not-exist"
 
-run "$TMP/does-not-exist" >/dev/null 2>&1 && fail "a missing directory was accepted" \
-  || pass "a missing directory is refused"
+# Usage errors are exit 2, as in derive_version.sh and restore_firebase_config.sh.
+check "an unknown flag exits 2" bash -c '"$1" --help; [[ $? -eq 2 ]]' _ "$SCRIPT"
+check "a stray second argument exits 2" bash -c '"$1" a b; [[ $? -eq 2 ]]' _ "$SCRIPT"
 
 if (( failures )); then
   echo "$failures failure(s)" >&2

--- a/.github/scripts/checksums_test.sh
+++ b/.github/scripts/checksums_test.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# Covers checksums.sh. The release job that calls it only runs on a tag push,
+# so this is the only place a regression can surface before a release.
+set -Eeuo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/checksums.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+failures=0
+
+pass() { printf '  ok    %s\n' "$1"; }
+fail() { printf '  FAIL  %s\n' "$1"; failures=$((failures + 1)); }
+
+echo "checksums.sh"
+
+d="$TMP/assets"; mkdir -p "$d"
+printf 'apk\n'  > "$d/qunleashed_0.13.0_android_arm64-v8a.apk"
+printf 'dmg\n'  > "$d/qunleashed_0.13.0_macos_universal.dmg"
+printf 'exe\n'  > "$d/qunleashed_0.13.0_windows_x64.exe"
+mkdir -p "$d/nested"
+
+bash "$SCRIPT" "$d" >/dev/null 2>&1 || fail "a normal run exited non-zero"
+
+# The whole point: the file has to verify with the standard tool.
+( cd "$d" && sha256sum -c SHA256SUMS >/dev/null 2>&1 ) \
+  && pass "output verifies with sha256sum -c" || fail "sha256sum -c rejected the output"
+
+grep -q " [*]qunleashed_0.13.0_windows_x64.exe$" "$d/SHA256SUMS" \
+  && pass "names are bare and the mode is binary" || fail "wrong name or mode marker"
+
+[[ "$(wc -l < "$d/SHA256SUMS")" -eq 3 ]] \
+  && pass "covers every file and no directory" || fail "wrong line count"
+
+grep -q "SHA256SUMS" "$d/SHA256SUMS" && fail "the sums file lists itself" \
+  || pass "the sums file does not list itself"
+
+# Deterministic: rerunning over unchanged assets must not churn the file.
+before="$(cat "$d/SHA256SUMS")"
+bash "$SCRIPT" "$d" >/dev/null 2>&1
+[[ "$before" == "$(cat "$d/SHA256SUMS")" ]] \
+  && pass "rerunning is byte-identical" || fail "output changed on rerun"
+
+# A tampered asset must be caught, which is the only reason the file exists.
+printf 'tampered\n' > "$d/qunleashed_0.13.0_macos_universal.dmg"
+( cd "$d" && sha256sum -c SHA256SUMS >/dev/null 2>&1 ) \
+  && fail "a tampered asset still verified" || pass "a tampered asset fails verification"
+
+empty="$TMP/empty"; mkdir -p "$empty"
+bash "$SCRIPT" "$empty" >/dev/null 2>&1 \
+  && fail "an empty directory was accepted" || pass "an empty directory is refused"
+
+bash "$SCRIPT" "$TMP/does-not-exist" >/dev/null 2>&1 \
+  && fail "a missing directory was accepted" || pass "a missing directory is refused"
+
+if (( failures )); then
+  echo "$failures failure(s)" >&2
+  exit 1
+fi
+echo "all passed"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -268,6 +268,9 @@ jobs:
             } >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Write SHA256SUMS
+        run: .github/scripts/checksums.sh dist
+
       - name: Publish GitHub release
         uses: softprops/action-gh-release@v2
         with:
@@ -284,6 +287,7 @@ jobs:
             dist/qunleashed_*_macos_*.dmg
             dist/qunleashed_*_windows_x64_raw.zip
             dist/qunleashed_*_windows_x64.exe
+            dist/SHA256SUMS
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -279,6 +279,9 @@ jobs:
           prerelease: ${{ steps.channel.outputs.prerelease }}
           make_latest: ${{ steps.channel.outputs.make_latest }}
           generate_release_notes: true
+          # Defaults to false, which would publish a release quietly missing an
+          # asset - including SHA256SUMS itself.
+          fail_on_unmatched_files: true
           overwrite_files: true
           files: |
             dist/qunleashed_*_android_*.apk

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
         with:
           submodules: recursive
 
-      # Pure bash, and needs neither Flutter nor the Firebase stub. It runs first
-      # so a broken setup cannot mask a regression in the release version maths,
-      # which auto-release.yml can only exercise on a real tag push.
+      # Both are pure bash and need neither Flutter nor the Firebase stub. They
+      # run first so a broken setup cannot mask a regression in release logic
+      # that auto-release.yml can only exercise on a real tag push.
       - name: Test the release version derivation
         run: .github/scripts/derive_version_test.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Test the release version derivation
         run: .github/scripts/derive_version_test.sh
 
+      - name: Test the release checksums
+        run: .github/scripts/checksums_test.sh
+
       - name: Test the Android artifact verification
         run: .github/scripts/verify_apks_test.sh
 

--- a/.github/workflows/crowdin-rx.yml
+++ b/.github/workflows/crowdin-rx.yml
@@ -22,6 +22,15 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
 
+      # A pull request opened with GITHUB_TOKEN starts no workflow runs, so a
+      # translation would reach main with no analyze or test behind it - and a
+      # malformed .arb breaks gen-l10n for every later build. L10N_PR_TOKEN is
+      # a token belonging to an account, which does trigger them.
+      - name: Check the pull request token
+        if: ${{ !secrets.L10N_PR_TOKEN }}
+        run: |
+          echo "::warning::L10N_PR_TOKEN is not set, so this pull request will run no checks. See issue #40."
+
       - name: Download translations
         uses: crowdin/github-action@v2
         with:
@@ -35,7 +44,7 @@ jobs:
           pull_request_base_branch_name: main
           commit_message: "Update translations from Crowdin"
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.L10N_PR_TOKEN || secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 

--- a/.github/workflows/crowdin-rx.yml
+++ b/.github/workflows/crowdin-rx.yml
@@ -22,15 +22,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
 
-      # A pull request opened with GITHUB_TOKEN starts no workflow runs, so a
-      # translation would reach main with no analyze or test behind it - and a
-      # malformed .arb breaks gen-l10n for every later build. L10N_PR_TOKEN is
-      # a token belonging to an account, which does trigger them.
-      - name: Check the pull request token
-        if: ${{ !secrets.L10N_PR_TOKEN }}
-        run: |
-          echo "::warning::L10N_PR_TOKEN is not set, so this pull request will run no checks. See issue #40."
-
       - name: Download translations
         uses: crowdin/github-action@v2
         with:
@@ -44,7 +35,7 @@ jobs:
           pull_request_base_branch_name: main
           commit_message: "Update translations from Crowdin"
         env:
-          GITHUB_TOKEN: ${{ secrets.L10N_PR_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 


### PR DESCRIPTION
Closes #32.

Releases shipped nine binaries with nothing to verify them against. `checksums.sh` writes `SHA256SUMS` over the merged assets in the publish job, and the release carries it alongside them.

Two decisions worth noting:

- **Binary mode is forced.** Left to the default, coreutils picks text mode on Linux and binary under Git Bash, so the published file would differ depending on where it was generated.
- **Names are stored bare**, so `sha256sum -c SHA256SUMS` works from whatever directory somebody downloaded the assets into.

An empty directory is an error rather than an empty file — the job reaches that step only after three build jobs uploaded artifacts, so nothing to checksum means something upstream failed without failing the run.

This is also a winget prerequisite (M2): a manifest requires a SHA256 per installer.

## Coverage

`checksums_test.sh` runs in CI, since the release job that calls the script only runs on a tag push. The suite pins the contract rather than the implementation: that the output verifies with the standard tool, that a **tampered asset fails verification**, that rerunning over unchanged assets is byte-identical, and that an empty or missing directory is refused.

## Not covered

`auto-release.yml` still cannot be dry-run, so the `Write SHA256SUMS` step itself runs for the first time on a real tag. The script is covered; its wiring into the publish job is not. See #38.

## Dropped from this PR

An earlier commit here also pointed the Crowdin action at an `L10N_PR_TOKEN` so translation pull requests would run CI (#40). Reverted by decision — the current Crowdin flow stays on `GITHUB_TOKEN`, and that gap is not worth a personal access token. #40 stays open with the no-credential option recorded.
