### PR TITLE
Verify the Android APKs actually contain an app before publishing

### DIFF
--- a/.github/scripts/android_abis.sh
+++ b/.github/scripts/android_abis.sh
@@ -1,0 +1,11 @@
+# The Android ABIs every release builds, in one place.
+#
+# android.sh names an artifact per ABI and verify_apks.sh checks the artifacts
+# against these names, so the two must agree. Adding an ABI to one and not the
+# other turns the next release red.
+# shellcheck disable=SC2034
+ANDROID_ABIS=(
+  "armeabi-v7a"
+  "arm64-v8a"
+  "x86_64"
+)

--- a/.github/scripts/build/android.sh
+++ b/.github/scripts/build/android.sh
@@ -3,6 +3,9 @@ set -Eeuo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 APP_NAME="qunleashed"
+
+# shellcheck source=../android_abis.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/android_abis.sh"
 DIST_DIR="$ROOT_DIR/dist"
 VERSION_NAME="${QUNLEASHED_VERSION_NAME:-}"
 
@@ -44,12 +47,6 @@ cp "$UNIVERSAL_APK" "$DIST_DIR/${APP_NAME}_${VERSION_NAME}_android_universal.apk
 
 echo "Building Android ABI APKs..."
 (cd "$ROOT_DIR" && "$FLUTTER_BIN" build apk --release --split-per-abi "${FLUTTER_BUILD_ARGS[@]}")
-
-ANDROID_ABIS=(
-  "armeabi-v7a"
-  "arm64-v8a"
-  "x86_64"
-)
 
 for abi in "${ANDROID_ABIS[@]}"; do
   apk="$ROOT_DIR/build/app/outputs/flutter-apk/app-${abi}-release.apk"

--- a/.github/scripts/verify_apks.sh
+++ b/.github/scripts/verify_apks.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Checks that the built Android APKs actually contain a working application
+# before the release publishes them.
+#
+#   verify_apks.sh [directory]   # default: dist
+#
+# The build only ever checked that the files exist, and so did the upload. An
+# APK missing lib/<abi>/libapp.so - the Dart snapshot - builds green, installs,
+# and dies at launch. CopyFlutterJniLibsTask in the Flutter SDK documents two
+# regressions that dropped libapp.so from the APK (flutter#186810, #187388), and
+# its copy step silently stages nothing when the per-ABI directory is missing or
+# empty, so the shape is reachable without anything failing.
+#
+# Integrity is checked first and separately, because `unzip -Z` reads only the
+# central directory: an APK whose entry data is truncated or zeroed still lists
+# every expected name. `unzip -t` is what actually reads the bytes.
+#
+# The expected ABIs come from android_abis.sh, shared with android.sh so the
+# names it writes and the names checked here cannot drift apart.
+#
+# Note this assumes standalone APKs from `flutter build apk`. An App Bundle
+# config split carries no classes.dex and would be rejected; if the build ever
+# moves to bundles (Play requires them), this needs revisiting.
+set -Eeuo pipefail
+
+# shellcheck source=android_abis.sh
+. "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/android_abis.sh"
+
+# A real snapshot is multiple megabytes. This only has to be large enough to
+# reject an empty or stub file and small enough never to reject a real one.
+MIN_SNAPSHOT_BYTES=1048576
+
+dir="${1:-dist}"
+failures=0
+
+fault() {
+  echo "::error::$1" >&2
+  failures=$((failures + 1))
+}
+
+shopt -s nullglob
+apks=("$dir"/*_android_*.apk)
+if (( ${#apks[@]} == 0 )); then
+  echo "::error::No Android APKs found in $dir." >&2
+  exit 1
+fi
+
+seen_universal=0
+declare -A seen_abi=()
+
+for apk in "${apks[@]}"; do
+  name="$(basename "$apk")"
+  before=$failures
+
+  # Both the expected ABIs and the artifact's identity come from the name.
+  case "$name" in
+    *_android_universal.apk)
+      want=("${ANDROID_ABIS[@]}")
+      seen_universal=1
+      ;;
+    *)
+      abi="${name##*_android_}"
+      abi="${abi%.apk}"
+      if printf '%s\n' "${ANDROID_ABIS[@]}" | grep -qxF -- "$abi"; then
+        want=("$abi")
+        seen_abi["$abi"]=1
+      else
+        fault "$name does not match any known Android artifact name."
+        continue
+      fi
+      ;;
+  esac
+
+  # Reads the entry data and checks every CRC, which the listing below does not.
+  if ! err="$(unzip -tqq "$apk" 2>&1)"; then
+    fault "$name failed its integrity check: ${err:-no detail}"
+    continue
+  fi
+
+  if ! listing="$(unzip -Z1 "$apk" 2>&1)"; then
+    fault "$name could not be listed: ${listing:-no detail}"
+    continue
+  fi
+
+  grep -qxF -- 'AndroidManifest.xml' <<<"$listing" \
+    || fault "$name has no AndroidManifest.xml."
+  grep -qxF -- 'classes.dex' <<<"$listing" \
+    || fault "$name has no classes.dex."
+
+  for abi in "${want[@]}"; do
+    if ! grep -qxF -- "lib/$abi/libapp.so" <<<"$listing"; then
+      fault "$name has no lib/$abi/libapp.so - the Dart snapshot is missing."
+      continue
+    fi
+    # Present is not the same as populated: a truncated or stub snapshot is
+    # still an app that dies at launch.
+    bytes="$(unzip -p "$apk" "lib/$abi/libapp.so" | wc -c)"
+    if (( bytes < MIN_SNAPSHOT_BYTES )); then
+      fault "$name has a $bytes-byte lib/$abi/libapp.so; expected at least $MIN_SNAPSHOT_BYTES."
+    fi
+  done
+
+  # A split carrying an ABI it should not have means the split did not happen.
+  # `|| true` because no lib/ entries at all is a fault reported above, not a
+  # reason to abandon the remaining artifacts.
+  found="$(grep -oE '^lib/[^/]+/' <<<"$listing" | cut -d/ -f2 | sort -u || true)"
+  for abi in $found; do
+    printf '%s\n' "${want[@]}" | grep -qxF -- "$abi" \
+      || fault "$name carries an unexpected ABI: $abi."
+  done
+
+  if (( failures == before )); then
+    echo "  ok  $name (${want[*]})"
+  fi
+done
+
+# The build hard-fails on a missing artifact, but this is the gate that is meant
+# not to trust the build.
+(( seen_universal )) || fault "No universal APK in $dir."
+for abi in "${ANDROID_ABIS[@]}"; do
+  [[ -n "${seen_abi[$abi]:-}" ]] || fault "No $abi APK in $dir."
+done
+
+if (( failures )); then
+  echo "::error::$failures problem(s) found; refusing to publish." >&2
+  exit 1
+fi
+echo "Verified ${#apks[@]} Android artifact(s)."

--- a/.github/scripts/verify_apks_test.sh
+++ b/.github/scripts/verify_apks_test.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Covers verify_apks.sh. auto-release.yml only runs on a tag push, so without
+# this a regression would not surface until a release was already being cut.
+#
+# An APK is a zip, so the fixtures are built with python's zipfile and need no
+# Android toolchain. Every negative case asserts the message as well as the
+# exit status: a script that merely exits non-zero for the wrong reason - or
+# dies on a syntax error - would otherwise satisfy almost the whole suite.
+set -Eeuo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$HERE/verify_apks.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+failures=0
+
+pass() { printf '  ok    %s\n' "$1"; }
+fail() {
+  printf '  FAIL  %s\n' "$1"
+  [[ -n "${2:-}" ]] && printf '%s\n' "$2" | sed 's/^/          /'
+  failures=$((failures + 1))
+}
+
+run() { bash "$SCRIPT" "$@" 2>&1; }
+
+# accepts <label> <dir>
+accepts() {
+  local out
+  if out="$(run "$2")"; then pass "$1"; else fail "$1" "$out"; fi
+}
+
+# refuses <label> <dir> <expected message substring>
+refuses() {
+  local out
+  if out="$(run "$2")"; then
+    fail "$1 (was accepted)" "$out"
+  elif [[ "$out" != *"$3"* ]]; then
+    fail "$1 (refused for the wrong reason; wanted \"$3\")" "$out"
+  else
+    pass "$1"
+  fi
+}
+
+# A snapshot large enough to clear the script's floor.
+SNAPSHOT_BYTES=$((1024 * 1024 + 32))
+
+# apk <path> <abi>...
+apk() {
+  python3 - "$SNAPSHOT_BYTES" "$@" <<'PY'
+import sys, zipfile
+size, path, abis = int(sys.argv[1]), sys.argv[2], sys.argv[3:]
+with zipfile.ZipFile(path, "w") as z:
+    z.writestr("AndroidManifest.xml", "manifest")
+    z.writestr("classes.dex", "dex")
+    z.writestr("classes2.dex", "dex")          # real APKs have these; must not confuse the check
+    z.writestr("resources.arsc", "res")
+    z.writestr("assets/flutter_assets/lib/fonts/x.ttf", "font")
+    for abi in abis:
+        z.writestr(f"lib/{abi}/libapp.so", b"\0" * size)
+        z.writestr(f"lib/{abi}/libflutter.so", "engine")
+        z.writestr(f"lib/{abi}/libapp.so.sym", "symbols")  # superstring; pins the exact-line match
+PY
+}
+
+# apk_omitting <path> <prefix-to-omit> <abi>...  (prefix drops a file or a whole tree)
+apk_omitting() {
+  python3 - "$SNAPSHOT_BYTES" "$@" <<'PY'
+import sys, zipfile
+size, path, omit, abis = int(sys.argv[1]), sys.argv[2], sys.argv[3], sys.argv[4:]
+with zipfile.ZipFile(path, "w") as z:
+    for entry in ("AndroidManifest.xml", "classes.dex"):
+        if not entry.startswith(omit):
+            z.writestr(entry, "body")
+    for abi in abis:
+        if not f"lib/{abi}/libapp.so".startswith(omit):
+            z.writestr(f"lib/{abi}/libapp.so", b"\0" * size)
+        # Kept even when libapp.so is omitted, so a substring match would
+        # wrongly satisfy the snapshot check. Only a dropped tree removes it.
+        if not (omit.endswith("/") and f"lib/{abi}/libapp.so.sym".startswith(omit)):
+            z.writestr(f"lib/{abi}/libapp.so.sym", "symbols")
+        if not f"lib/{abi}/libflutter.so".startswith(omit):
+            z.writestr(f"lib/{abi}/libflutter.so", "engine")
+PY
+}
+
+good_set() {
+  local d="$1"; mkdir -p "$d"
+  apk "$d/qunleashed_0.13.0_android_universal.apk"   armeabi-v7a arm64-v8a x86_64
+  apk "$d/qunleashed_0.13.0_android_armeabi-v7a.apk" armeabi-v7a
+  apk "$d/qunleashed_0.13.0_android_arm64-v8a.apk"   arm64-v8a
+  apk "$d/qunleashed_0.13.0_android_x86_64.apk"      x86_64
+}
+
+echo "verify_apks.sh"
+
+d="$TMP/good"; good_set "$d"
+accepts "a complete artifact set passes" "$d"
+
+d="$TMP/no-snapshot"; good_set "$d"
+apk_omitting "$d/qunleashed_0.13.0_android_arm64-v8a.apk" "lib/arm64-v8a/libapp.so" arm64-v8a
+refuses "a split APK missing libapp.so is refused" "$d" "the Dart snapshot is missing"
+
+# The task stages nothing when the per-ABI directory is absent, so the APK has
+# no lib/ tree at all - not merely a missing file.
+d="$TMP/no-lib-tree"; good_set "$d"
+apk_omitting "$d/qunleashed_0.13.0_android_x86_64.apk" "lib/x86_64/" x86_64
+refuses "an APK with no lib/ tree at all is refused" "$d" "the Dart snapshot is missing"
+
+# Present is not populated.
+d="$TMP/empty-snapshot"; good_set "$d"
+python3 - "$d/qunleashed_0.13.0_android_x86_64.apk" <<'PY'
+import sys, zipfile
+with zipfile.ZipFile(sys.argv[1], "w") as z:
+    z.writestr("AndroidManifest.xml", "manifest")
+    z.writestr("classes.dex", "dex")
+    z.writestr("lib/x86_64/libapp.so", b"")
+PY
+refuses "a zero-byte libapp.so is refused" "$d" "expected at least"
+
+# The listing reads only the central directory, so entry data must be checked.
+d="$TMP/corrupt-data"; good_set "$d"
+python3 - "$d/qunleashed_0.13.0_android_x86_64.apk" <<'PY'
+import sys, zipfile, io
+path = sys.argv[1]
+raw = bytearray(open(path, "rb").read())
+end = raw.rfind(b"PK\x01\x02")           # start of the central directory
+raw[:end] = b"\0" * end                  # obliterate the entry data, keep the index
+open(path, "wb").write(bytes(raw))
+PY
+refuses "an APK whose data is corrupt but listable is refused" "$d" "failed its integrity check"
+
+d="$TMP/universal-partial"; good_set "$d"
+apk "$d/qunleashed_0.13.0_android_universal.apk" armeabi-v7a arm64-v8a
+refuses "a universal APK missing an ABI is refused" "$d" "the Dart snapshot is missing"
+
+d="$TMP/unsplit"; good_set "$d"
+apk "$d/qunleashed_0.13.0_android_x86_64.apk" armeabi-v7a arm64-v8a x86_64
+refuses "a split APK carrying other ABIs is refused" "$d" "carries an unexpected ABI"
+
+d="$TMP/no-manifest"; good_set "$d"
+apk_omitting "$d/qunleashed_0.13.0_android_x86_64.apk" "AndroidManifest.xml" x86_64
+refuses "an APK with no AndroidManifest.xml is refused" "$d" "has no AndroidManifest.xml"
+
+d="$TMP/no-dex"; good_set "$d"
+apk_omitting "$d/qunleashed_0.13.0_android_universal.apk" "classes.dex" armeabi-v7a arm64-v8a x86_64
+refuses "an APK with no classes.dex is refused" "$d" "has no classes.dex"
+
+d="$TMP/unreadable"; good_set "$d"
+printf 'not a zip\n' > "$d/qunleashed_0.13.0_android_x86_64.apk"
+refuses "an unreadable APK is refused" "$d" "failed its integrity check"
+
+d="$TMP/stray"; good_set "$d"
+apk "$d/qunleashed_0.13.0_android_riscv64.apk" riscv64
+refuses "an artifact with an unrecognised name is refused" "$d" "does not match any known"
+
+# The build guards this too, but this is the gate that must not trust the build.
+d="$TMP/partial-set"; mkdir -p "$d"
+apk "$d/qunleashed_0.13.0_android_universal.apk" armeabi-v7a arm64-v8a x86_64
+refuses "an incomplete artifact set is refused" "$d" "No armeabi-v7a APK"
+
+d="$TMP/no-universal"; mkdir -p "$d"
+apk "$d/qunleashed_0.13.0_android_armeabi-v7a.apk" armeabi-v7a
+apk "$d/qunleashed_0.13.0_android_arm64-v8a.apk"   arm64-v8a
+apk "$d/qunleashed_0.13.0_android_x86_64.apk"      x86_64
+refuses "a set with no universal APK is refused" "$d" "No universal APK"
+
+d="$TMP/empty"; mkdir -p "$d"
+refuses "a directory with no APKs is refused" "$d" "No Android APKs found"
+refuses "a missing directory is refused" "$TMP/does-not-exist" "No Android APKs found"
+
+# One run must report every problem, not stop at the first.
+d="$TMP/many"; good_set "$d"
+apk_omitting "$d/qunleashed_0.13.0_android_x86_64.apk" "classes.dex" x86_64
+apk_omitting "$d/qunleashed_0.13.0_android_arm64-v8a.apk" "lib/arm64-v8a/libapp.so" arm64-v8a
+out="$(run "$d" || true)"
+if [[ "$out" == *"has no classes.dex"* && "$out" == *"the Dart snapshot is missing"* ]]; then
+  pass "one run reports every broken artifact"
+else
+  fail "one run reports every broken artifact" "$out"
+fi
+
+# A rejected artifact must not also be logged as ok.
+if [[ "$out" == *"  ok  qunleashed_0.13.0_android_x86_64.apk"* ]]; then
+  fail "a failing APK is still logged as ok" "$out"
+else
+  pass "a failing APK is not logged as ok"
+fi
+
+if (( failures )); then
+  echo "$failures failure(s)" >&2
+  exit 1
+fi
+echo "all passed"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -95,6 +95,11 @@ jobs:
       - name: Build Android release APKs
         run: .github/scripts/build/android.sh
 
+      # Existence was the only thing checked before this. An APK with no
+      # libapp.so builds green, installs, and dies at launch.
+      - name: Verify Android APKs
+        run: .github/scripts/verify_apks.sh dist
+
       - name: Install Linux build dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Test the release version derivation
         run: .github/scripts/derive_version_test.sh
 
+      - name: Test the Android artifact verification
+        run: .github/scripts/verify_apks_test.sh
+
       - name: Set up Flutter
         uses: ./.github/actions/setup-flutter
 


### PR DESCRIPTION
Closes #51.

Nothing in the pipeline ever opened an Android artifact. `android.sh` checked the APK files exist; `if-no-files-found: error` checked existence again. An APK missing `lib/<abi>/libapp.so` — the Dart snapshot — builds green, installs, dies at launch, and would be published as `latest` with a push notification behind it.

That shape is reachable, not hypothetical. `CopyFlutterJniLibsTask` in the pinned Flutter SDK documents two regressions that dropped `libapp.so` from the APK (flutter#186810, #187388), and its copy step silently stages nothing when the per-ABI directory is missing or empty.

`verify_apks.sh` runs between the build and the upload, so a bad artifact never reaches `dist/`.

## What review changed

Three rounds found the first version had the problem inverted.

**`unzip -Z` is zipinfo — it reads only the central directory.** It never touches an entry or checks a CRC. An APK whose data was zeroed or truncated (a partial copy, a full disk, a bad transfer) listed every expected name and **passed green**. That is the failure class the script exists to stop. `unzip -t` now runs first, as its own check with its own message.

**A present `libapp.so` is not a working one.** A zero-byte or stub snapshot passed as readily as a real one. Its uncompressed size now has to clear a floor far below any real snapshot and far above an empty file.

**No `lib/` entries at all killed the run mid-loop.** That is exactly what the Flutter task produces when it stages nothing — the headline case. `grep` exited 1, `pipefail` propagated it, `set -e` ended the script: every remaining APK went unchecked and the summary never printed. An artifact that failed a check was also still logged as `ok` beside its own error.

**The ABI list existed twice.** `android.sh` names artifacts per ABI and this script checked them, with nothing tying the two together — the likeliest false positive, since whoever adds an ABI to one gets a red release from the other. They now share `android_abis.sh`. The script also asserts the whole expected set rather than "at least one artifact".

## On false positives

This gates every release, so a wrong rejection is worse than the gap it closes. Two reviewers checked independently and cleared it: the expected ABIs match what Flutter 3.47.1 actually emits (`configureAbiWithoutSplits` clamps `abiFilters` to exactly these three — without which the CMake targets would emit `lib/x86/` and trip the check), `classes.dex` is always present given `multiDexEnabled`, `unzip -Z1` is unbothered by the APK signing block, and a real Flutter APK passes unmodified.

One caveat worth knowing: that correctness is borrowed. Pinning `flutter-version` back to a release without `configureAbiWithoutSplits`, or passing `-Pdisable-abi-filtering`, re-opens the `x86` leak.

## Tests

Every negative case asserts the message, not just a non-zero exit — pointed at a script consisting of nothing but `exit 1`, the first suite passed 9 of 10. Fixtures cover a tree with no `lib/` at all, a corrupt-but-listable archive, a zero-byte snapshot, an incomplete set, a superstring entry pinning the exact-line match, and a `lib/` segment that is not an ABI directory.

**Eleven of twelve mutants are caught.** The survivor drops `sort -u`, which only ever changed whether a fault repeated.

## Note

An App Bundle config split carries no `classes.dex` and would be rejected. Not this pipeline's output today, but M5 requires bundles for Play — recorded in the script header.
