### PR TITLE
Let the release workflow build without publishing

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -31,7 +31,7 @@ runs:
 
     # Always runs and always reports, so a mistyped input cannot leave a macOS
     # build silently on SPM - the failure it would cause surfaces far from here,
-    # in a release pipeline that cannot be dry-run.
+    # in a release pipeline whose publish path only runs on a tag.
     - name: Configure Swift Package Manager
       shell: bash
       env:

--- a/.github/scripts/derive_version.sh
+++ b/.github/scripts/derive_version.sh
@@ -2,13 +2,19 @@
 # Derives the app version from the release tag, so no two jobs can disagree
 # about what a tag means.
 #
-#   derive_version.sh                 # write to $GITHUB_ENV and $GITHUB_OUTPUT
-#   derive_version.sh --print         # write "<name> <code>" to stdout instead
-#   derive_version.sh --print <tag>   # ... for an explicit tag
+#   derive_version.sh                    # write to $GITHUB_ENV and $GITHUB_OUTPUT
+#   derive_version.sh -- <tag>           # ... for an explicit tag
+#   derive_version.sh --print [--] <tag> # write "<name> <code>" to stdout instead
 #
-# Without an explicit tag the value comes from $GITHUB_REF_NAME. --print exists
-# for the tests; jobs consume the values through the environment or through the
-# step output, so nothing in the workflow depends on this script's stdout.
+# Pass a caller-supplied tag after `--`. The release workflow does, because on a
+# tag push `${{ inputs.tag }}` expands to an empty argument and on a dispatch it
+# is whatever an operator typed - without the separator, a tag of `--print`
+# would take the print arm, write nothing to $GITHUB_ENV and exit 0, and the
+# build would silently fall back to the pubspec version with no dart-defines.
+#
+# An empty or absent tag falls back to $GITHUB_REF_NAME. --print exists for the
+# tests; jobs consume the values through the environment or the step output, so
+# nothing in the workflow depends on this script's stdout.
 #
 # QU_BUILD_SERVER_URL and QU_BUILD_SERVER_KEY are folded into the Flutter build
 # arguments only when both are set, since a URL without a key authenticates
@@ -18,8 +24,10 @@ set -Eeuo pipefail
 print_only=0
 case "${1:-}" in
   --print) print_only=1; shift ;;
-  --*) echo "Usage: $0 [--print] [tag]" >&2; exit 2 ;;
+  --) shift ;;
+  --*) echo "Usage: $0 [--print] [--] [tag]" >&2; exit 2 ;;
 esac
+if [[ "${1:-}" == "--" ]]; then shift; fi
 
 tag="${1:-${GITHUB_REF_NAME:-}}"
 if [[ -z "$tag" ]]; then

--- a/.github/scripts/derive_version_test.sh
+++ b/.github/scripts/derive_version_test.sh
@@ -70,6 +70,12 @@ got="$(run GITHUB_REF_NAME=beta-0.11.2 bash "$DERIVE" --print || true)"
 [[ "$got" == "0.11.2 11002" ]] && pass "--print reads GITHUB_REF_NAME" \
   || fail "--print GITHUB_REF_NAME fallback -> '$got'"
 
+# On a tag push the workflow passes "${{ inputs.tag }}", which expands to an
+# empty argument - it must fall back rather than be read as a tag.
+got="$(run GITHUB_REF_NAME=beta-0.11.2 bash "$DERIVE" --print "" || true)"
+[[ "$got" == "0.11.2 11002" ]] && pass "an empty tag argument falls back" \
+  || fail "empty tag argument -> '$got'"
+
 # --- $GITHUB_ENV / $GITHUB_OUTPUT mode --------------------------------------
 
 echo "derive_version.sh (workflow mode)"
@@ -112,6 +118,24 @@ fi
 refutes "a secret with a newline" run_env GITHUB_REF_NAME=beta-0.11.2 QU_CARTO_KEY="$(printf 'a\nb')"
 refutes "a secret with a space"   run_env GITHUB_REF_NAME=beta-0.11.2 QU_CARTO_KEY="a b"
 refutes "a missing GITHUB_ENV"    run GITHUB_REF_NAME=beta-0.11.2 bash "$DERIVE"
+
+# A dispatch passes an explicit tag while GITHUB_REF_NAME is a branch that the
+# version regex would reject. The argument has to win, and it has to reach
+# $GITHUB_ENV - the push path only ever exercises the fallback.
+out="$TMP/env"; step="$TMP/out"; : > "$out"; : > "$step"
+if run GITHUB_ENV="$out" GITHUB_OUTPUT="$step" GITHUB_REF_NAME=main \
+     bash "$DERIVE" -- beta-0.13.0 >/dev/null; then
+  body="$(cat "$out" "$step")"
+  has "an explicit tag beats the branch ref" "QUNLEASHED_VERSION_NAME=0.13.0"
+  has "and reaches the step output"          "version_code=13000"
+else
+  fail "an explicit tag in workflow mode exited non-zero"
+fi
+
+# The tag is passed after `--` so operator text cannot land in the option slot.
+refutes "a tag of --print is not read as a flag" \
+        run GITHUB_ENV="$TMP/env2" GITHUB_REF_NAME=beta-0.13.0 \
+        bash "$DERIVE" -- --print
 
 if (( failures )); then
   echo "$failures failure(s)" >&2

--- a/.github/scripts/derive_version_test.sh
+++ b/.github/scripts/derive_version_test.sh
@@ -63,6 +63,21 @@ refutes "no-version-here" run bash "$DERIVE" --print "no-version-here"
 refutes "1.2"             run bash "$DERIVE" --print "1.2"
 refutes "0.0.0"           run bash "$DERIVE" --print "0.0.0"
 refutes "an unknown flag" run bash "$DERIVE" --bogus
+
+# The workflow passes the tag after `--` in all four call sites, so the arm
+# that consumes it is load-bearing.
+ok_sep() {
+  local want="$2" got
+  if ! got="$(run bash "$DERIVE" --print -- "$1")"; then got="<rejected>"; fi
+  [[ "$got" == "$want" ]] && pass "-- $1 -> $got" || fail "-- $1 -> $got (want $want)"
+}
+ok_sep "beta-0.11.2" "0.11.2 11002"
+ok_sep "--print"     "<rejected>"
+
+# `-- ""` is the tag-push shape: an empty argument after the separator.
+got="$(run GITHUB_REF_NAME=beta-0.11.2 bash "$DERIVE" --print -- "" || true)"
+[[ "$got" == "0.11.2 11002" ]] && pass "-- with an empty tag falls back" \
+  || fail "-- empty tag -> '$got'"
 refutes "a missing tag"   run bash "$DERIVE" --print
 
 # The tag falls back to GITHUB_REF_NAME when no argument is given.

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -47,7 +47,9 @@ jobs:
 
       - name: Validate the dispatched tag
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: .github/scripts/derive_version.sh --print -- "${{ inputs.tag }}"
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: .github/scripts/derive_version.sh --print -- "$RELEASE_TAG"
 
   build-android-linux:
     name: Build Android and Linux releases
@@ -91,7 +93,8 @@ jobs:
           QU_BUILD_SERVER_URL: ${{ secrets.QU_BUILD_SERVER_URL }}
           QU_BUILD_SERVER_KEY: ${{ secrets.QU_BUILD_SERVER_KEY }}
           QU_CARTO_KEY: ${{ secrets.QU_CARTO_KEY }}
-        run: .github/scripts/derive_version.sh -- "${{ inputs.tag }}"
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: .github/scripts/derive_version.sh -- "$RELEASE_TAG"
 
       - name: Configure Android signing
         env:
@@ -183,7 +186,8 @@ jobs:
           QU_BUILD_SERVER_URL: ${{ secrets.QU_BUILD_SERVER_URL }}
           QU_BUILD_SERVER_KEY: ${{ secrets.QU_BUILD_SERVER_KEY }}
           QU_CARTO_KEY: ${{ secrets.QU_CARTO_KEY }}
-        run: .github/scripts/derive_version.sh -- "${{ inputs.tag }}"
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: .github/scripts/derive_version.sh -- "$RELEASE_TAG"
 
       - name: Build Windows raw ZIP and packaged EXE
         shell: pwsh
@@ -245,7 +249,8 @@ jobs:
           QU_BUILD_SERVER_URL: ${{ secrets.QU_BUILD_SERVER_URL }}
           QU_BUILD_SERVER_KEY: ${{ secrets.QU_BUILD_SERVER_KEY }}
           QU_CARTO_KEY: ${{ secrets.QU_CARTO_KEY }}
-        run: .github/scripts/derive_version.sh -- "${{ inputs.tag }}"
+          RELEASE_TAG: ${{ inputs.tag }}
+        run: .github/scripts/derive_version.sh -- "$RELEASE_TAG"
 
       - name: Install macOS build dependencies
         run: brew install automake libtool
@@ -274,8 +279,12 @@ jobs:
       - build-android-linux
       - build-macos
       - build-windows
-    # Creates the GitHub release, so only ever for a tag.
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    # Creates the GitHub release, so only ever for a pushed tag. A dispatch can
+    # be started from a tag ref, so the ref alone does not distinguish them -
+    # event_name is what does.
+    if: ${{ github.server_url == 'https://github.com'
+      && github.event_name == 'push'
+      && startsWith(github.ref, 'refs/tags/') }}
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -366,7 +375,8 @@ jobs:
     needs: publish
     # `if:` skips do not fail a run, so a tag push that quietly produced no
     # release would otherwise be green - the worst outcome available here.
-    if: ${{ always() && startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ always() && github.event_name == 'push'
+      && startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -379,8 +389,10 @@ jobs:
   sync-version:
     name: Sync pubspec version with tag
     needs: [publish, build-android-linux]
-    # Pushes to the default branch, so only ever for a tag.
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    # Pushes to the default branch, so only ever for a pushed tag.
+    if: ${{ github.server_url == 'https://github.com'
+      && github.event_name == 'push'
+      && startsWith(github.ref, 'refs/tags/') }}
     permissions:
       contents: write
     runs-on: ubuntu-latest

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,12 +4,27 @@ on:
   push:
     tags:
       - "*"
+  # Builds every platform without publishing anything, so a change to the build
+  # path can be tried without cutting a release. It does NOT exercise publishing:
+  # artifact merging, SHA256SUMS, the release globs and the push notification all
+  # live in `publish`, which a dispatch never reaches.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Version tag to build as, e.g. beta-0.13.0. Nothing is published."
+        required: true
+        type: string
 
+# Read by default: the build jobs never write anything outside the run. The two
+# jobs that do are granted it individually, so a dispatch is structurally unable
+# to publish rather than merely gated off it.
 permissions:
-  contents: write
+  contents: read
 
+# A dispatch can be started from a tag ref, which would otherwise share a group
+# with that tag's release push and cancel it.
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -17,6 +32,9 @@ jobs:
     name: Check GitHub server
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
       - name: Cancel outside github.com
         if: ${{ github.server_url != 'https://github.com' }}
         run: |
@@ -26,6 +44,10 @@ jobs:
       - name: Confirm github.com
         if: ${{ github.server_url == 'https://github.com' }}
         run: echo "Running on ${{ github.server_url }}"
+
+      - name: Validate the dispatched tag
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: .github/scripts/derive_version.sh --print -- "${{ inputs.tag }}"
 
   build-android-linux:
     name: Build Android and Linux releases
@@ -69,7 +91,7 @@ jobs:
           QU_BUILD_SERVER_URL: ${{ secrets.QU_BUILD_SERVER_URL }}
           QU_BUILD_SERVER_KEY: ${{ secrets.QU_BUILD_SERVER_KEY }}
           QU_CARTO_KEY: ${{ secrets.QU_CARTO_KEY }}
-        run: .github/scripts/derive_version.sh
+        run: .github/scripts/derive_version.sh -- "${{ inputs.tag }}"
 
       - name: Configure Android signing
         env:
@@ -95,6 +117,19 @@ jobs:
       - name: Build Android release APKs
         run: .github/scripts/build/android.sh
 
+      - name: Note what a dispatch does not exercise
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        run: |
+          {
+            echo "## Dispatch build - nothing was published"
+            echo "Built as \`${{ inputs.tag }}\`. This run did NOT exercise:"
+            echo "- artifact merging, SHA256SUMS, or the GitHub release"
+            echo "- release notes and the asset globs"
+            echo "- the push notification, or the pubspec bump on the default branch"
+            echo ""
+            echo "Artifacts carry release filenames and the release key. Do not promote them."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # Existence was the only thing checked before this. An APK with no
       # libapp.so builds green, installs, and dies at launch.
       - name: Verify Android APKs
@@ -116,6 +151,9 @@ jobs:
             dist/qunleashed_*_android_*.apk
             dist/qunleashed_*_linux_x64
           if-no-files-found: error
+          # A dispatch build carries release filenames and the release key.
+          # Keep it briefly so it cannot be mistaken for a published asset.
+          retention-days: ${{ github.event_name == 'workflow_dispatch' && 1 || 90 }}
 
   build-windows:
     name: Build Windows release
@@ -145,7 +183,7 @@ jobs:
           QU_BUILD_SERVER_URL: ${{ secrets.QU_BUILD_SERVER_URL }}
           QU_BUILD_SERVER_KEY: ${{ secrets.QU_BUILD_SERVER_KEY }}
           QU_CARTO_KEY: ${{ secrets.QU_CARTO_KEY }}
-        run: .github/scripts/derive_version.sh
+        run: .github/scripts/derive_version.sh -- "${{ inputs.tag }}"
 
       - name: Build Windows raw ZIP and packaged EXE
         shell: pwsh
@@ -164,6 +202,9 @@ jobs:
             dist/qunleashed_*_windows_x64_raw.zip
             dist/qunleashed_*_windows_x64.exe
           if-no-files-found: error
+          # A dispatch build carries release filenames and the release key.
+          # Keep it briefly so it cannot be mistaken for a published asset.
+          retention-days: ${{ github.event_name == 'workflow_dispatch' && 1 || 90 }}
 
   build-macos:
     name: Build macOS and iOS releases
@@ -204,7 +245,7 @@ jobs:
           QU_BUILD_SERVER_URL: ${{ secrets.QU_BUILD_SERVER_URL }}
           QU_BUILD_SERVER_KEY: ${{ secrets.QU_BUILD_SERVER_KEY }}
           QU_CARTO_KEY: ${{ secrets.QU_CARTO_KEY }}
-        run: .github/scripts/derive_version.sh
+        run: .github/scripts/derive_version.sh -- "${{ inputs.tag }}"
 
       - name: Install macOS build dependencies
         run: brew install automake libtool
@@ -223,6 +264,9 @@ jobs:
             dist/qunleashed_*_macos_*.dmg
             dist/qunleashed_*_ios_*.ipa
           if-no-files-found: error
+          # A dispatch build carries release filenames and the release key.
+          # Keep it briefly so it cannot be mistaken for a published asset.
+          retention-days: ${{ github.event_name == 'workflow_dispatch' && 1 || 90 }}
 
   publish:
     name: Publish GitHub release
@@ -230,7 +274,10 @@ jobs:
       - build-android-linux
       - build-macos
       - build-windows
-    if: ${{ github.server_url == 'https://github.com' }}
+    # Creates the GitHub release, so only ever for a tag.
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 15
 
@@ -314,10 +361,28 @@ jobs:
           fi
           python .github/scripts/notify_push.py "$PUSH_TOPIC" "$PUSH_TITLE" "$PUSH_BODY"
 
+  assert-published:
+    name: Assert the release published
+    needs: publish
+    # `if:` skips do not fail a run, so a tag push that quietly produced no
+    # release would otherwise be green - the worst outcome available here.
+    if: ${{ always() && startsWith(github.ref, 'refs/tags/') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Fail if publish did not run
+        if: ${{ needs.publish.result != 'success' }}
+        run: |
+          echo "::error::Tag push finished without publishing (publish: ${{ needs.publish.result }})."
+          exit 1
+
   sync-version:
     name: Sync pubspec version with tag
     needs: [publish, build-android-linux]
-    if: ${{ github.server_url == 'https://github.com' }}
+    # Pushes to the default branch, so only ever for a tag.
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,10 @@ jobs:
         with:
           submodules: recursive
 
-      # Both are pure bash and need neither Flutter nor the Firebase stub. They
-      # run first so a broken setup cannot mask a regression in release logic
-      # that auto-release.yml can only exercise on a real tag push.
+      # All are pure bash and need neither Flutter nor the Firebase stub. They
+      # run first so a broken setup cannot mask a regression in release logic.
+      # auto-release.yml can be dispatched now, but a unit test is faster and
+      # deterministic, so it stays the first line of defence.
       - name: Test the release version derivation
         run: .github/scripts/derive_version_test.sh
 


### PR DESCRIPTION
Closes #50.

`auto-release.yml` only ran on a tag push, so nothing in it could be exercised without cutting a release. That has cost repeatedly — two review rounds on earlier PRs ended at "this path is uncovered until a real tag", and the Android build measurement in #48 is blocked on having any way to run it.

A `workflow_dispatch` entry takes the tag as an input and builds every platform.

**It does not exercise publishing, and the comment says so.** Artifact merging, `SHA256SUMS`, the release globs under `fail_on_unmatched_files`, and the push notification all live in `publish`, which a dispatch never reaches. A green dispatch run proves the *build* path works — nothing more. The run writes a job summary saying exactly that, so a green check is not mistaken for proof the release path is sound.

## What review changed

**The tag now goes after `--`.** Without the separator, operator-controlled text landed in the option slot: dispatching with a tag of `--print` took the print arm, wrote **nothing** to `$GITHUB_ENV`, and exited 0. The build then fell back to the pubspec version having silently lost every `--dart-define` — the build-server key, the Carto key, the release tag — while staying green and signed with the release key. `verify_apks.sh` checks structure, not defines, so it would have passed too.

**Least privilege replaced the guard as the real protection.** `contents: write` was workflow-level, so all five jobs held a token they never used. It now sits on the two jobs that write. A dispatch run is **structurally unable** to publish rather than merely gated off it — the protection survives someone later editing a guard away.

**The gate is `github.event_name == 'push'`, and a review round is why.** I briefly changed it to `startsWith(github.ref, 'refs/tags/')` on the argument that it expresses intent more directly. That was wrong and reintroduced the exact hole this PR exists to close: **`workflow_dispatch` accepts a tag as its ref** — the UI's ref picker has a Tags tab — so a dispatch against a tag satisfies the ref test, and both jobs would have run. `event_name` is the half that cannot be spoofed: it is never `push` on a dispatch, and a re-run replays the original event. The ref test and the `server_url` check are kept alongside it as defence in depth, not as the mechanism.

**The tag reaches the script as data, not as text.** `--` stops the *script's* option parsing; it does nothing about the *shell's*. `${{ inputs.tag }}` was substituted into the `run:` script before bash saw it, so a tag of `1.2.3"; …; : "` executed as a command — with the `QU_*` secrets in that step's env, and able to rewrite a workspace script that later handles the signing keystore. It now arrives through an environment variable in all four call sites.

**A silent skip is now loud.** An `if:` skip does not fail a run, so a tag push that quietly produced no release would have been green. `assert-published` turns that red.

Smaller: a dispatched tag is validated once in `guard` (a ten-second job every build already needs) instead of three times after three parallel checkouts including macOS; and dispatch artifacts expire in a day, since they carry release filenames and the release key and would otherwise sit downloadable for 90 days on a public repo.

## Coverage

The `+6` I first wrote covered the **push** path — an empty argument falling back to `GITHUB_REF_NAME` — which was already effectively pinned. The path this PR actually introduces is a dispatch: an explicit tag while `GITHUB_REF_NAME` is a *branch* the version regex would reject. That is precisely the objection #38 recorded against dispatch, and it is now pinned, along with the `--print`-as-a-tag case.

Three comments elsewhere asserted the workflow could not be dry-run; they no longer say that.

## Follow-ups this changes

- **#48** is unblocked — the decomposition it waits on can now be measured.
- **#35** is partly satisfied (its `workflow_dispatch` checkbox); the rest is a `schedule:` entry on this workflow rather than the separate workflow it assumed.
- **#38's** recorded rejection of dispatch no longer holds, though its extraction work remains warranted — a unit test is faster and deterministic.
