### PR TITLE
Lint the workflows in CI

### DIFF
--- a/.github/scripts/lint_workflows.sh
+++ b/.github/scripts/lint_workflows.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Runs actionlint over the workflows and the composite action.
+#
+#   lint_workflows.sh
+#
+# Workflow mistakes are otherwise only found by running the workflow, and the
+# release workflow publishes on a tag. Two that reached this repository would
+# have been caught here: a `secrets` reference in a step-level `if:`, which is a
+# template-parse failure that kills the whole file, and an input that the action
+# being called does not declare, which GitHub ignores silently.
+#
+# The binary is pinned and its checksum verified, because this runs in the same
+# repository whose release job holds the signing key. See the issue on Gradle
+# distribution verification for the same argument applied to the build.
+set -Eeuo pipefail
+
+VERSION="1.7.12"
+SHA256="8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8"
+ARCHIVE="actionlint_${VERSION}_linux_amd64.tar.gz"
+URL="https://github.com/rhysd/actionlint/releases/download/v${VERSION}/${ARCHIVE}"
+
+if [[ "$(uname -s)" != "Linux" ]]; then
+  echo "::error::This script fetches the Linux build; run it on a Linux runner." >&2
+  exit 1
+fi
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+curl -fsSL "$URL" -o "$tmp/$ARCHIVE"
+echo "$SHA256  $tmp/$ARCHIVE" | sha256sum -c - >/dev/null \
+  || { echo "::error::actionlint checksum mismatch; refusing to run it." >&2; exit 1; }
+
+tar -xzf "$tmp/$ARCHIVE" -C "$tmp" actionlint
+"$tmp/actionlint" -version
+
+# shellcheck is not installed on the runner by default; actionlint skips it and
+# says so. Workflow-level checks are the point here.
+"$tmp/actionlint" -color

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
       - name: Test the Android artifact verification
         run: .github/scripts/verify_apks_test.sh
 
+      # Catches what only running a workflow would otherwise catch, and the
+      # release workflow only publishes on a tag.
+      - name: Lint the workflows
+        run: .github/scripts/lint_workflows.sh
+
       - name: Set up Flutter
         uses: ./.github/actions/setup-flutter
 


### PR DESCRIPTION
Refs #38. Closes nothing — see the note on #46 below, which turned out to be wrong.

## What #46 claimed, and what is actually true

#46 said `overwrite_files: true` is "not a valid input" for `softprops/action-gh-release@v2` and was being silently ignored. **That is false.** Checked against the action's own `action.yml`:

```
overwrite_files:
  description: Overwrite existing files with the same name. Defaults to true
  default: 'true'
```

It is one of the action's 19 declared inputs, added in v2.3.3. Passing it is **redundant** — it restates the default — not ignored. I left it in place: explicit intent is worth a line, and it keeps working if the default ever changes.

I also ran actionlint directly against the repository. It reports **nothing** on these workflows. So the finding that motivated #46 was not something the tool produced.

## Why the tool is still worth adding — and what it does not do

Measured against the three defects actually shipped in this milestone's PRs, rather than against planted examples:

| Defect | Caught |
|---|---|
| `secrets` in a step-level `if:` | **yes** |
| Shell injection via `"${{ inputs.tag }}"` in a `run:` | no |
| Guard gated on `startsWith(github.ref, 'refs/tags/')`, which a dispatch satisfies | no |

One of three. The injection rule exists — it flags `github.event.issue.title` — but its untrusted list does not include `inputs.*` from `workflow_dispatch`. The guard hole is semantic; no linter catches it.

The case rests on the character of the class it does catch, not the count. A `secrets` reference in a step `if:` is a **template-parse failure that kills the whole workflow file**, and a version of it reached a commit in this milestone — it was removed only because that change was reverted for unrelated reasons. Had it landed on `crowdin-rx.yml`, which runs solely on a 04:00 cron, the symptom would have been translations quietly ceasing to arrive: no red X, no failed job anyone looks at.

It also catches undeclared inputs to called actions (which GitHub ignores silently) and context property typos.

Cost, stated plainly: ~40 lines of script, a pinned version and checksum to maintain, and a network download on every CI run — a new way for CI to fail for reasons unrelated to the code. This is a judgment call, not an obvious win.

## Implementation

`lint_workflows.sh` pins actionlint to v1.7.12 and verifies the archive checksum before running it. It executes in the same repository whose release job holds the signing key, so an unverified download would reproduce exactly the hole #52 describes for the Gradle distribution.

It runs alongside the other bash suites, before the Flutter setup, so a broken toolchain cannot mask a workflow regression.
