### PR TITLE
Install the committed lockfile in CI

### DIFF
--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -46,6 +46,10 @@ runs:
             ;;
         esac
 
+    # --enforce-lockfile installs exactly what pubspec.lock records instead of
+    # re-resolving. Without it CI tested, and a release shipped, a dependency
+    # set nobody had committed - and the pub cache, keyed on the lockfile hash,
+    # missed on every run that resolved something newer.
     - name: Install Flutter dependencies
       shell: bash
-      run: flutter pub get
+      run: flutter pub get --enforce-lockfile

--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -8,7 +8,13 @@ description: >
 
 inputs:
   flutter-version:
-    description: Flutter SDK version to install. Every job in this repository builds on the same default; override only to trial a different SDK.
+    description: >
+      Flutter SDK version to install. Every job in this repository builds on the
+      same default. Bumping it means regenerating pubspec.lock in the same
+      commit: flutter_test pins matcher, test_api, vector_math and meta to exact
+      versions that move with the SDK, and --enforce-lockfile below turns any
+      mismatch into a red build on every job at once. For the same reason an
+      override to trial a different SDK fails here rather than building.
     required: false
     default: "3.47.1"
   swift-package-manager:
@@ -46,10 +52,22 @@ runs:
             ;;
         esac
 
-    # --enforce-lockfile installs exactly what pubspec.lock records instead of
-    # re-resolving. Without it CI tested, and a release shipped, a dependency
-    # set nobody had committed - and the pub cache, keyed on the lockfile hash,
-    # missed on every run that resolved something newer.
+    # --enforce-lockfile installs exactly the hosted versions pubspec.lock
+    # records instead of re-resolving. Without it CI tested, and a release
+    # shipped, a dependency set nobody had committed: main's lockfile was
+    # resolved against Flutter 3.44.0 while this action pins 3.47.1, so every
+    # run silently re-resolved five packages. It also stopped the pub cache
+    # persisting them - the key is the committed lockfile, so it hit, and a hit
+    # suppresses the post-job save.
+    #
+    # It does not cover the two path dependencies: lib/modules/flipperlib and
+    # lib/modules/dartufbt record a version string and no hash, so a submodule
+    # whose code moved still satisfies the lockfile. What pins those is the
+    # gitlink plus `submodules: recursive` on every checkout.
     - name: Install Flutter dependencies
       shell: bash
-      run: flutter pub get --enforce-lockfile
+      run: |
+        if ! flutter pub get --enforce-lockfile; then
+          echo "::error::pubspec.lock does not match pubspec.yaml or the pinned Flutter SDK. Run 'flutter pub get' locally and commit the regenerated pubspec.lock. Do not drop --enforce-lockfile - that is what keeps CI and releases on the committed dependency set."
+          exit 1
+        fi

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -511,10 +511,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
       url: "https://pub.dev"
     source: hosted
-    version: "0.20.2"
+    version: "0.20.3"
   isolate_contactor:
     dependency: transitive
     description:
@@ -647,10 +647,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "31bd099b47c10cd1aeb55146a2d46ce0277630ecef3f7dae54ad7873f36696cd"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.20"
   material_color_utilities:
     dependency: transitive
     description:
@@ -663,10 +663,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "307249ce4ff29d58a18e97f6345f539382eb9c9c29ecda628900f31de0443dd9"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.19.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -1100,10 +1100,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "2a122cbe059f8b610d3a5415f42e255b6c17b1f21eee1d960f31080237fb4f11"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.12"
   timezone:
     dependency: transitive
     description:
@@ -1244,10 +1244,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: f36f9f3be64c6198714492bb455c11056e33e2f85d9a0b676a48301e44fdcf47
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.4.2"
   vm_service:
     dependency: transitive
     description:


### PR DESCRIPTION
Closes #18.

`flutter pub get` **re-resolves** rather than installing what `pubspec.lock` records. So whenever a package published a new version inside the existing constraints, CI tested — and a release shipped — a dependency set nobody had committed.

This was observed live rather than theorised: running `flutter analyze` locally during earlier work silently rewrote `pubspec.lock`, which is what surfaced the issue.

**It was not a latent risk — it was already happening on every run.** `main`'s lockfile was resolved against Flutter 3.44.0, while the composite action pins 3.47.1. Three of its entries did not even *satisfy* the pinned SDK's constraints, so every CI run and every release build on `main` re-resolved. Measured against a local 3.47.1:

```
$ flutter pub get --enforce-lockfile --dry-run     # main's lockfile
Would change 5 dependencies.
Unable to satisfy `pubspec.yaml` using `pubspec.lock`.   → exit 65

$ flutter pub get --enforce-lockfile --dry-run     # this branch
No dependencies would change.                            → exit 0
```

## The dependency change is smaller than it looks

| package | | |
|---|---|---|
| `intl` | 0.20.2 → 0.20.3 | direct, declared `any` |
| `matcher` | 0.12.19 → 0.12.20 | from `flutter_test` |
| `test_api` | 0.7.11 → 0.7.12 | from `flutter_test` |
| `vector_math` | 2.2.0 → 2.4.2 | from `flutter` |
| `meta` | 1.18.0 → 1.19.0 | from `flutter`, `flutter_test`, `device_info_plus` |

**None of the five is a choice.** Four come from the SDK's own packages — `flutter_test` pins `matcher` and `test_api` *exactly*, which is why `test_api 0.7.14` exists on pub but is correctly not taken. The fifth looks like a free choice but isn't: `flutter_localizations` constrains `intl: ^0.20.3`, so `any` in `pubspec.yaml` defers to the SDK, and 0.20.2 is simply what 3.44.0 wanted.

That makes this an alignment of the lockfile with the SDK the pin already selected, not a dependency upgrade. `flutter analyze` is clean and all 226 tests pass against it.

## Where enforcement lives

In the `setup-flutter` composite action rather than in `ci.yml`, so the three release build jobs install exactly the set CI tested instead of re-resolving independently on three runners — which is where a drift would matter most and be least visible.

## What it does *not* cover

The two path dependencies. `flipperlib` and `dartufbt` record a `version:` string and **no hash**, so a submodule whose code moved still satisfies the lockfile — verified by editing `flipperlib`'s source and watching enforcement pass. What pins those is the gitlink plus `submodules: recursive`, present on every checkout. The comment in the action says so rather than claiming the lockfile covers them.

## Sharper edges this creates, both documented in the action

- A `pubspec.yaml` edit without a matching `pubspec.lock` update now fails every job rather than silently resolving. That is the intent.
- **Bumping `flutter-version` now requires regenerating `pubspec.lock` in the same commit**, since the SDK-vendored packages move with the SDK — exactly as they did here.

Pub's own failure advice is *"run without `--enforce-lockfile`"*, which points a contributor facing four red jobs at deleting the guard. The step adds an `::error::` annotation naming the real fix instead.