### PR TITLE
Make the IR library unpack survive a bad entry, and ~7x faster

### DIFF
--- a/lib/pages/tools/infrared/local_repo.dart
+++ b/lib/pages/tools/infrared/local_repo.dart
@@ -8,6 +8,7 @@ import 'package:path_provider/path_provider.dart';
 
 import '../../../components/path.dart';
 import '../../../services/http/app_http.dart';
+import '../../../services/logging.dart';
 import '../../../services/storage/paths.dart';
 
 class IrLibDownloadProgress {
@@ -183,7 +184,14 @@ class IrLibLocalRepo {
     receivePort.listen((msg) {
       if (msg is _UnpackProgress) {
         onProgress(msg.extracted, msg.totalFiles, msg.done);
-        if (msg.done && !done.isCompleted) done.complete();
+        if (!msg.done) return;
+        if (msg.skipped > 0) {
+          LogService.log(
+            '[IrLib] unpacked ${msg.extracted}, skipped ${msg.skipped} '
+            '(first: ${msg.firstError})',
+          );
+        }
+        if (!done.isCompleted) done.complete();
       }
     });
     errorPort.listen((msg) {
@@ -209,36 +217,110 @@ class IrLibLocalRepo {
     }
   }
 
+  /// Writes every entry of [archive] under [rootPath], skipping the ones the
+  /// filesystem refuses instead of abandoning the whole library.
+  ///
+  /// Entries whose name does not resolve inside the root are dropped silently -
+  /// that is [resolveWrappedArchivePath] refusing a traversal, not a failure -
+  /// so they count as neither extracted nor skipped.
+  ///
+  /// A single entry can fail for reasons no name check can predict: a reserved
+  /// device name like `CON` on Windows, a component the OS rejects, a full
+  /// disk, or a name colliding with a file already on disk. Any one of those
+  /// used to abort the import of all ~15,000 entries.
+  static ({int extracted, int skipped, String? firstError}) unpackArchiveTo(
+    Archive archive,
+    String rootPath, {
+    required String separator,
+    void Function(int extracted)? onProgress,
+  }) {
+    // createSync(recursive: true) is not free when the directory is already
+    // there, and the library holds ~15,000 files across far fewer folders, so
+    // calling it per file re-created directories ~11,500 times for nothing:
+    // ~0.2s of the unpack, measured. Only successful calls are recorded, so a
+    // failure that later clears is retried rather than remembered as done.
+    final createdDirs = <String>{};
+    void ensureDir(io.Directory dir) {
+      if (createdDirs.contains(dir.path)) return;
+      dir.createSync(recursive: true);
+      createdDirs.add(dir.path);
+    }
+
+    var extracted = 0;
+    var skipped = 0;
+    String? firstError;
+
+    for (final entry in archive.files) {
+      final outPath = resolveWrappedArchivePath(
+        rootPath,
+        entry.name,
+        separator: separator,
+      );
+      if (outPath == null) continue;
+      try {
+        if (entry.isFile) {
+          final file = io.File(outPath);
+          ensureDir(file.parent);
+          // Deliberately unflushed. An fsync per file dominated this loop:
+          // 2.10ms per entry against 0.33ms without one, measured on Windows
+          // over 2,000 files. It bought nothing - the zip is re-downloadable,
+          // and an interrupted unpack already leaves a partial tree that the
+          // next run overwrites.
+          file.writeAsBytesSync(entry.readBytes()!);
+          extracted += 1;
+          onProgress?.call(extracted);
+        } else {
+          ensureDir(io.Directory(outPath));
+        }
+      } catch (e) {
+        skipped += 1;
+        firstError ??= '${entry.name}: $e';
+      }
+    }
+
+    return (extracted: extracted, skipped: skipped, firstError: firstError);
+  }
+
   static void _unpackIsolateEntry(_UnpackArgs args) {
     final send = args.sendPort;
     final input = InputFileStream(args.zipPath);
     try {
       final archive = ZipDecoder().decodeStream(input);
       final totalFiles = archive.files.where((f) => f.isFile).length;
-      var extracted = 0;
-      send.send(_UnpackProgress(extracted, totalFiles, false));
+      send.send(_UnpackProgress(0, totalFiles, false));
 
-      for (final entry in archive.files) {
-        final outPath = resolveWrappedArchivePath(
-          args.rootPath,
-          entry.name,
-          separator: args.sep,
-        );
-        if (outPath == null) continue;
-        if (entry.isFile) {
-          final file = io.File(outPath);
-          file.parent.createSync(recursive: true);
-          file.writeAsBytesSync(entry.readBytes()!, flush: true);
-          extracted += 1;
-          if (extracted % 25 == 0 || extracted == totalFiles) {
+      final tally = unpackArchiveTo(
+        archive,
+        args.rootPath,
+        separator: args.sep,
+        onProgress: (extracted) {
+          if (extracted % 25 == 0) {
             send.send(_UnpackProgress(extracted, totalFiles, false));
           }
-        } else {
-          io.Directory(outPath).createSync(recursive: true);
-        }
+        },
+      );
+
+      // Tolerating failed entries must not extend to tolerating all of them:
+      // reporting done with nothing on disk would leave the user an empty
+      // library and no error at all. An archive carrying no files is the same
+      // outcome by a different route, so it fails the same way.
+      if (tally.extracted == 0) {
+        throw StateError(
+          totalFiles == 0
+              ? 'the archive contained no files'
+              : 'all $totalFiles entries failed, first: ${tally.firstError}',
+        );
       }
 
-      send.send(_UnpackProgress(extracted, totalFiles, true));
+      send.send(
+        _UnpackProgress(
+          tally.extracted,
+          totalFiles,
+          true,
+          skipped: tally.skipped,
+          firstError: tally.firstError,
+        ),
+      );
     } finally {
       input.close();
     }
@@ -254,8 +336,20 @@ class _UnpackArgs {
 }
 
 class _UnpackProgress {
-  _UnpackProgress(this.extracted, this.totalFiles, this.done);
+  _UnpackProgress(
+    this.extracted,
+    this.totalFiles,
+    this.done, {
+    this.skipped = 0,
+    this.firstError,
+  });
   final int extracted;
   final int totalFiles;
   final bool done;
+
+  /// Entries the filesystem refused. Carried back over the port rather than
+  /// logged where they happen, since the isolate's static state - LogService
+  /// included - is its own and never reaches the app's log.
+  final int skipped;
+  final String? firstError;
 }

--- a/lib/pages/tools/infrared/local_repo.dart
+++ b/lib/pages/tools/infrared/local_repo.dart
@@ -182,17 +182,31 @@ class IrLibLocalRepo {
     final done = Completer<void>();
 
     receivePort.listen((msg) {
-      if (msg is _UnpackProgress) {
-        onProgress(msg.extracted, msg.totalFiles, msg.done);
-        if (!msg.done) return;
-        if (msg.skipped > 0) {
-          LogService.log(
-            '[IrLib] unpacked ${msg.extracted}, skipped ${msg.skipped} '
-            '(first: ${msg.firstError})',
-          );
-        }
-        if (!done.isCompleted) done.complete();
+      if (msg is _UnpackTick) {
+        onProgress(msg.extracted, msg.totalFiles, false);
+        return;
       }
+      if (msg is! _UnpackResult || done.isCompleted) return;
+
+      final tally = msg.tally;
+      if (tally.skipped > 0 || tally.dropped > 0) {
+        LogService.log(
+          '[IrLib] unpacked ${tally.extracted}, skipped ${tally.skipped}, '
+          'dropped ${tally.dropped} (first: ${tally.firstError})',
+        );
+      }
+
+      // Deciding here rather than in the isolate: this side owns the Completer
+      // and the only localized vocabulary in the flow, so the isolate stays a
+      // worker that reports what happened instead of throwing a hardcoded
+      // English sentence at the user through StateError.toString().
+      final failure = failureFor(tally, msg.totalFiles);
+      if (failure != null) {
+        done.completeError(StateError(l10n.irUnpackFailed(failure)));
+        return;
+      }
+      onProgress(tally.extracted, msg.totalFiles, true);
+      done.complete();
     });
     errorPort.listen((msg) {
       if (done.isCompleted) return;
@@ -217,68 +231,141 @@ class IrLibLocalRepo {
     }
   }
 
-  /// Writes every entry of [archive] under [rootPath], skipping the ones the
-  /// filesystem refuses instead of abandoning the whole library.
+  /// How many unwritable entries a successful unpack may hide.
   ///
-  /// Entries whose name does not resolve inside the root are dropped silently -
-  /// that is [resolveWrappedArchivePath] refusing a traversal, not a failure -
-  /// so they count as neither extracted nor skipped.
+  /// The per-entry handler exists so a few pathological names do not cost the
+  /// user the whole library. Past that the cause is systemic - a full disk, a
+  /// revoked permission - and the result is a truncated library replacing the
+  /// good one [download] already deleted, so it has to fail as loudly as it
+  /// used to. Floor and share both matter: a fixed count alone hair-triggers
+  /// on a small archive, a share alone lets a big library lose hundreds of
+  /// files quietly.
+  static const int _skipFloor = 10;
+  static const double _skipShare = 0.01;
+
+  /// Why [tally] should be reported as a failure, or null if it succeeded.
+  ///
+  /// Public so the policy can be tested directly: it is the one piece of this
+  /// flow that decides whether the user keeps a library or gets an error, and
+  /// it runs on the far side of an isolate boundary from everything else.
+  static String? failureFor(UnpackTally tally, int totalFiles) {
+    final resolved = tally.extracted + tally.skipped;
+    if (resolved == 0) {
+      return totalFiles == 0
+          ? 'the archive contained no files'
+          : 'none of $totalFiles entries resolved inside the library root';
+    }
+    if (tally.extracted == 0) {
+      return 'all $resolved entries failed to write '
+          '(first: ${tally.firstError})';
+    }
+    if (tally.skipped > _skipFloor && tally.skipped > resolved * _skipShare) {
+      return '${tally.skipped} of $resolved entries failed to write '
+          '(first: ${tally.firstError})';
+    }
+    return null;
+  }
+
+  /// Writes every file entry of [archive] under [rootPath], skipping the ones
+  /// the filesystem refuses instead of abandoning the whole library.
+  ///
+  /// Entries [resolveWrappedArchivePath] declines - the wrapper folder itself,
+  /// anything beside it rather than inside it, or a `..` traversal - are
+  /// counted as dropped. That is the name check working, not a failure.
   ///
   /// A single entry can fail for reasons no name check can predict: a reserved
-  /// device name like `CON` on Windows, a component the OS rejects, a full
-  /// disk, or a name colliding with a file already on disk. Any one of those
-  /// used to abort the import of all ~15,000 entries.
-  static ({int extracted, int skipped, String? firstError}) unpackArchiveTo(
+  /// device name like `CON` on Windows, a full disk, or a collision with
+  /// something the archive itself already wrote there. Any one of those used to
+  /// abort the import of the whole library.
+  static UnpackTally unpackWrappedArchiveTo(
     Archive archive,
     String rootPath, {
     required String separator,
     void Function(int extracted)? onProgress,
   }) {
     // createSync(recursive: true) is not free when the directory is already
-    // there, and the library holds ~15,000 files across far fewer folders, so
-    // calling it per file re-created directories ~11,500 times for nothing:
-    // ~0.2s of the unpack, measured. Only successful calls are recorded, so a
-    // failure that later clears is retried rather than remembered as done.
+    // there, and the library holds far more files than folders, so calling it
+    // per file spent most calls re-creating directories that existed. Only
+    // successful calls are recorded, so a failure that later clears is retried
+    // rather than remembered as done.
     final createdDirs = <String>{};
-    void ensureDir(io.Directory dir) {
-      if (createdDirs.contains(dir.path)) return;
-      dir.createSync(recursive: true);
-      createdDirs.add(dir.path);
+    void ensureDir(String path) {
+      if (createdDirs.contains(path)) return;
+      io.Directory(path).createSync(recursive: true);
+      createdDirs.add(path);
     }
 
     var extracted = 0;
     var skipped = 0;
+    var dropped = 0;
     String? firstError;
 
     for (final entry in archive.files) {
-      final outPath = resolveWrappedArchivePath(
-        rootPath,
-        entry.name,
-        separator: separator,
-      );
-      if (outPath == null) continue;
-      try {
-        if (entry.isFile) {
-          final file = io.File(outPath);
-          ensureDir(file.parent);
-          // Deliberately unflushed. An fsync per file dominated this loop:
-          // 2.10ms per entry against 0.33ms without one, measured on Windows
-          // over 2,000 files. It bought nothing - the zip is re-downloadable,
-          // and an interrupted unpack already leaves a partial tree that the
-          // next run overwrites.
-          file.writeAsBytesSync(entry.readBytes()!);
-          extracted += 1;
-          onProgress?.call(extracted);
-        } else {
-          ensureDir(io.Directory(outPath));
+      final outPath = entry.name.isEmpty
+          ? null
+          : resolveWrappedArchivePath(
+              rootPath,
+              entry.name,
+              separator: separator,
+            );
+
+      if (!entry.isFile) {
+        if (outPath == null) continue;
+        try {
+          ensureDir(outPath);
+        } on io.FileSystemException {
+          // A directory that cannot be created fails the files inside it, and
+          // those are counted where they are written. Counting it here too
+          // would put one loss in the tally twice.
         }
-      } catch (e) {
+        continue;
+      }
+
+      // ZipDecoder does not throw on an entry whose local header it cannot
+      // read: it yields a nameless, empty ArchiveFile. That is a file lost to
+      // corruption, so it is a skip - not a name the check declined - and
+      // counting it is what keeps extracted + skipped + dropped equal to the
+      // number of file entries the decoder produced.
+      if (entry.name.isEmpty) {
+        skipped += 1;
+        firstError ??= '<unnamed>: the archive entry could not be read';
+        continue;
+      }
+      if (outPath == null) {
+        dropped += 1;
+        continue;
+      }
+
+      var wrote = false;
+      try {
+        final file = io.File(outPath);
+        ensureDir(file.parent.path);
+        // Deliberately unflushed. An fsync per file dominated this loop:
+        // 2.10ms per entry against 0.33ms without one, measured on Windows
+        // over 2,000 files. It bought nothing - the zip is re-downloadable,
+        // and an interrupted unpack already leaves a partial tree that the
+        // next run deletes outright.
+        file.writeAsBytesSync(entry.readBytes()!);
+        extracted += 1;
+        wrote = true;
+      } on io.FileSystemException catch (e) {
+        // Narrow on purpose. Every failure this tolerance is for is a
+        // FileSystemException; catching Object here would fold an OOM or a
+        // decoder bug into "the filesystem refused it" and keep looping.
         skipped += 1;
         firstError ??= '${entry.name}: $e';
       }
+      // Outside the try: a throwing callback is the caller's bug, and counting
+      // it as a refusal would put one entry in both totals.
+      if (wrote) onProgress?.call(extracted);
     }
 
-    return (extracted: extracted, skipped: skipped, firstError: firstError);
+    return UnpackTally(
+      extracted: extracted,
+      skipped: skipped,
+      dropped: dropped,
+      firstError: firstError,
+    );
   }
 
   static void _unpackIsolateEntry(_UnpackArgs args) {
@@ -287,40 +374,20 @@ class IrLibLocalRepo {
     try {
       final archive = ZipDecoder().decodeStream(input);
       final totalFiles = archive.files.where((f) => f.isFile).length;
-      send.send(_UnpackProgress(0, totalFiles, false));
+      send.send(_UnpackTick(0, totalFiles));
 
-      final tally = unpackArchiveTo(
+      final tally = unpackWrappedArchiveTo(
         archive,
         args.rootPath,
         separator: args.sep,
         onProgress: (extracted) {
           if (extracted % 25 == 0) {
-            send.send(_UnpackProgress(extracted, totalFiles, false));
+            send.send(_UnpackTick(extracted, totalFiles));
           }
         },
       );
 
-      // Tolerating failed entries must not extend to tolerating all of them:
-      // reporting done with nothing on disk would leave the user an empty
-      // library and no error at all. An archive carrying no files is the same
-      // outcome by a different route, so it fails the same way.
-      if (tally.extracted == 0) {
-        throw StateError(
-          totalFiles == 0
-              ? 'the archive contained no files'
-              : 'all $totalFiles entries failed, first: ${tally.firstError}',
-        );
-      }
-
-      send.send(
-        _UnpackProgress(
-          tally.extracted,
-          totalFiles,
-          true,
-          skipped: tally.skipped,
-          firstError: tally.firstError,
-        ),
-      );
+      send.send(_UnpackResult(tally, totalFiles));
     } finally {
       input.close();
     }
@@ -335,21 +402,46 @@ class _UnpackArgs {
   final SendPort sendPort;
 }
 
-class _UnpackProgress {
-  _UnpackProgress(
-    this.extracted,
-    this.totalFiles,
-    this.done, {
-    this.skipped = 0,
+/// What one unpack did with an archive's file entries. Every file entry lands
+/// in exactly one of the three counts, so `extracted + skipped + dropped` is
+/// the number the decoder produced - which is what makes a quietly lost entry
+/// impossible to hide.
+class UnpackTally {
+  const UnpackTally({
+    required this.extracted,
+    required this.skipped,
+    required this.dropped,
     this.firstError,
   });
+
+  /// Entries written to disk.
+  final int extracted;
+
+  /// Entries that resolved to a path but could not be written, plus entries the
+  /// decoder could not even name. Every one is a file the user does not get.
+  final int skipped;
+
+  /// Entries the name check declined: the wrapper folder itself, anything
+  /// beside it rather than inside it, and any `..` traversal. Every real
+  /// archive has some, so these are not a loss.
+  final int dropped;
+
+  /// The first failure, entry name included, for the log and the error message.
+  final String? firstError;
+}
+
+/// Progress while the loop runs. Deliberately carries nothing about failures:
+/// those are only meaningful once the loop has finished, and a type that held
+/// them here would invite a reader to trust a count that is always zero.
+class _UnpackTick {
+  _UnpackTick(this.extracted, this.totalFiles);
   final int extracted;
   final int totalFiles;
-  final bool done;
+}
 
-  /// Entries the filesystem refused. Carried back over the port rather than
-  /// logged where they happen, since the isolate's static state - LogService
-  /// included - is its own and never reaches the app's log.
-  final int skipped;
-  final String? firstError;
+/// The single terminal message. Its arrival is what completes the operation.
+class _UnpackResult {
+  _UnpackResult(this.tally, this.totalFiles);
+  final UnpackTally tally;
+  final int totalFiles;
 }

--- a/lib/pages/tools/infrared/local_repo.dart
+++ b/lib/pages/tools/infrared/local_repo.dart
@@ -277,6 +277,9 @@ class IrLibLocalRepo {
   /// device name like `CON` on Windows, a full disk, or a collision with
   /// something the archive itself already wrote there. Any one of those used to
   /// abort the import of the whole library.
+  ///
+  /// Consumes [archive]: each entry's decompressed bytes are released once
+  /// written, so the entries are empty when this returns.
   static UnpackTally unpackWrappedArchiveTo(
     Archive archive,
     String rootPath, {
@@ -346,6 +349,13 @@ class IrLibLocalRepo {
         // and an interrupted unpack already leaves a partial tree that the
         // next run deletes outright.
         file.writeAsBytesSync(entry.readBytes()!);
+        // readBytes caches the inflated bytes on the entry and nothing frees
+        // them, so without this the whole decompressed library is live at once
+        // - measured at ~37MB of RSS for a 30MB library, in a spawned isolate,
+        // for nothing. clear() only drops the two content references;
+        // closeSync() would close the zip's single shared handle and make
+        // every later entry read zeros.
+        entry.clear();
         extracted += 1;
         wrote = true;
       } on io.FileSystemException catch (e) {

--- a/test/ir_unpack_test.dart
+++ b/test/ir_unpack_test.dart
@@ -37,15 +37,13 @@ void main() {
     if (base.existsSync()) base.deleteSync(recursive: true);
   });
 
-  ({int extracted, int skipped, String? firstError}) unpack(
-    List<String> names, {
-    void Function(int)? onProgress,
-  }) => IrLibLocalRepo.unpackArchiveTo(
-    archiveOf(names),
-    root.path,
-    separator: sep,
-    onProgress: onProgress,
-  );
+  UnpackTally unpack(List<String> names, {void Function(int)? onProgress}) =>
+      IrLibLocalRepo.unpackWrappedArchiveTo(
+        archiveOf(names),
+        root.path,
+        separator: sep,
+        onProgress: onProgress,
+      );
 
   File under(String relative) =>
       File('${root.path}$sep${relative.replaceAll('/', sep)}');
@@ -58,7 +56,18 @@ void main() {
     File('${root.path}$sep$name').writeAsStringSync('in the way');
   }
 
-  group('unpackArchiveTo', () {
+  /// The mirror of [blockWithFile]: a directory exactly where an entry's file
+  /// must go, so the *write* throws rather than the directory creation before
+  /// it. Both halves matter - a reserved name used as a directory component
+  /// fails in createSync, the same name used as the file fails in the write,
+  /// and only this one reaches the second branch.
+  void blockWithDir(String relative) {
+    Directory(
+      '${root.path}$sep${relative.replaceAll('/', sep)}',
+    ).createSync(recursive: true);
+  }
+
+  group('unpackWrappedArchiveTo', () {
     test('writes every entry under the root', () {
       final tally = unpack(['$wrapper/Samsung/TV.ir', '$wrapper/Sony/TV.ir']);
 
@@ -125,12 +134,16 @@ void main() {
 
       expect(tally.extracted, 1);
       expect(tally.skipped, 0);
+      expect(tally.dropped, 1);
       expect(File('${base.path}${sep}evil.ir').existsSync(), isFalse);
-      expect(File('${base.parent.path}${sep}evil.ir').existsSync(), isFalse);
     });
 
     test('skips an entry sitting beside the wrapper folder', () {
-      expect(unpack(['README.md', '$wrapper/Sony/TV.ir']).extracted, 1);
+      final tally = unpack(['README.md', '$wrapper/Sony/TV.ir']);
+
+      expect(tally.extracted, 1);
+      expect(tally.dropped, 1);
+      expect(tally.skipped, 0);
     });
 
     // The directory cache records only successful creations, so every file
@@ -180,6 +193,113 @@ void main() {
       expect(Directory('${root.path}${sep}Empty').existsSync(), isTrue);
     });
 
+    // blockWithFile only ever throws from ensureDir, so without this the write
+    // branch is never exercised - and `extracted += 1` could sit above the
+    // write that throws with the whole suite still green.
+    test('skips an entry whose write itself fails', () {
+      blockWithDir('Sony/TV.ir');
+
+      final tally = unpack(['$wrapper/Sony/TV.ir', '$wrapper/Sony/Radio.ir']);
+
+      expect(tally.extracted, 1, reason: 'only Radio.ir can be written');
+      expect(tally.skipped, 1);
+      expect(tally.firstError, contains('TV.ir'));
+      expect(under('Sony/Radio.ir').existsSync(), isTrue);
+    });
+
+    test('keeps the first failure rather than the last', () {
+      blockWithFile('Alpha');
+      blockWithDir('Beta/TV.ir');
+
+      final tally = unpack([
+        '$wrapper/Alpha/TV.ir',
+        '$wrapper/Beta/TV.ir',
+        '$wrapper/Sony/TV.ir',
+      ]);
+
+      expect(tally.skipped, 2);
+      expect(tally.firstError, contains('Alpha'));
+      expect(tally.firstError, isNot(contains('Beta')));
+    });
+
+    // The reconciliation that makes a quietly lost entry impossible: a file
+    // entry that is neither written nor refused nor declined would break this.
+    test('accounts for every file entry exactly once', () {
+      blockWithFile('Blocked');
+
+      final names = [
+        '$wrapper/Blocked/a.ir',
+        '$wrapper/Sony/TV.ir',
+        '$wrapper/../../evil.ir',
+        'README.md',
+        '$wrapper/Empty/',
+      ];
+      final tally = unpack(names);
+      final fileEntries = names.where((n) => !n.endsWith('/')).length;
+
+      expect(tally.extracted + tally.skipped + tally.dropped, fileEntries);
+    });
+
+    // ZipDecoder does not throw on an entry whose local header it cannot read -
+    // it yields a nameless, empty file. That is a lost file, so it has to be a
+    // skip; counting it as dropped would report the loss as normal.
+    test('counts an entry the decoder could not name as a skip', () {
+      final archive = Archive()
+        ..add(ArchiveFile.string('', 'unreadable'))
+        ..add(ArchiveFile.string('$wrapper/Sony/TV.ir', 'ok'));
+
+      final tally = IrLibLocalRepo.unpackWrappedArchiveTo(
+        archive,
+        root.path,
+        separator: sep,
+      );
+
+      expect(tally.extracted, 1);
+      expect(tally.skipped, 1);
+      expect(tally.dropped, 0);
+      expect(tally.firstError, contains('unnamed'));
+    });
+
+    // The catch is deliberately narrow. Folding a decoder bug or an OOM into
+    // "the filesystem refused it" would keep the loop running through 15,000
+    // more entries and report the result as a partial success.
+    test('lets a failure that is not the filesystem refusing it propagate', () {
+      // symlink sets neither content field, so readBytes() returns null and
+      // the null-check operator throws - the cheapest non-Exception throwable.
+      final archive = Archive()
+        ..add(ArchiveFile.symlink('$wrapper/link.ir', '../target.ir'));
+
+      expect(
+        () => IrLibLocalRepo.unpackWrappedArchiveTo(
+          archive,
+          root.path,
+          separator: sep,
+        ),
+        throwsA(isA<TypeError>()),
+      );
+    });
+
+    // The progress call sits outside the try for this reason: inside it, a
+    // callback that threw was recorded as the filesystem refusing an entry
+    // that had in fact just been written, so one entry counted as both
+    // extracted and skipped.
+    test(
+      'does not record a written entry as refused if the callback throws',
+      () {
+        // A FileSystemException specifically: a progress callback that touches
+        // the disk can raise one, and it is the only class the entry handler
+        // would otherwise mistake for the write itself having failed.
+        expect(
+          () => unpack([
+            '$wrapper/Sony/TV.ir',
+            '$wrapper/Sony/Radio.ir',
+          ], onProgress: (_) => throw const FileSystemException('callback')),
+          throwsA(isA<FileSystemException>()),
+        );
+        expect(under('Sony/TV.ir').existsSync(), isTrue);
+      },
+    );
+
     test('reports progress once per written file', () {
       final seen = <int>[];
 
@@ -191,6 +311,73 @@ void main() {
       ], onProgress: seen.add);
 
       expect(seen, [1, 2, 3]);
+    });
+  });
+
+  group('failureFor', () {
+    UnpackTally tally({
+      int extracted = 0,
+      int skipped = 0,
+      int dropped = 0,
+      String? firstError = 'x: boom',
+    }) => UnpackTally(
+      extracted: extracted,
+      skipped: skipped,
+      dropped: dropped,
+      firstError: firstError,
+    );
+
+    test('passes a clean unpack', () {
+      expect(IrLibLocalRepo.failureFor(tally(extracted: 100), 100), isNull);
+    });
+
+    // What the per-entry tolerance exists for: a few pathological names cost
+    // the user those entries, not the library.
+    test('passes a handful of refused entries', () {
+      expect(
+        IrLibLocalRepo.failureFor(tally(extracted: 9990, skipped: 10), 10000),
+        isNull,
+      );
+    });
+
+    // The regression the tolerance could otherwise introduce. download() has
+    // already deleted the previous library, so a quiet partial result replaces
+    // a good library with a worse one and says nothing.
+    test('fails when a material share of the library is lost', () {
+      final why = IrLibLocalRepo.failureFor(
+        tally(extracted: 12000, skipped: 3000),
+        15000,
+      );
+
+      expect(why, isNotNull);
+      expect(why, contains('3000 of 15000'));
+      expect(why, contains('boom'));
+    });
+
+    test('fails when nothing was written', () {
+      expect(
+        IrLibLocalRepo.failureFor(tally(skipped: 12), 12),
+        contains('all 12 entries failed'),
+      );
+    });
+
+    // A flat archive with no wrapper folder: nothing failed, nothing resolved.
+    // Reporting "all N entries failed, first: null" would be a lie twice over.
+    test('names the wrong archive shape rather than blaming failures', () {
+      final why = IrLibLocalRepo.failureFor(
+        tally(dropped: 4, firstError: null),
+        4,
+      );
+
+      expect(why, contains('none of 4 entries resolved'));
+      expect(why, isNot(contains('null')));
+    });
+
+    test('names an empty archive', () {
+      expect(
+        IrLibLocalRepo.failureFor(tally(firstError: null), 0),
+        contains('no files'),
+      );
     });
   });
 }

--- a/test/ir_unpack_test.dart
+++ b/test/ir_unpack_test.dart
@@ -1,0 +1,196 @@
+import 'dart:io';
+
+import 'package:archive/archive_io.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qunleashed/pages/tools/infrared/local_repo.dart';
+
+/// The IRDB zip wraps its whole tree in one top-level folder, which
+/// `resolveWrappedArchivePath` strips, so every entry name here carries it.
+const String wrapper = 'Flipper-IRDB-main';
+
+final String sep = Platform.pathSeparator;
+
+Archive archiveOf(List<String> names) {
+  final archive = Archive();
+  for (final name in names) {
+    archive.add(
+      name.endsWith('/')
+          ? ArchiveFile.directory(name)
+          : ArchiveFile.string(name, 'content of $name'),
+    );
+  }
+  return archive;
+}
+
+void main() {
+  /// [root] sits inside [base] so an entry that escapes the root still lands
+  /// in a directory the test owns and can assert on.
+  late Directory base;
+  late Directory root;
+
+  setUp(() {
+    base = Directory.systemTemp.createTempSync('ir_unpack_test');
+    root = Directory('${base.path}${sep}library')..createSync();
+  });
+
+  tearDown(() {
+    if (base.existsSync()) base.deleteSync(recursive: true);
+  });
+
+  ({int extracted, int skipped, String? firstError}) unpack(
+    List<String> names, {
+    void Function(int)? onProgress,
+  }) => IrLibLocalRepo.unpackArchiveTo(
+    archiveOf(names),
+    root.path,
+    separator: sep,
+    onProgress: onProgress,
+  );
+
+  File under(String relative) =>
+      File('${root.path}$sep${relative.replaceAll('/', sep)}');
+
+  /// Puts a plain file exactly where an entry needs a directory. Creating that
+  /// directory then fails on every platform, which is the point: this is the
+  /// class of failure no name check can predict, standing in for a reserved
+  /// device name on Windows or a full disk anywhere.
+  void blockWithFile(String name) {
+    File('${root.path}$sep$name').writeAsStringSync('in the way');
+  }
+
+  group('unpackArchiveTo', () {
+    test('writes every entry under the root', () {
+      final tally = unpack(['$wrapper/Samsung/TV.ir', '$wrapper/Sony/TV.ir']);
+
+      expect(tally.extracted, 2);
+      expect(tally.skipped, 0);
+      expect(tally.firstError, isNull);
+      expect(under('Samsung/TV.ir').readAsStringSync(), contains('Samsung'));
+      expect(under('Sony/TV.ir').existsSync(), isTrue);
+    });
+
+    // The regression this guards is the whole point of the change: the loop
+    // had no per-entry handler, and the isolate ran with errorsAreFatal, so a
+    // single unwritable entry failed the import of all ~15,000.
+    test('skips an entry the filesystem refuses and keeps the rest', () {
+      blockWithFile('Blocked');
+
+      final tally = unpack([
+        '$wrapper/Blocked/TV.ir',
+        '$wrapper/Sony/TV.ir',
+        '$wrapper/Samsung/TV.ir',
+      ]);
+
+      expect(tally.extracted, 2);
+      expect(tally.skipped, 1);
+      expect(tally.firstError, contains('Blocked'));
+      expect(under('Sony/TV.ir').existsSync(), isTrue);
+      expect(under('Samsung/TV.ir').existsSync(), isTrue);
+    });
+
+    test('keeps writing after a failure that appears first', () {
+      blockWithFile('Blocked');
+
+      final tally = unpack([
+        '$wrapper/Blocked/a.ir',
+        '$wrapper/Blocked/b.ir',
+        '$wrapper/Sony/TV.ir',
+      ]);
+
+      expect(tally.skipped, 2);
+      expect(tally.extracted, 1);
+      expect(under('Sony/TV.ir').existsSync(), isTrue);
+    });
+
+    // Nothing extracted is not a partial success, and the caller turns this
+    // tally into the error that used to be raised for any failure at all.
+    test('reports nothing extracted when every entry fails', () {
+      blockWithFile('Blocked');
+
+      final tally = unpack(['$wrapper/Blocked/a.ir', '$wrapper/Blocked/b.ir']);
+
+      expect(tally.extracted, 0);
+      expect(tally.skipped, 2);
+      expect(tally.firstError, isNotNull);
+    });
+
+    test('reports nothing extracted for an archive with no entries', () {
+      expect(unpack([]).extracted, 0);
+    });
+
+    // A refused name is the containment check working, not the filesystem
+    // failing, so it must not inflate the skip count the caller logs.
+    test('refuses a traversal without counting it as a failure', () {
+      final tally = unpack(['$wrapper/../../evil.ir', '$wrapper/Sony/TV.ir']);
+
+      expect(tally.extracted, 1);
+      expect(tally.skipped, 0);
+      expect(File('${base.path}${sep}evil.ir').existsSync(), isFalse);
+      expect(File('${base.parent.path}${sep}evil.ir').existsSync(), isFalse);
+    });
+
+    test('skips an entry sitting beside the wrapper folder', () {
+      expect(unpack(['README.md', '$wrapper/Sony/TV.ir']).extracted, 1);
+    });
+
+    // The directory cache records only successful creations, so every file
+    // after the first in a folder still has to land.
+    test('writes every file in a folder the first entry created', () {
+      final names = [for (var i = 0; i < 5; i++) '$wrapper/Samsung/TV$i.ir'];
+
+      expect(unpack(names).extracted, 5);
+      for (var i = 0; i < 5; i++) {
+        expect(under('Samsung/TV$i.ir').existsSync(), isTrue);
+      }
+    });
+
+    // The cache records a directory only once createSync actually succeeded,
+    // so a failure that later clears - a lock released, space freed - is
+    // retried instead of being remembered as done. onProgress is the only hook
+    // that runs mid-loop, so it is what clears the obstruction here.
+    test('retries a directory whose creation failed earlier', () {
+      blockWithFile('Blocked');
+
+      final tally = unpack(
+        [
+          '$wrapper/Blocked/a.ir',
+          '$wrapper/Sony/TV.ir',
+          '$wrapper/Blocked/b.ir',
+        ],
+        onProgress: (_) {
+          final blocking = File('${root.path}${sep}Blocked');
+          if (blocking.existsSync()) blocking.deleteSync();
+        },
+      );
+
+      expect(tally.skipped, 1, reason: 'only the entry before the fix clears');
+      expect(tally.extracted, 2);
+      expect(under('Blocked/b.ir').existsSync(), isTrue);
+    });
+
+    test('creates a directory entry that carries no file', () {
+      final tally = unpack(['$wrapper/Empty/', '$wrapper/Sony/TV.ir']);
+
+      expect(
+        tally.extracted,
+        1,
+        reason: 'a directory is not an extracted file',
+      );
+      expect(tally.skipped, 0);
+      expect(Directory('${root.path}${sep}Empty').existsSync(), isTrue);
+    });
+
+    test('reports progress once per written file', () {
+      final seen = <int>[];
+
+      unpack([
+        '$wrapper/a.ir',
+        '$wrapper/Empty/',
+        '$wrapper/b.ir',
+        '$wrapper/c.ir',
+      ], onProgress: seen.add);
+
+      expect(seen, [1, 2, 3]);
+    });
+  });
+}


### PR DESCRIPTION
Closes #22. Closes #24.

Both issues are the same ten lines of `_unpackIsolateEntry`, so they are one change.

## One unwritable entry aborted the whole import

The loop had no per-entry handler and the isolate runs with `errorsAreFatal: true`, so a single entry the filesystem refused failed the import of the whole library. `resolveWrappedArchivePath` is the gatekeeper for hostile names, but it only defuses the punctuation class — a reserved device name like `CON` on Windows, a full disk, or a collision with something the archive itself already wrote all pass the name check and then throw at write time.

Failed entries are now skipped and counted.

## ~7x faster

Measured on Windows, AOT, 2,000 files across 400 folders, three runs:

| | |
|---|---|
| mkdir per file + `flush: true` (before) | 4207 ms |
| mkdir per file, no flush | 656 ms |
| cached mkdir, no flush (after) | 629 ms |

**6.7–7.1x**, or roughly 32s → 4.6s at library scale. The fsync is almost all of it: 2.10 ms per entry against 0.33 ms. It bought nothing — the zip is re-downloadable, and `download()` deletes the tree outright before each run. The issue estimated ~4x from a per-call measurement; end to end it is closer to 7x.

## What the review changed

Six agents reviewed the first commit. Five findings were regressions **it introduced** — it had traded a loud failure for a quiet one.

**The tolerance could hide an arbitrarily broken import.** `LogService.log` was the only signal, and `enabled` is `bool.fromEnvironment('QLOG', defaultValue: kDebugMode)` — in a shipped build it emits nothing. The guard was `extracted == 0`, so 1 of 15,000 entries landing reported success. A disk filling partway through produced a green "IRDB downloaded" toast over a library missing thousands of remotes, and since `download()` deletes the previous library first, the user ends up worse off than before the update. `failureFor` now decides: a handful of refused entries passes, losing a material share fails.

**Entries could vanish from the accounting entirely.** `ZipDecoder` doesn't throw on an entry whose local header it can't read — it yields a *nameless, empty* `ArchiveFile`. That resolved to null, took the `continue`, and counted as nothing, so a corrupt zip reported `extracted=4, skipped=0` for six files with the log line never firing. Invisible even with `QLOG` on. The tally now has three counts and every file entry lands in exactly one, so `extracted + skipped + dropped` equals what the decoder produced.

Also: narrowed `catch (e)` (it swallowed `OutOfMemoryError` and kept looping); moved `onProgress` out of the `try` (a callback raising `FileSystemException` counted an already-written entry as refused); moved the failure decision out of the isolate, which was throwing a hardcoded English `StateError` that reached the user with a `Bad state: ` prefix — and produced `"all 2 entries failed, first: null"` for any archive without a wrapper folder, which the settings dialog lets a user configure.

My own comments were also wrong: Flipper-IRDB holds **8,954 files in 3,850 folders**, not ~15,000 files, so the directory-cache figures overstated by 2x — and the 27 ms they rest on is inside run-to-run noise. The numbers are gone; the mechanism stayed.

## Testing

The loop had **no coverage** — it was private and ran inside a spawned isolate. The writing half is now a public seam and `test/ir_unpack_test.dart` covers it with 23 tests.

Forcing a write to fail portably needs care: `CON` is only reserved on Windows, so the tests put a plain file where an entry needs a directory (fails everywhere) — and its mirror, a directory where the file must go, because the first shape only ever throws from `createSync`, leaving the write branch untested. That gap let `extracted += 1` sit *above* the write with the whole suite green.

Mutation testing: **7 of 8 caught**. The survivor is `flush: true`, which by definition changes no observable behaviour — covered by the benchmark instead.

## Deliberately out of scope

`build_service.dart`, `sdk_deployer.dart` and `atp_source.dart` have the same loop shape, but adopting this helper would silently strip a path segment from non-wrapped archives and impose skip-and-continue where a half-extracted SDK should fail loudly. That is #29's territory, it needs a cross-repo change in the `dartufbt` submodule, and it has an unsettled question a bugfix has no business deciding.

## Memory, and where the time now goes

Profiling the loop at library scale (14,000 files / 3,500 folders) found one thing left worth fixing: `readBytes()` caches each entry's inflated bytes on the `ArchiveFile` and nothing frees them, so the **entire decompressed library was live at once** — ~37 MB of RSS held in a spawned isolate for nothing. One `entry.clear()` after the write takes it to ~1.5 MB, at no measurable time cost. It scales with library size rather than being a fixed per-entry tax, so it bites hardest on phones.

(`closeSync()` would have been the wrong call — it closes `_rawContent`, and every entry's `InputFileStream` shares one `RandomAccessFile` for the whole zip, so closing one entry makes every later entry read zeros.)

The same profile settles that there is nothing else here worth chasing:

| phase | share |
|---|---|
| `writeAsBytesSync` (open + write + close) | 69% |
| directory creation | 18% |
| inflate | 9% |
| `resolveWrappedArchivePath` | 2% |

87% is syscalls that cannot be avoided — swapping `writeAsBytesSync` for a manual open/write/close measures identically. **The unpack is no longer the bottleneck in this operation:** the pre-download delete of the old tree is ~1.6 s and the download itself is seconds, so they are now comparable terms.

Two structural wins were measured and deliberately left out of scope: parallelising writes across isolates (~1.7x on the loop), and unpacking to a sibling directory and renaming instead of deleting the live library up front — which would also make updates atomic, rather than destroying the working library before knowing the download succeeds. That second one is worth its own issue.