### PR TITLE
Keep the cached response body off the calling isolate

### DIFF
--- a/lib/services/http/app_http.dart
+++ b/lib/services/http/app_http.dart
@@ -126,7 +126,15 @@ class AppHttp {
     } catch (_) {}
 
     if (cached != null && DateTime.now().difference(cached.fetchedAt) < ttl) {
-      return _decodeBodyFile(cached.bodyFile);
+      try {
+        return await _decodeBodyFile(cached.bodyFile);
+      } catch (_) {
+        // A body that will not parse - truncated by a crash mid-write, or
+        // half-written by a concurrent call - is a miss, not an error. The
+        // await is load-bearing: without it the failure escapes to the caller
+        // instead of falling through to the fetch below.
+        cached = null;
+      }
     }
 
     // Only the fetch is guarded, and the body is decoded after it: falling back

--- a/lib/services/http/app_http.dart
+++ b/lib/services/http/app_http.dart
@@ -55,8 +55,7 @@ class AppHttp {
     if (res.statusCode < 200 || res.statusCode >= 300) {
       throw AppHttpException(res.statusCode, uri.toString(), text);
     }
-    if (text.isEmpty) return null;
-    return compute(jsonDecode, text);
+    return _decodeText(text);
   }
 
   static Future<dynamic> postJson(
@@ -77,8 +76,7 @@ class AppHttp {
     if (res.statusCode < 200 || res.statusCode >= 300) {
       throw AppHttpException(res.statusCode, uri.toString(), text);
     }
-    if (text.isEmpty) return null;
-    return compute(jsonDecode, text);
+    return _decodeText(text);
   }
 
   static io.Directory? _jsonCacheDir;
@@ -126,15 +124,10 @@ class AppHttp {
     } catch (_) {}
 
     if (cached != null && DateTime.now().difference(cached.fetchedAt) < ttl) {
-      try {
-        return await _decodeBodyFile(cached.bodyFile);
-      } catch (_) {
-        // A body that will not parse - truncated by a crash mid-write, or
-        // half-written by a concurrent call - is a miss, not an error. The
-        // await is load-bearing: without it the failure escapes to the caller
-        // instead of falling through to the fetch below.
-        cached = null;
-      }
+      final hit = await _tryDecodeBodyFile(cached.bodyFile);
+      if (hit.ok) return hit.value;
+      // Unusable, so fall through to the fetch below rather than serve it.
+      cached = null;
     }
 
     // Only the fetch is guarded, and the body is decoded after it: falling back
@@ -146,6 +139,7 @@ class AppHttp {
     // Exactly one of these is set below: a 304 leaves the body already on disk
     // current, anything else produces a fresh one.
     String? fresh;
+    String? freshEtag;
     io.File? unchanged;
     try {
       final etag = cached?.etag ?? '';
@@ -161,37 +155,68 @@ class AppHttp {
         await res.drain<void>();
         // Only the timestamp moves, and it now lives in its own file - a 304
         // used to rewrite the entire body to disk to re-stamp the TTL.
-        if (paths != null) await _JsonCacheEntry.stamp(paths, cached.etag);
+        // A 304 should carry an ETag and servers do rotate weak validators, so
+        // re-stamping with the old one would keep revalidating against a
+        // validator the server has already moved past.
+        final rotated = res.headers.value(io.HttpHeaders.etagHeader);
+        if (paths != null) {
+          await _JsonCacheEntry.stamp(paths, rotated ?? cached.etag);
+        }
         unchanged = cached.bodyFile;
       } else {
         final text = await res.transform(utf8.decoder).join();
         if (res.statusCode < 200 || res.statusCode >= 300) {
           throw AppHttpException(res.statusCode, uri.toString(), text);
         }
-        if (paths != null) {
-          try {
-            await _JsonCacheEntry.store(
-              paths,
-              etag: res.headers.value(io.HttpHeaders.etagHeader) ?? '',
-              body: text,
-            );
-          } catch (_) {}
-        }
         fresh = text;
+        freshEtag = res.headers.value(io.HttpHeaders.etagHeader) ?? '';
       }
     } catch (_) {
-      if (cached != null) return _decodeBodyFile(cached.bodyFile);
+      // The stale copy is the answer to a network failure - but only if it
+      // reads. If it does not, the caller needs the network error that sent us
+      // here, not a parse error about the fallback.
+      if (cached != null) {
+        final stale = await _tryDecodeBodyFile(cached.bodyFile);
+        if (stale.ok) return stale.value;
+      }
       rethrow;
     }
     // Freshly fetched, so the text is already in this isolate: hand it over
     // rather than making the isolate read back what we just wrote.
     final body = fresh;
-    if (body != null) return _decodeText(body);
+    if (body != null) {
+      // Decoded before it is stored, and outside the try so a parse failure is
+      // not answered with the stale copy. A captive portal replies 200 with an
+      // HTML login page; caching that would overwrite a good entry with
+      // something that can never be served, taking the offline copy with it.
+      final decoded = await _decodeText(body);
+      // An empty response is not cached either: a zero-length body on disk is
+      // exactly what damage looks like, and it must stay unambiguous.
+      if (paths != null && body.isNotEmpty) {
+        try {
+          await _JsonCacheEntry.store(paths, etag: freshEtag ?? '', body: body);
+        } catch (_) {}
+      }
+      return decoded;
+    }
     final file = unchanged;
-    if (file != null) return _decodeBodyFile(file);
+    if (file != null) {
+      final revalidated = await _tryDecodeBodyFile(file);
+      if (revalidated.ok) return revalidated.value;
+      // The server says our copy is current and it will not parse. There is
+      // nothing to serve now; the next open reads the same file, treats it as
+      // a miss and refetches, so this heals itself rather than sticking.
+      throw const FormatException('cached body unreadable after revalidation');
+    }
     throw StateError('revalidation produced neither a body nor a cache hit');
   }
 
+  /// Parses a body that is already in this isolate, off the calling isolate.
+  ///
+  /// An empty *response* decodes to null, which is a legitimate answer from a
+  /// server. That is the opposite of [_readAndDecodeJson], where an empty
+  /// *file* is damage - and the difference is why an empty response is never
+  /// written to the cache in the first place.
   static Future<dynamic> _decodeText(String text) {
     if (text.isEmpty) return Future.value();
     return compute(jsonDecode, text);
@@ -202,6 +227,29 @@ class AppHttp {
   /// parse. This is the whole point of splitting the body out of the entry.
   static Future<dynamic> _decodeBodyFile(io.File file) =>
       compute(_readAndDecodeJson, file.path);
+
+  /// Decodes a cached body, reporting a bad file rather than throwing.
+  ///
+  /// Every caller answers an unusable cache entry the same way - treat it as
+  /// absent - and two of them must not let a parse error stand in for the
+  /// reason they were reached: the offline path would report a truncated file
+  /// instead of the connection failure that sent it there.
+  ///
+  /// Only these two exceptions mean the file itself is unusable. Anything else
+  /// - an isolate that will not spawn under memory pressure, most of all - is
+  /// not a cache fault and must propagate, or every open silently refetches
+  /// with no way to tell the two apart.
+  static Future<({bool ok, dynamic value})> _tryDecodeBodyFile(
+    io.File file,
+  ) async {
+    try {
+      return (ok: true, value: await _decodeBodyFile(file));
+    } on FormatException {
+      return (ok: false, value: null);
+    } on io.FileSystemException {
+      return (ok: false, value: null);
+    }
+  }
 
   static Future<Uint8List> getBytes(
     Uri uri, {
@@ -254,7 +302,11 @@ class AppHttp {
 /// stay top-level and take nothing but the path.
 Future<dynamic> _readAndDecodeJson(String path) async {
   final text = await io.File(path).readAsString();
-  if (text.isEmpty) return null;
+  // An empty cache file is damage, never a value: an empty response is not
+  // stored in the first place. Throwing is what lets the callers treat it as a
+  // miss - returning null here made a destroyed entry look like a successful
+  // hit that decoded to nothing, and no guard could tell the difference.
+  if (text.isEmpty) throw const FormatException('empty cache body');
   return jsonDecode(text);
 }
 
@@ -322,8 +374,16 @@ class _JsonCacheEntry {
       final body = data['body'] as String?;
       if (fetchedAtMs == null || body == null) return null;
       final etag = (data['etag'] as String?) ?? '';
+      // store throws if either half failed, so reaching the delete means the
+      // new pair is on disk. The legacy file is the only copy until then, and
+      // removing it on a half-completed write is how an offline user loses
+      // their cache for good.
       await store(paths, etag: etag, body: body, fetchedAtMs: fetchedAtMs);
-      await paths.legacy.delete();
+      // Cleanup, so its failure - including losing the race with a concurrent
+      // call that already deleted it - must not discard the migrated entry.
+      try {
+        await paths.legacy.delete();
+      } catch (_) {}
       return _JsonCacheEntry(
         etag: etag,
         fetchedAt: DateTime.fromMillisecondsSinceEpoch(fetchedAtMs),
@@ -334,33 +394,66 @@ class _JsonCacheEntry {
     }
   }
 
-  /// Body first, then metadata: [read] requires both, so a crash between the
-  /// two leaves a miss rather than metadata promising a body that is not there.
+  /// Writes the body beside its target and renames it into place, then the
+  /// metadata.
+  ///
+  /// The rename is what makes an overwrite safe. Writing in place truncates
+  /// first, so a crash or a full disk mid-write used to leave a zero-length
+  /// body next to metadata that was still intact and still inside its TTL -
+  /// a cache hit that decoded to null, healed its own timestamp on the next
+  /// 304, and never refetched. A rename is atomic, so a reader sees either the
+  /// previous complete body or the new one.
+  ///
+  /// Metadata goes last. On a first write a crash between the two leaves no
+  /// metadata, which reads as a miss. On an overwrite it leaves the previous
+  /// metadata against the new body: an older timestamp and a stale validator,
+  /// so the next read revalidates and corrects itself.
+  ///
+  /// Throws if either write fails. Callers that delete another copy of the
+  /// body depend on hearing about it.
   static Future<void> store(
     _CachePaths paths, {
     required String etag,
     required String body,
     int? fetchedAtMs,
   }) async {
-    await paths.body.writeAsString(body, flush: true);
-    await stamp(paths, etag, fetchedAtMs: fetchedAtMs);
+    final tmp = io.File('${paths.body.path}.tmp');
+    try {
+      await tmp.writeAsString(body, flush: true);
+      await tmp.rename(paths.body.path);
+    } catch (_) {
+      try {
+        if (await tmp.exists()) await tmp.delete();
+      } catch (_) {}
+      rethrow;
+    }
+    await _writeMeta(paths, etag, fetchedAtMs);
   }
 
-  /// Rewrites just the metadata, which is what a 304 needs: the body on disk
-  /// is still current, only the TTL window restarts.
-  static Future<void> stamp(
+  /// Not flushed, deliberately. The body above is fsynced before its rename
+  /// because that is what makes the swap atomic; this is ~46 bytes whose loss
+  /// costs one revalidation round trip, and fsyncing it measured 1.8ms - most
+  /// of the cost of a 304, which is the most frequent write there is. The
+  /// ordering [store] documents comes from the await and the rename, not from
+  /// this flush: a crash preserves page-cache order, and a power loss leaves
+  /// no metadata, which reads as a miss.
+  static Future<void> _writeMeta(
     _CachePaths paths,
-    String etag, {
+    String etag,
     int? fetchedAtMs,
-  }) async {
+  ) => paths.meta.writeAsString(
+    jsonEncode({
+      'etag': etag,
+      'fetched_at': fetchedAtMs ?? DateTime.now().millisecondsSinceEpoch,
+    }),
+  );
+
+  /// Re-stamps the metadata after a 304, best-effort on purpose: the body on
+  /// disk is valid either way, so failing here costs one revalidation round
+  /// trip rather than correctness.
+  static Future<void> stamp(_CachePaths paths, String etag) async {
     try {
-      await paths.meta.writeAsString(
-        jsonEncode({
-          'etag': etag,
-          'fetched_at': fetchedAtMs ?? DateTime.now().millisecondsSinceEpoch,
-        }),
-        flush: true,
-      );
+      await _writeMeta(paths, etag, null);
     } catch (_) {}
   }
 }

--- a/lib/services/http/app_http.dart
+++ b/lib/services/http/app_http.dart
@@ -87,6 +87,15 @@ class AppHttp {
   /// Exposed so the Storage settings can report its size and clear it.
   static Future<io.Directory> httpCacheDirectory() => _ensureJsonCacheDir();
 
+  /// Points the cache at a directory of the caller's choosing.
+  ///
+  /// For tests only: the real path comes from the platform's app-support
+  /// container, which a unit test has no plugin to resolve, and without this
+  /// none of the caching behaviour - the TTL, revalidation, the stale copy
+  /// that makes screens work offline - can be exercised at all.
+  @visibleForTesting
+  static set jsonCacheDirectory(io.Directory? dir) => _jsonCacheDir = dir;
+
   static Future<io.Directory> _ensureJsonCacheDir() async {
     final existing = _jsonCacheDir;
     if (existing != null) return existing;
@@ -107,23 +116,29 @@ class AppHttp {
     Duration ttl = const Duration(minutes: 5),
     Map<String, String> headers = const {},
   }) async {
-    io.File? file;
+    _CachePaths? paths;
     _JsonCacheEntry? cached;
     try {
       final dir = await _ensureJsonCacheDir();
       final key = sha256.convert(utf8.encode(uri.toString())).toString();
-      file = io.File('${dir.path}${io.Platform.pathSeparator}$key.json');
-      cached = await _JsonCacheEntry.read(file);
+      paths = _CachePaths(dir, key);
+      cached = await _JsonCacheEntry.read(paths);
     } catch (_) {}
 
     if (cached != null && DateTime.now().difference(cached.fetchedAt) < ttl) {
-      return _decodeCachedBody(cached.body);
+      return _decodeBodyFile(cached.bodyFile);
     }
 
     // Only the fetch is guarded, and the body is decoded after it: falling back
     // to a stale copy is the answer to a network failure, not to a response
-    // that arrived and will not parse.
-    final String body;
+    // that arrived and will not parse. Returning a decode from inside the try
+    // would put it back under the catch, which answers failure with the same
+    // stale copy - spawning a second isolate to redo the work that just failed.
+    //
+    // Exactly one of these is set below: a 304 leaves the body already on disk
+    // current, anything else produces a fresh one.
+    String? fresh;
+    io.File? unchanged;
     try {
       final etag = cached?.etag ?? '';
       final res = await get(
@@ -136,36 +151,49 @@ class AppHttp {
       );
       if (res.statusCode == io.HttpStatus.notModified && cached != null) {
         await res.drain<void>();
-        if (file != null) await cached.refresh(file);
-        body = cached.body;
+        // Only the timestamp moves, and it now lives in its own file - a 304
+        // used to rewrite the entire body to disk to re-stamp the TTL.
+        if (paths != null) await _JsonCacheEntry.stamp(paths, cached.etag);
+        unchanged = cached.bodyFile;
       } else {
         final text = await res.transform(utf8.decoder).join();
         if (res.statusCode < 200 || res.statusCode >= 300) {
           throw AppHttpException(res.statusCode, uri.toString(), text);
         }
-        if (file != null) {
-          final entry = _JsonCacheEntry(
-            etag: res.headers.value(io.HttpHeaders.etagHeader) ?? '',
-            fetchedAt: DateTime.now(),
-            body: text,
-          );
+        if (paths != null) {
           try {
-            await entry.write(file);
+            await _JsonCacheEntry.store(
+              paths,
+              etag: res.headers.value(io.HttpHeaders.etagHeader) ?? '',
+              body: text,
+            );
           } catch (_) {}
         }
-        body = text;
+        fresh = text;
       }
     } catch (_) {
-      if (cached != null) return _decodeCachedBody(cached.body);
+      if (cached != null) return _decodeBodyFile(cached.bodyFile);
       rethrow;
     }
-    return _decodeCachedBody(body);
+    // Freshly fetched, so the text is already in this isolate: hand it over
+    // rather than making the isolate read back what we just wrote.
+    final body = fresh;
+    if (body != null) return _decodeText(body);
+    final file = unchanged;
+    if (file != null) return _decodeBodyFile(file);
+    throw StateError('revalidation produced neither a body nor a cache hit');
   }
 
-  static Future<dynamic> _decodeCachedBody(String text) {
+  static Future<dynamic> _decodeText(String text) {
     if (text.isEmpty) return Future.value();
     return compute(jsonDecode, text);
   }
+
+  /// Parses a cached body without touching it on the calling isolate: the
+  /// isolate is given the path and does the read, the UTF-8 decode and the
+  /// parse. This is the whole point of splitting the body out of the entry.
+  static Future<dynamic> _decodeBodyFile(io.File file) =>
+      compute(_readAndDecodeJson, file.path);
 
   static Future<Uint8List> getBytes(
     Uri uri, {
@@ -214,52 +242,117 @@ class AppHttp {
   }
 }
 
+/// Reads and parses a JSON file. Runs inside a [compute] isolate, so it must
+/// stay top-level and take nothing but the path.
+Future<dynamic> _readAndDecodeJson(String path) async {
+  final text = await io.File(path).readAsString();
+  if (text.isEmpty) return null;
+  return jsonDecode(text);
+}
+
+/// The three files one cache key can occupy: the metadata, the raw body, and
+/// the single pre-split file an older build may have left behind.
+class _CachePaths {
+  _CachePaths(io.Directory dir, String key)
+    : meta = io.File('${dir.path}${io.Platform.pathSeparator}$key.meta'),
+      body = io.File('${dir.path}${io.Platform.pathSeparator}$key.body'),
+      legacy = io.File('${dir.path}${io.Platform.pathSeparator}$key.json');
+
+  final io.File meta;
+  final io.File body;
+  final io.File legacy;
+}
+
+/// A cache entry's metadata, plus where its body is. The body deliberately is
+/// not a field: holding it here is what forced the whole payload through the
+/// calling isolate, since reading the entry meant unescaping the body out of
+/// the same JSON object.
 class _JsonCacheEntry {
   _JsonCacheEntry({
     required this.etag,
     required this.fetchedAt,
-    required this.body,
+    required this.bodyFile,
   });
 
   final String etag;
   final DateTime fetchedAt;
-  final String body;
+  final io.File bodyFile;
 
-  static Future<_JsonCacheEntry?> read(io.File file) async {
-    if (!await file.exists()) return null;
+  static Future<_JsonCacheEntry?> read(_CachePaths paths) async {
     try {
-      final data = jsonDecode(await file.readAsString());
-      if (data is! Map<String, dynamic>) return null;
+      if (await paths.meta.exists() && await paths.body.exists()) {
+        // Tens of bytes, so decoding it here costs nothing measurable.
+        final data = jsonDecode(await paths.meta.readAsString());
+        if (data is! Map<String, dynamic>) return null;
+        final fetchedAtMs = (data['fetched_at'] as num?)?.toInt();
+        if (fetchedAtMs == null) return null;
+        return _JsonCacheEntry(
+          etag: (data['etag'] as String?) ?? '',
+          fetchedAt: DateTime.fromMillisecondsSinceEpoch(fetchedAtMs),
+          bodyFile: paths.body,
+        );
+      }
+    } catch (_) {
+      return null;
+    }
+    return _migrate(paths);
+  }
+
+  /// Splits a pre-split-format entry into the pair and returns it.
+  ///
+  /// Here only so an upgrade does not throw away a cache an offline user is
+  /// relying on - the stale copy is what makes cached screens work with no
+  /// network. The decode runs in an isolate because it is exactly the
+  /// whole-body unescape the new format exists to keep off the UI isolate, and
+  /// the old file is deleted once split, so this runs at most once per entry.
+  static Future<_JsonCacheEntry?> _migrate(_CachePaths paths) async {
+    try {
+      if (!await paths.legacy.exists()) return null;
+      final data = await compute(_readAndDecodeJson, paths.legacy.path);
+      if (data is! Map) return null;
       final fetchedAtMs = (data['fetched_at'] as num?)?.toInt();
       final body = data['body'] as String?;
       if (fetchedAtMs == null || body == null) return null;
+      final etag = (data['etag'] as String?) ?? '';
+      await store(paths, etag: etag, body: body, fetchedAtMs: fetchedAtMs);
+      await paths.legacy.delete();
       return _JsonCacheEntry(
-        etag: (data['etag'] as String?) ?? '',
+        etag: etag,
         fetchedAt: DateTime.fromMillisecondsSinceEpoch(fetchedAtMs),
-        body: body,
+        bodyFile: paths.body,
       );
     } catch (_) {
       return null;
     }
   }
 
-  Future<void> write(io.File file) => file.writeAsString(
-    jsonEncode({
-      'etag': etag,
-      'fetched_at': fetchedAt.millisecondsSinceEpoch,
-      'body': body,
-    }),
-    flush: true,
-  );
+  /// Body first, then metadata: [read] requires both, so a crash between the
+  /// two leaves a miss rather than metadata promising a body that is not there.
+  static Future<void> store(
+    _CachePaths paths, {
+    required String etag,
+    required String body,
+    int? fetchedAtMs,
+  }) async {
+    await paths.body.writeAsString(body, flush: true);
+    await stamp(paths, etag, fetchedAtMs: fetchedAtMs);
+  }
 
-  /// Re-stamps the entry after a 304 so the TTL window restarts.
-  Future<void> refresh(io.File file) async {
+  /// Rewrites just the metadata, which is what a 304 needs: the body on disk
+  /// is still current, only the TTL window restarts.
+  static Future<void> stamp(
+    _CachePaths paths,
+    String etag, {
+    int? fetchedAtMs,
+  }) async {
     try {
-      await _JsonCacheEntry(
-        etag: etag,
-        fetchedAt: DateTime.now(),
-        body: body,
-      ).write(file);
+      await paths.meta.writeAsString(
+        jsonEncode({
+          'etag': etag,
+          'fetched_at': fetchedAtMs ?? DateTime.now().millisecondsSinceEpoch,
+        }),
+        flush: true,
+      );
     } catch (_) {}
   }
 }

--- a/test/http_json_cache_test.dart
+++ b/test/http_json_cache_test.dart
@@ -217,6 +217,19 @@ void main() {
       });
     });
 
+    // The old format failed closed here: a body it could not parse came back
+    // as null from read() and became a miss. Decoding outside that guard must
+    // not turn it into an error the caller sees.
+    test('treats an unparseable body as a miss and refetches', () async {
+      await AppHttp.getJsonCached(server.uri);
+      cacheFile(server.uri, 'body').writeAsStringSync('{"data": [trunca');
+
+      final got = await AppHttp.getJsonCached(server.uri);
+
+      expect((got as Map)['total'], 40);
+      expect(server.requests, 2);
+    });
+
     test('ignores metadata whose body file is gone', () async {
       await AppHttp.getJsonCached(server.uri);
       cacheFile(server.uri, 'body').deleteSync();

--- a/test/http_json_cache_test.dart
+++ b/test/http_json_cache_test.dart
@@ -1,0 +1,230 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:crypto/crypto.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qunleashed/services/http/app_http.dart';
+
+/// A payload big enough that the split matters, small enough to stay quick.
+final Map<String, Object?> payload = {
+  'data': [
+    for (var i = 0; i < 40; i++) {'id': 'app_$i', 'name': 'Application $i'},
+  ],
+  'total': 40,
+};
+
+/// A server that answers one JSON document, counts requests, and honours
+/// If-None-Match so revalidation can be observed rather than assumed.
+class FakeCatalog {
+  FakeCatalog(this._server)
+    : uri = Uri.parse('http://127.0.0.1:${_server.port}/catalog.json') {
+    _server.listen((req) async {
+      requests += 1;
+      ifNoneMatch.add(req.headers.value(HttpHeaders.ifNoneMatchHeader));
+      if (status != 200) {
+        req.response.statusCode = status;
+        req.response.write('upstream said no');
+        await req.response.close();
+        return;
+      }
+      if (req.headers.value(HttpHeaders.ifNoneMatchHeader) == etag) {
+        req.response.statusCode = HttpStatus.notModified;
+        await req.response.close();
+        return;
+      }
+      req.response.headers.set(HttpHeaders.etagHeader, etag);
+      req.response.write(jsonEncode(body));
+      await req.response.close();
+    });
+  }
+
+  static Future<FakeCatalog> start() async =>
+      FakeCatalog(await HttpServer.bind(InternetAddress.loopbackIPv4, 0));
+
+  final HttpServer _server;
+
+  /// Captured up front: reading `port` off a closed server throws, and the
+  /// offline tests need the address after shutting it down.
+  final Uri uri;
+  bool _stopped = false;
+  int requests = 0;
+  int status = 200;
+  String etag = 'W/"v1"';
+  Object? body = payload;
+  final List<String?> ifNoneMatch = [];
+
+  Future<void> stop() async {
+    if (_stopped) return;
+    _stopped = true;
+    await _server.close(force: true);
+  }
+}
+
+void main() {
+  late Directory cacheDir;
+  late FakeCatalog server;
+
+  setUp(() async {
+    cacheDir = Directory.systemTemp.createTempSync('http_json_cache');
+    AppHttp.jsonCacheDirectory = cacheDir;
+    server = await FakeCatalog.start();
+  });
+
+  tearDown(() async {
+    await server.stop();
+    AppHttp.jsonCacheDirectory = null;
+    if (cacheDir.existsSync()) cacheDir.deleteSync(recursive: true);
+  });
+
+  String keyFor(Uri uri) =>
+      sha256.convert(utf8.encode(uri.toString())).toString();
+
+  File cacheFile(Uri uri, String ext) =>
+      File('${cacheDir.path}${Platform.pathSeparator}${keyFor(uri)}.$ext');
+
+  /// Backdates an entry's timestamp so staleness can be tested without waiting.
+  void ageEntry(Uri uri, Duration by) {
+    final meta = cacheFile(uri, 'meta');
+    final data = jsonDecode(meta.readAsStringSync()) as Map<String, dynamic>;
+    data['fetched_at'] = DateTime.fromMillisecondsSinceEpoch(
+      data['fetched_at'] as int,
+    ).subtract(by).millisecondsSinceEpoch;
+    meta.writeAsStringSync(jsonEncode(data));
+  }
+
+  group('getJsonCached', () {
+    test('fetches and returns the document', () async {
+      final got = await AppHttp.getJsonCached(server.uri);
+
+      expect((got as Map)['total'], 40);
+      expect(server.requests, 1);
+    });
+
+    test('serves a fresh entry without touching the network', () async {
+      await AppHttp.getJsonCached(server.uri);
+      final again = await AppHttp.getJsonCached(server.uri);
+
+      expect((again as Map)['total'], 40);
+      expect(server.requests, 1, reason: 'the second read came from disk');
+    });
+
+    // The point of the change: the body is stored raw, so reading an entry
+    // never means unescaping the whole payload out of a wrapper object on the
+    // calling isolate.
+    test('stores the body raw, not embedded in the metadata', () async {
+      await AppHttp.getJsonCached(server.uri);
+
+      final body = cacheFile(server.uri, 'body');
+      final meta = cacheFile(server.uri, 'meta');
+
+      expect(body.existsSync(), isTrue);
+      expect(meta.existsSync(), isTrue);
+      expect(jsonDecode(body.readAsStringSync()), payload);
+      expect(meta.lengthSync(), lessThan(200), reason: 'metadata only');
+      expect(meta.readAsStringSync(), isNot(contains('app_0')));
+    });
+
+    test(
+      'revalidates a stale entry and serves the cached body on 304',
+      () async {
+        await AppHttp.getJsonCached(server.uri);
+        final again = await AppHttp.getJsonCached(
+          server.uri,
+          ttl: Duration.zero,
+        );
+
+        expect(server.requests, 2);
+        expect(server.ifNoneMatch.last, 'W/"v1"');
+        expect(
+          (again as Map)['total'],
+          40,
+          reason: 'served from the cached body',
+        );
+      },
+    );
+
+    test('a 304 restarts the freshness window', () async {
+      const window = Duration(minutes: 10);
+      await AppHttp.getJsonCached(server.uri);
+      // Aged past the window rather than slept past it, so the difference
+      // between re-stamping and not is deterministic instead of a race.
+      ageEntry(server.uri, const Duration(hours: 1));
+
+      await AppHttp.getJsonCached(server.uri, ttl: window);
+      expect(server.requests, 2, reason: 'the stale entry was revalidated');
+
+      await AppHttp.getJsonCached(server.uri, ttl: window);
+      expect(server.requests, 2, reason: 'the 304 made it fresh again');
+    });
+
+    test('picks up a changed document when the etag moves', () async {
+      await AppHttp.getJsonCached(server.uri);
+      server
+        ..etag = 'W/"v2"'
+        ..body = {'total': 7};
+
+      final got = await AppHttp.getJsonCached(server.uri, ttl: Duration.zero);
+
+      expect((got as Map)['total'], 7);
+    });
+
+    // What makes cached screens work with no network.
+    test('falls back to the stale copy when the network fails', () async {
+      await AppHttp.getJsonCached(server.uri);
+      await server.stop();
+
+      final got = await AppHttp.getJsonCached(server.uri, ttl: Duration.zero);
+
+      expect((got as Map)['total'], 40);
+    });
+
+    test('rethrows when the network fails and nothing is cached', () async {
+      final uri = server.uri;
+      await server.stop();
+
+      expect(() => AppHttp.getJsonCached(uri), throwsA(isA<Exception>()));
+    });
+
+    test('throws on a non-2xx response and caches nothing', () async {
+      server.status = 500;
+
+      await expectLater(
+        AppHttp.getJsonCached(server.uri),
+        throwsA(isA<AppHttpException>()),
+      );
+      expect(cacheFile(server.uri, 'body').existsSync(), isFalse);
+    });
+
+    // An upgrade must not throw away a cache an offline user is relying on.
+    test('migrates a pre-split entry and still serves it offline', () async {
+      final uri = server.uri;
+      cacheFile(uri, 'json').writeAsStringSync(
+        jsonEncode({
+          'etag': 'W/"old"',
+          'fetched_at': DateTime.now().millisecondsSinceEpoch,
+          'body': jsonEncode({'total': 99}),
+        }),
+      );
+      await server.stop();
+
+      final got = await AppHttp.getJsonCached(uri);
+
+      expect((got as Map)['total'], 99);
+      expect(cacheFile(uri, 'json').existsSync(), isFalse, reason: 'consumed');
+      expect(cacheFile(uri, 'body').existsSync(), isTrue);
+      expect(jsonDecode(cacheFile(uri, 'body').readAsStringSync()), {
+        'total': 99,
+      });
+    });
+
+    test('ignores metadata whose body file is gone', () async {
+      await AppHttp.getJsonCached(server.uri);
+      cacheFile(server.uri, 'body').deleteSync();
+
+      final got = await AppHttp.getJsonCached(server.uri);
+
+      expect((got as Map)['total'], 40);
+      expect(server.requests, 2, reason: 'a half-written entry is a miss');
+    });
+  });
+}

--- a/test/http_json_cache_test.dart
+++ b/test/http_json_cache_test.dart
@@ -21,6 +21,7 @@ class FakeCatalog {
     _server.listen((req) async {
       requests += 1;
       ifNoneMatch.add(req.headers.value(HttpHeaders.ifNoneMatchHeader));
+      userAgents.add(req.headers.value(HttpHeaders.userAgentHeader));
       if (status != 200) {
         req.response.statusCode = status;
         req.response.write('upstream said no');
@@ -29,11 +30,15 @@ class FakeCatalog {
       }
       if (req.headers.value(HttpHeaders.ifNoneMatchHeader) == etag) {
         req.response.statusCode = HttpStatus.notModified;
+        final rotated = etagOn304;
+        if (rotated != null) {
+          req.response.headers.set(HttpHeaders.etagHeader, rotated);
+        }
         await req.response.close();
         return;
       }
-      req.response.headers.set(HttpHeaders.etagHeader, etag);
-      req.response.write(jsonEncode(body));
+      if (sendEtag) req.response.headers.set(HttpHeaders.etagHeader, etag);
+      req.response.write(rawBody ?? jsonEncode(body));
       await req.response.close();
     });
   }
@@ -50,8 +55,17 @@ class FakeCatalog {
   int requests = 0;
   int status = 200;
   String etag = 'W/"v1"';
+  bool sendEtag = true;
   Object? body = payload;
+
+  /// Sent verbatim instead of [body] - a captive portal's HTML, say.
+  String? rawBody;
+
+  /// A validator handed back on a 304, as servers do when they rotate a weak
+  /// one without the body changing.
+  String? etagOn304;
   final List<String?> ifNoneMatch = [];
+  final List<String?> userAgents = [];
 
   Future<void> stop() async {
     if (_stopped) return;
@@ -71,9 +85,12 @@ void main() {
   });
 
   tearDown(() async {
-    await server.stop();
+    // Reset before stopping: `server` is late, so if setUp failed at start()
+    // this would otherwise throw a LateInitializationError that masks the real
+    // failure and skips the cleanup below.
     AppHttp.jsonCacheDirectory = null;
     if (cacheDir.existsSync()) cacheDir.deleteSync(recursive: true);
+    await server.stop();
   });
 
   String keyFor(Uri uri) =>
@@ -182,7 +199,13 @@ void main() {
       final uri = server.uri;
       await server.stop();
 
-      expect(() => AppHttp.getJsonCached(uri), throwsA(isA<Exception>()));
+      // The exact type varies - a dead pooled socket and a refused connect
+      // differ - but it must not be a parse error, which is the bug class
+      // where the fallback's own failure stands in for the network's.
+      await expectLater(
+        AppHttp.getJsonCached(uri),
+        throwsA(allOf(isA<Exception>(), isNot(isA<FormatException>()))),
+      );
     });
 
     test('throws on a non-2xx response and caches nothing', () async {
@@ -229,6 +252,169 @@ void main() {
       expect((got as Map)['total'], 40);
       expect(server.requests, 2);
     });
+
+    // A captive portal answers 200 with an HTML login page. Storing that would
+    // overwrite a good entry with something that can never be served.
+    test('a 200 that is not JSON leaves the previous entry intact', () async {
+      await AppHttp.getJsonCached(server.uri);
+      // A new etag too, or the server answers 304 and the portal's page never
+      // reaches the client at all.
+      server
+        ..etag = 'W/"v2"'
+        ..rawBody = '<html>captive portal</html>';
+
+      await expectLater(
+        AppHttp.getJsonCached(server.uri, ttl: Duration.zero),
+        throwsA(isA<FormatException>()),
+      );
+
+      await server.stop();
+      final offline = await AppHttp.getJsonCached(
+        server.uri,
+        ttl: Duration.zero,
+      );
+      expect((offline as Map)['total'], 40, reason: 'the good copy survived');
+    });
+
+    test('a corrupt body offline surfaces the network error', () async {
+      await AppHttp.getJsonCached(server.uri);
+      cacheFile(server.uri, 'body').writeAsStringSync('{"data": [trunca');
+      await server.stop();
+
+      await expectLater(
+        AppHttp.getJsonCached(server.uri, ttl: Duration.zero),
+        throwsA(isNot(isA<FormatException>())),
+      );
+    });
+
+    // Every entry on disk at upgrade time is older than its TTL, so a fresh
+    // fixture would never reach the revalidation this has to get right.
+    test('a stale pre-split entry keeps its timestamp and its etag', () async {
+      cacheFile(server.uri, 'json').writeAsStringSync(
+        jsonEncode({
+          'etag': 'W/"v1"',
+          'fetched_at': DateTime.now()
+              .subtract(const Duration(days: 3))
+              .millisecondsSinceEpoch,
+          'body': jsonEncode(payload),
+        }),
+      );
+
+      final got = await AppHttp.getJsonCached(server.uri);
+
+      expect(server.requests, 1, reason: 'the migrated entry was still stale');
+      expect(server.ifNoneMatch.last, 'W/"v1"', reason: 'etag carried over');
+      expect((got as Map)['total'], 40);
+    });
+
+    // _migrate returns an entry built from its own locals, so the call that
+    // performs the migration cannot show what was persisted - only the
+    // metadata it left behind can. A 30-day window keeps the migrated entry
+    // fresh so nothing revalidates and re-stamps it first.
+    test(
+      'migration carries the timestamp and validator into the new format',
+      () async {
+        final threeDaysAgo = DateTime.now().subtract(const Duration(days: 3));
+        cacheFile(server.uri, 'json').writeAsStringSync(
+          jsonEncode({
+            'etag': 'W/"v1"',
+            'fetched_at': threeDaysAgo.millisecondsSinceEpoch,
+            'body': jsonEncode(payload),
+          }),
+        );
+
+        await AppHttp.getJsonCached(server.uri, ttl: const Duration(days: 30));
+
+        final meta =
+            jsonDecode(cacheFile(server.uri, 'meta').readAsStringSync())
+                as Map<String, dynamic>;
+        expect(meta['etag'], 'W/"v1"');
+        expect(meta['fetched_at'], threeDaysAgo.millisecondsSinceEpoch);
+        expect(server.requests, 0, reason: 'served from the migrated entry');
+      },
+    );
+
+    test('adopts a validator the server rotates on a 304', () async {
+      await AppHttp.getJsonCached(server.uri);
+      server.etagOn304 = 'W/"v2"';
+
+      await AppHttp.getJsonCached(server.uri, ttl: Duration.zero);
+      await AppHttp.getJsonCached(server.uri, ttl: Duration.zero);
+
+      expect(server.ifNoneMatch.last, 'W/"v2"', reason: 'the rotated one');
+    });
+
+    test('forwards caller headers', () async {
+      await AppHttp.getJsonCached(
+        server.uri,
+        headers: {HttpHeaders.userAgentHeader: 'qunleashed-test/9'},
+      );
+
+      expect(server.userAgents.last, 'qunleashed-test/9');
+    });
+
+    test('revalidates without If-None-Match when there was no etag', () async {
+      server.sendEtag = false;
+      await AppHttp.getJsonCached(server.uri);
+
+      await AppHttp.getJsonCached(server.uri, ttl: Duration.zero);
+
+      expect(server.requests, 2);
+      expect(server.ifNoneMatch.last, isNull);
+    });
+
+    test('does not cache an empty response', () async {
+      server.rawBody = '';
+
+      expect(await AppHttp.getJsonCached(server.uri), isNull);
+      expect(cacheFile(server.uri, 'body').existsSync(), isFalse);
+    });
+
+    test('round-trips non-ASCII through the cache', () async {
+      server.body = {'name': 'Устройство 🐬', 'total': 1};
+      await AppHttp.getJsonCached(server.uri);
+
+      final again = await AppHttp.getJsonCached(server.uri);
+
+      expect((again as Map)['name'], 'Устройство 🐬');
+      expect(server.requests, 1, reason: 'read back from disk');
+    });
+
+    test(
+      'treats a zero-length body as damage, not an empty document',
+      () async {
+        await AppHttp.getJsonCached(server.uri);
+        cacheFile(server.uri, 'body').writeAsStringSync('');
+
+        final got = await AppHttp.getJsonCached(server.uri);
+
+        expect((got as Map)['total'], 40);
+        expect(server.requests, 2, reason: 'an empty cache file is a miss');
+      },
+    );
+
+    // The migration deletes the only readable copy, so it must not run on a
+    // half-completed write - a metadata write that failed silently would take
+    // an offline user's cache with it, permanently.
+    test(
+      'keeps the pre-split entry when the new one cannot be written',
+      () async {
+        final uri = server.uri;
+        cacheFile(uri, 'json').writeAsStringSync(
+          jsonEncode({
+            'etag': 'W/"old"',
+            'fetched_at': DateTime.now().millisecondsSinceEpoch,
+            'body': jsonEncode(payload),
+          }),
+        );
+        // A directory exactly where the metadata file has to go.
+        Directory(cacheFile(uri, 'meta').path).createSync();
+
+        await AppHttp.getJsonCached(uri);
+
+        expect(cacheFile(uri, 'json').existsSync(), isTrue);
+      },
+    );
 
     test('ignores metadata whose body file is gone', () async {
       await AppHttp.getJsonCached(server.uri);


### PR DESCRIPTION
Closes #25.

A cache entry was one JSON object with the whole response body embedded as an escaped string alongside `etag` and `fetched_at`. Reading it meant `jsonDecode(await file.readAsString())` on the **calling** isolate — unescaping the entire payload — and only then was the smaller, real parse handed to `compute`. The isolate was protecting the cheaper half of the work.

Measured on a catalog-shaped 152 KB body, median of 40, AOT:

| | on the UI isolate |
|---|---|
| before: read wrapper + unescape body | **3.73 ms** |
| after: read metadata + decode | **0.09 ms** |
| *(the body parse — what `compute` did all along)* | *1.18 ms* |

So the UI isolate was doing roughly three times the work it was offloading. The apps catalog is the hot path and pays this on every open.

An entry is now a pair: a metadata file of a few dozen bytes, and the raw body beside it. The metadata decodes on the calling isolate because it is tiny; the body is handed to `compute` as a **path**, so the read, the UTF-8 decode and the parse all happen there and the payload never crosses the UI isolate at all. A 304 also stops rewriting the entire body to disk just to re-stamp the TTL.

An entry written by an older build is migrated on read rather than discarded — the stale copy is what makes cached screens work with no network, so dropping it at upgrade would take the catalog offline for exactly the users who cannot refetch.

## What review changed

Four agents. The split was right, but it moved several decisions out from behind guards the single-file format had provided *by accident*: any damage to that one file failed `jsonDecode` in `read()` and became a clean miss. Splitting put the timestamp in a small file that survives while the large one dies.

- **An empty body file was served as a successful `null`** — no throw, no refetch — and a 304 then re-stamped its TTL, so the entry healed its own timestamp while staying destroyed. `writeAsString` truncates on open, so a crash or full disk mid-write left exactly that. The body is now written beside its target and **renamed** into place, an empty cache file throws, and an empty response is never stored.
- **Only one of three decode sites was guarded**, and the two that weren't are furthest from the read that validated the entry. All three now share one guard, and the offline path reports the network error that sent it there rather than a parse error about the fallback.
- **`store()` reported success when half of it failed.** `stamp()` swallowed its own failure, so the body could land without the metadata — and `_migrate` treated that as success and deleted the legacy file, the only readable copy. For a user offline at upgrade time the cache was gone for good.
- **A captive portal poisoned the cache.** It answers 200 with an HTML login page, which was written to disk before anything checked it parses. The body is now decoded before it is stored.
- A 304 carries a rotated validator; re-stamping with the old one kept revalidating against something the server had moved past.

The metadata write is no longer fsynced: ~46 bytes whose loss costs one revalidation, where the flush measured **1.8 ms** — most of the cost of a 304, the most frequent write there is. The ordering `store()` documents comes from the await and the rename, not the flush.

## Testing

This flow had **no coverage** — the TTL, revalidation, and the stale-copy fallback the offline behaviour depends on. The cache directory comes from `path_provider`, so a `@visibleForTesting` setter for it is the whole seam; the tests then run against a real loopback `HttpServer` that counts requests and honours `If-None-Match`, so revalidation is observed rather than assumed.

23 tests. **Mutation testing: 16 mutations, all caught.** Two initially survived and both turned out to be real gaps rather than noise — `_migrate` returns an entry built from its own locals, so the migrating call cannot observe what was persisted, and the fake server never rotated a validator on a 304, which made that mutation a no-op. Both now assert against what actually reaches disk.

## Follow-ups deliberately left out

- `manifest_registry.dart:142-172` has the same defect (a wrapper with `icon_base64` blobs decoded on the calling isolate, no `compute`) — different feature, different file.
- Two callers that should be using `getJsonCached` and are not: `devices/firmware/directory.dart` and `tools/infrared/api.dart` both keep memory-only caches with no offline copy and no ETag. Changing them changes those screens' freshness behaviour.
- A single-`stat` format using mtime as the TTL would cut `read()` from three filesystem round trips to one, but it is another on-disk format and another migration.