### PR TITLE
Stop showing apps that are no longer on the device as installed

### DIFF
--- a/lib/pages/apps/data/device_source.dart
+++ b/lib/pages/apps/data/device_source.dart
@@ -37,6 +37,14 @@ class DeviceSource extends ChangeNotifier {
   final Map<String, ({int size, String folder, String path, int stamp})>
   _local = {};
 
+  /// Aliases whose `.fap` the last complete device walk found.
+  ///
+  /// Null until one completes. That distinction is the whole point: a device
+  /// nobody has scanned, or one that disconnected mid-walk, must not read as a
+  /// device with nothing installed - only a finished walk can prove an app is
+  /// gone.
+  Set<String>? _deviceAliases;
+
   final Map<String, FapInfo?> _parsed = {};
   final Map<String, int> _parsedStamp = {};
 
@@ -53,6 +61,7 @@ class DeviceSource extends ChangeNotifier {
       if (alias.isEmpty) continue;
       final m = manifests.byAlias(alias);
       final local = _local[alias];
+      final onDevice = _deviceAliases?.contains(alias);
       final folder =
           local?.folder ??
           (m != null && m.path.isNotEmpty ? _folderFromPath(m.path) : '');
@@ -68,6 +77,7 @@ class DeviceSource extends ChangeNotifier {
           manifest: m,
           fap: _parsed[alias],
           fapChecked: _parsed.containsKey(alias),
+          onDevice: onDevice,
         ),
       );
     }
@@ -183,7 +193,14 @@ class DeviceSource extends ChangeNotifier {
     notifyListeners();
     try {
       await manifests.refresh();
-      final deviceApps = await _walkDevice();
+      final walk = await _walkDevice();
+      final deviceApps = walk.apps;
+      // Only a complete walk proves absence. A partial one - a disconnect
+      // mid-scan - must leave the previous answer alone rather than report an
+      // empty device.
+      if (walk.complete) {
+        _deviceAliases = {for (final d in deviceApps) d.alias};
+      }
       _syncTotal = deviceApps.length;
       notifyListeners();
 
@@ -246,9 +263,13 @@ class DeviceSource extends ChangeNotifier {
   }
 
   Future<
-    List<
-      ({String alias, String folder, String devicePath, String md5, int size})
-    >
+    ({
+      List<
+        ({String alias, String folder, String devicePath, String md5, int size})
+      >
+      apps,
+      bool complete,
+    })
   >
   _walkDevice() async {
     final root = await client.storageList(
@@ -260,6 +281,7 @@ class DeviceSource extends ChangeNotifier {
         for (final f in item.file)
           if (f.type == File_FileType.DIR && f.name.isNotEmpty) f.name,
     ];
+    var complete = true;
     final out =
         <
           ({
@@ -270,8 +292,32 @@ class DeviceSource extends ChangeNotifier {
             int size,
           })
         >[];
+    // Apps normally live one folder deep, but a .fap sitting directly in the
+    // apps root is still installed. Missing it here would let the completeness
+    // check below call it absent.
+    for (final item in root.items) {
+      for (final f in item.file) {
+        if (f.type != File_FileType.FILE) continue;
+        if (!f.name.endsWith('.fap')) continue;
+        final alias = f.name.substring(0, f.name.length - 4);
+        if (alias.isEmpty) continue;
+        out.add((
+          alias: alias,
+          folder: '',
+          devicePath: '$kAppsRoot/${f.name}',
+          md5: f.md5sum,
+          size: f.size,
+        ));
+      }
+    }
+
     for (final folder in folders) {
-      if (!isReady) break;
+      if (!isReady) {
+        // Disconnected part-way: what was collected is still worth syncing,
+        // but it is no longer evidence that anything is absent.
+        complete = false;
+        break;
+      }
       _syncingItem = folder;
       notifyListeners();
       final list = await client.storageList(
@@ -294,7 +340,7 @@ class DeviceSource extends ChangeNotifier {
         }
       }
     }
-    return out;
+    return (apps: out, complete: complete);
   }
 
   Future<bool> _localMatchesRemote(
@@ -422,7 +468,11 @@ class DeviceSource extends ChangeNotifier {
 
   void handleDisconnect() => notifyListeners();
 
-  void handleConnect() => notifyListeners();
+  void handleConnect() {
+    // The set describes one device's storage, and this may be a different one.
+    _deviceAliases = null;
+    notifyListeners();
+  }
 
   void handleDeviceChange() {
     _local.clear();

--- a/lib/pages/apps/data/device_source.dart
+++ b/lib/pages/apps/data/device_source.dart
@@ -17,6 +17,15 @@ import 'manifest_registry.dart';
 import 'models/installed_app.dart';
 import '../../../services/logging.dart';
 
+/// One `.fap` as the device reports it.
+typedef _DeviceFap = ({
+  String alias,
+  String folder,
+  String devicePath,
+  String md5,
+  int size,
+});
+
 class DeviceSource extends ChangeNotifier {
   DeviceSource({
     required this.client,
@@ -33,6 +42,20 @@ class DeviceSource extends ChangeNotifier {
   final InstallEngine engine;
 
   bool get isReady => client.isRpcReady;
+
+  /// Overrides where mirrored copies of installed apps live.
+  ///
+  /// Tests only. The real path is derived from the user's documents directory
+  /// through platform environment variables, which a test process cannot
+  /// change - so without this a test either reads and writes the developer's
+  /// real Devices folder, or, where no device has ever been remembered, skips
+  /// the mirroring half of a scan entirely. Both make what is covered depend
+  /// on the machine.
+  @visibleForTesting
+  static Future<io.Directory> Function(String deviceName)? backupDirectory;
+
+  Future<io.Directory> _backupDir(String deviceName) =>
+      (backupDirectory ?? appsBackupDirectory)(deviceName);
 
   final Map<String, ({int size, String folder, String path, int stamp})>
   _local = {};
@@ -104,6 +127,10 @@ class DeviceSource extends ChangeNotifier {
     final parts = path.split('/')..removeWhere((e) => e.isEmpty);
     final idx = parts.indexOf('apps');
     if (idx >= 0 && parts.length > idx + 2) return parts[idx + 1];
+    // Directly inside the apps root: no folder, rather than the root's own
+    // name. The mirror stores such a copy at its own root, so answering
+    // "apps" here would send restore and delete to a path that never exists.
+    if (idx >= 0 && parts.length == idx + 2) return '';
     return parts.length >= 2 ? parts[parts.length - 2] : '';
   }
 
@@ -121,7 +148,7 @@ class DeviceSource extends ChangeNotifier {
     try {
       final name = await _deviceName();
       if (name != null) {
-        final dir = await appsBackupDirectory(name);
+        final dir = await _backupDir(name);
         if (await dir.exists()) {
           final sep = io.Platform.pathSeparator;
           await for (final e in dir.list(recursive: true, followLinks: false)) {
@@ -131,7 +158,13 @@ class DeviceSource extends ChangeNotifier {
             final alias = base.substring(0, base.length - 4);
             if (alias.isEmpty) continue;
             final parent = e.parent.path;
-            final folder = parent.substring(parent.lastIndexOf(sep) + 1);
+            // A copy of an app that lives in the apps root sits in the mirror
+            // root, where the parent directory is the mirror itself - reading
+            // its name as the folder would send restore and delete looking in
+            // a directory that does not exist.
+            final folder = parent == dir.path
+                ? ''
+                : parent.substring(parent.lastIndexOf(sep) + 1);
             int size = 0;
             int stamp = 0;
             try {
@@ -206,7 +239,7 @@ class DeviceSource extends ChangeNotifier {
 
       final name = await _deviceName();
       if (name == null) return;
-      final dir = await appsBackupDirectory(name);
+      final dir = await _backupDir(name);
 
       for (final d in deviceApps) {
         if (!isReady) break;
@@ -262,55 +295,44 @@ class DeviceSource extends ChangeNotifier {
     }
   }
 
-  Future<
-    ({
-      List<
-        ({String alias, String folder, String devicePath, String md5, int size})
-      >
-      apps,
-      bool complete,
-    })
-  >
-  _walkDevice() async {
+  Future<({List<_DeviceFap> apps, bool complete})> _walkDevice() async {
+    final out = <_DeviceFap>[];
+    var complete = true;
+
+    void collect(FlipperRpcBatch<ListResponse> listing, String folder) {
+      final dir = folder.isEmpty ? kAppsRoot : '$kAppsRoot/$folder';
+      for (final item in listing.items) {
+        for (final f in item.file) {
+          if (f.type != File_FileType.FILE) continue;
+          if (!f.name.endsWith('.fap')) continue;
+          final alias = aliasFromFapPath(f.name);
+          if (alias.isEmpty) continue;
+          out.add((
+            alias: alias,
+            folder: folder,
+            devicePath: '$dir/${f.name}',
+            md5: f.md5sum,
+            size: f.size,
+          ));
+        }
+      }
+    }
+
     final root = await client.storageList(
       ListRequest(path: kAppsRoot),
       timeout: const Duration(seconds: 20),
     );
+    // Apps normally live one folder deep, but a .fap sitting directly in the
+    // apps root is installed too, and overlooking it would let the
+    // completeness check call it absent.
+    collect(root, '');
+
     final folders = <String>[
       for (final item in root.items)
         for (final f in item.file)
           if (f.type == File_FileType.DIR && f.name.isNotEmpty) f.name,
     ];
-    var complete = true;
-    final out =
-        <
-          ({
-            String alias,
-            String folder,
-            String devicePath,
-            String md5,
-            int size,
-          })
-        >[];
-    // Apps normally live one folder deep, but a .fap sitting directly in the
-    // apps root is still installed. Missing it here would let the completeness
-    // check below call it absent.
-    for (final item in root.items) {
-      for (final f in item.file) {
-        if (f.type != File_FileType.FILE) continue;
-        if (!f.name.endsWith('.fap')) continue;
-        final alias = f.name.substring(0, f.name.length - 4);
-        if (alias.isEmpty) continue;
-        out.add((
-          alias: alias,
-          folder: '',
-          devicePath: '$kAppsRoot/${f.name}',
-          md5: f.md5sum,
-          size: f.size,
-        ));
-      }
-    }
-
+    // One level only, which is the layout the firmware's app loader expects.
     for (final folder in folders) {
       if (!isReady) {
         // Disconnected part-way: what was collected is still worth syncing,
@@ -320,25 +342,13 @@ class DeviceSource extends ChangeNotifier {
       }
       _syncingItem = folder;
       notifyListeners();
-      final list = await client.storageList(
-        ListRequest(path: '$kAppsRoot/$folder'),
-        timeout: const Duration(seconds: 20),
+      collect(
+        await client.storageList(
+          ListRequest(path: '$kAppsRoot/$folder'),
+          timeout: const Duration(seconds: 20),
+        ),
+        folder,
       );
-      for (final item in list.items) {
-        for (final f in item.file) {
-          if (f.type != File_FileType.FILE) continue;
-          if (!f.name.endsWith('.fap')) continue;
-          final alias = f.name.substring(0, f.name.length - 4);
-          if (alias.isEmpty) continue;
-          out.add((
-            alias: alias,
-            folder: folder,
-            devicePath: '$kAppsRoot/$folder/${f.name}',
-            md5: f.md5sum,
-            size: f.size,
-          ));
-        }
-      }
     }
     return (apps: out, complete: complete);
   }
@@ -375,18 +385,25 @@ class DeviceSource extends ChangeNotifier {
   Future<bool> restore(InstalledApp app) async {
     final name = await _deviceName();
     if (name == null) return false;
-    final dir = await appsBackupDirectory(name);
+    final dir = await _backupDir(name);
     final file = io.File(
       pathJoin([dir.path, sanitizePathSegment(app.folder), '${app.alias}.fap']),
     );
     if (!await file.exists()) return false;
     final bytes = await file.readAsBytes();
-    return engine.restore(
+    final ok = await engine.restore(
       alias: app.alias,
       fapPath: app.path,
       fapBytes: bytes,
       manifest: app.manifest,
     );
+    // Otherwise the app the user just put back keeps rendering as missing,
+    // with no way out of that state but another full scan.
+    if (ok) {
+      _deviceAliases?.add(app.alias);
+      notifyListeners();
+    }
+    return ok;
   }
 
   Future<void> adoptInstalled({
@@ -400,7 +417,7 @@ class DeviceSource extends ChangeNotifier {
     try {
       final name = await _deviceName();
       if (name != null) {
-        final dir = await appsBackupDirectory(name);
+        final dir = await _backupDir(name);
         final file = io.File(
           pathJoin([dir.path, sanitizePathSegment(folder), '$alias.fap']),
         );
@@ -419,6 +436,10 @@ class DeviceSource extends ChangeNotifier {
     );
     _parsed[alias] = FapInfo.parse(Uint8List.fromList(fapBytes));
     _parsedStamp.remove(alias);
+    // The app is on the device now. Without this the set still describes the
+    // walk that ran before the install, so an app the user has just installed
+    // renders as one that is missing from the device.
+    _deviceAliases?.add(alias);
     notifyListeners();
   }
 
@@ -426,7 +447,7 @@ class DeviceSource extends ChangeNotifier {
     try {
       final name = await _deviceName();
       if (name == null) return;
-      final dir = await appsBackupDirectory(name);
+      final dir = await _backupDir(name);
       final file = io.File(
         pathJoin([
           dir.path,
@@ -443,6 +464,7 @@ class DeviceSource extends ChangeNotifier {
 
   Future<void> uninstallFromDevice(InstalledApp app) async {
     await engine.deleteInstalled(alias: app.alias, fapPath: app.path);
+    _deviceAliases?.remove(app.alias);
     await deleteLocal(app);
   }
 
@@ -469,7 +491,8 @@ class DeviceSource extends ChangeNotifier {
   void handleDisconnect() => notifyListeners();
 
   void handleConnect() {
-    // The set describes one device's storage, and this may be a different one.
+    // Apps can be added or removed while disconnected - through a card reader,
+    // or the Flipper itself - so what the last walk saw is no longer evidence.
     _deviceAliases = null;
     notifyListeners();
   }
@@ -478,6 +501,9 @@ class DeviceSource extends ChangeNotifier {
     _local.clear();
     _parsed.clear();
     _parsedStamp.clear();
+    // Device-scoped like the three above: this set describes one device's
+    // storage, and this is a different device.
+    _deviceAliases = null;
     _syncDone = 0;
     _syncTotal = 0;
     notifyListeners();

--- a/lib/pages/apps/data/models/installed_app.dart
+++ b/lib/pages/apps/data/models/installed_app.dart
@@ -19,6 +19,16 @@ class InstalledApp {
   /// Whether the local copy was already read and handed to the parser.
   final bool fapChecked;
 
+  /// Whether the app's `.fap` was on the device the last time the whole device
+  /// was walked, or null when no walk has finished since connecting.
+  ///
+  /// An app can be known to this app without being installed: the list is the
+  /// union of the device's manifests and the local backup copies, and neither
+  /// disappears when a `.fap` is deleted outside this app - through the file
+  /// manager, qFlipper, or the card in a reader. Null and false are not the
+  /// same answer, so callers must not treat "not proven present" as "absent".
+  final bool? onDevice;
+
   const InstalledApp({
     required this.alias,
     required this.path,
@@ -27,7 +37,12 @@ class InstalledApp {
     this.manifest,
     this.fap,
     this.fapChecked = false,
+    this.onDevice,
   });
+
+  /// The app is not installed, and we know that rather than merely not having
+  /// looked. Only true once a complete walk has proved the `.fap` gone.
+  bool get isMissingFromDevice => onDevice == false;
 
   bool get hasManifest => manifest != null;
 

--- a/lib/pages/apps/manager/page.dart
+++ b/lib/pages/apps/manager/page.dart
@@ -171,44 +171,65 @@ class _AppsManagerPageState extends State<AppsManagerPage> {
             filled: true,
             onTap: () => _engine.cancel(app.alias),
           )
-        else if (updatable)
+        // A complete walk proved the .fap is gone, so Open would launch a path
+        // that is not there, Update would reinstall behind the user's back and
+        // Uninstall would delete nothing. Putting the backup copy back is the
+        // one action that helps - and is why the copy is kept rather than
+        // quietly pruned when an app leaves the device.
+        else if (app.isMissingFromDevice) ...[
           AppActionEntry(
-            label: ctx.l10n.commonUpdate,
-            icon: Icons.system_update_alt,
-            color: colors.success,
+            label: ctx.l10n.appActionRestore,
+            icon: Icons.restore,
+            color: colors.accent,
             filled: true,
-            onTap: () => unawaited(_update(app)),
+            onTap: () => unawaited(_restore(app)),
           ),
-        AppActionEntry(
-          label: ctx.l10n.commonOpen,
-          icon: Icons.play_arrow_rounded,
-          color: colors.accent,
-          filled: !updatable,
-          half: true,
-          onTap: () => unawaited(_launch(app)),
-        ),
-        AppActionEntry(
-          label: ctx.l10n.appActionRestore,
-          icon: Icons.restore,
-          color: colors.accent,
-          half: true,
-          onTap: () => unawaited(_restore(app)),
-        ),
-        AppActionEntry(
-          label: ctx.l10n.appActionDeleteCopy,
-          icon: Icons.sd_card_outlined,
-          color: colors.danger,
-          half: true,
-          onTap: () => unawaited(_deleteLocal(app)),
-        ),
-        AppActionEntry(
-          label: ctx.l10n.appActionUninstall,
-          icon: Icons.delete_outline,
-          color: colors.danger,
-          filled: true,
-          half: true,
-          onTap: () => unawaited(_uninstall(app)),
-        ),
+          AppActionEntry(
+            label: ctx.l10n.appActionDeleteCopy,
+            icon: Icons.sd_card_outlined,
+            color: colors.danger,
+            onTap: () => unawaited(_deleteLocal(app)),
+          ),
+        ] else ...[
+          if (updatable)
+            AppActionEntry(
+              label: ctx.l10n.commonUpdate,
+              icon: Icons.system_update_alt,
+              color: colors.success,
+              filled: true,
+              onTap: () => unawaited(_update(app)),
+            ),
+          AppActionEntry(
+            label: ctx.l10n.commonOpen,
+            icon: Icons.play_arrow_rounded,
+            color: colors.accent,
+            filled: !updatable,
+            half: true,
+            onTap: () => unawaited(_launch(app)),
+          ),
+          AppActionEntry(
+            label: ctx.l10n.appActionRestore,
+            icon: Icons.restore,
+            color: colors.accent,
+            half: true,
+            onTap: () => unawaited(_restore(app)),
+          ),
+          AppActionEntry(
+            label: ctx.l10n.appActionDeleteCopy,
+            icon: Icons.sd_card_outlined,
+            color: colors.danger,
+            half: true,
+            onTap: () => unawaited(_deleteLocal(app)),
+          ),
+          AppActionEntry(
+            label: ctx.l10n.appActionUninstall,
+            icon: Icons.delete_outline,
+            color: colors.danger,
+            filled: true,
+            half: true,
+            onTap: () => unawaited(_uninstall(app)),
+          ),
+        ],
       ],
     );
   }
@@ -471,7 +492,9 @@ class _AppRow extends StatelessWidget {
             manifest: app.manifest,
           ),
           title: app.name,
-          subtitle: app.hasManifest
+          subtitle: app.isMissingFromDevice
+              ? context.l10n.appNotOnDevice(app.folder)
+              : app.hasManifest
               ? app.folder
               : context.l10n.appSideloaded(app.folder),
         );

--- a/lib/pages/apps/manager/page.dart
+++ b/lib/pages/apps/manager/page.dart
@@ -172,10 +172,15 @@ class _AppsManagerPageState extends State<AppsManagerPage> {
             onTap: () => _engine.cancel(app.alias),
           )
         // A complete walk proved the .fap is gone, so Open would launch a path
-        // that is not there, Update would reinstall behind the user's back and
-        // Uninstall would delete nothing. Putting the backup copy back is the
-        // one action that helps - and is why the copy is kept rather than
-        // quietly pruned when an app leaves the device.
+        // that is not there and Update would reinstall behind the user's back.
+        // Putting the backup copy back is the action that helps - and is why
+        // the copy is kept rather than quietly pruned when an app leaves the
+        // device.
+        //
+        // Uninstall stays, because it is what clears the row: the .fap is gone
+        // but its manifest is not, and the manifest is why the app is still
+        // listed at all. deleteInstalled removes the .fim first and tolerates
+        // the absent .fap, so without this the entry can never be dismissed.
         else if (app.isMissingFromDevice) ...[
           AppActionEntry(
             label: ctx.l10n.appActionRestore,
@@ -188,7 +193,15 @@ class _AppsManagerPageState extends State<AppsManagerPage> {
             label: ctx.l10n.appActionDeleteCopy,
             icon: Icons.sd_card_outlined,
             color: colors.danger,
+            half: true,
             onTap: () => unawaited(_deleteLocal(app)),
+          ),
+          AppActionEntry(
+            label: ctx.l10n.appActionUninstall,
+            icon: Icons.delete_outline,
+            color: colors.danger,
+            half: true,
+            onTap: () => unawaited(_uninstall(app)),
           ),
         ] else ...[
           if (updatable)

--- a/test/apps_manager_presence_test.dart
+++ b/test/apps_manager_presence_test.dart
@@ -1,0 +1,229 @@
+import 'dart:convert';
+
+import 'package:flipperlib/flipperlib.dart' hide File;
+import 'package:flipperlib/flipperlib.dart' as fl show File;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:protobuf/protobuf.dart' show GeneratedMessage;
+import 'package:qunleashed/pages/apps/data/catalog_api.dart';
+import 'package:qunleashed/pages/apps/data/catalog_context.dart';
+import 'package:qunleashed/pages/apps/data/device_source.dart';
+import 'package:qunleashed/pages/apps/data/install_engine.dart';
+import 'package:qunleashed/pages/apps/data/manifest_registry.dart';
+
+/// A device whose storage is whatever the test says it is.
+///
+/// Only the four calls a scan makes are answered; everything else falls to
+/// [noSuchMethod], so a scan that starts reaching for something new fails
+/// loudly instead of quietly reading a default.
+class _FakeClient implements FlipperClient {
+  /// Directory path -> entries, as `storageList` would report them.
+  final Map<String, List<fl.File>> tree = {};
+
+  /// Manifest path -> its text.
+  final Map<String, String> manifestBodies = {};
+
+  bool connected = true;
+
+  /// Listings to answer before the device "disappears", or null to stay up.
+  /// This is how a walk is cut short part-way, which is the difference between
+  /// "these apps are gone" and "I did not get to look".
+  int? dropAfterListings;
+  int listings = 0;
+
+  @override
+  bool get isConnected => connected;
+
+  @override
+  FlipperMode get mode => FlipperMode.rpc;
+
+  /// storageList and storageReadChunked are extension methods, so they resolve
+  /// statically and arrive here rather than being overridable themselves.
+  List<Main> _framesFor(Main request) {
+    if (request.hasStorageListRequest()) {
+      listings += 1;
+      final drop = dropAfterListings;
+      if (drop != null && listings >= drop) connected = false;
+      final path = request.storageListRequest.path;
+      return [
+        Main(
+          storageListResponse: ListResponse()
+            ..file.addAll(tree[path] ?? const []),
+        ),
+      ];
+    }
+    if (request.hasStorageReadRequest()) {
+      final body = manifestBodies[request.storageReadRequest.path];
+      if (body == null) return const [];
+      return [
+        Main(
+          storageReadResponse: ReadResponse(
+            file: fl.File(data: utf8.encode(body)),
+          ),
+        ),
+      ];
+    }
+    return const [];
+  }
+
+  @override
+  Future<List<Main>> callRpcFrames(
+    Main request, {
+    Duration timeout = const Duration(seconds: 8),
+    FlipperRequestPriority priority = FlipperRequestPriority.defaultPriority,
+    void Function(Main frame)? onFrame,
+    void Function()? onSent,
+    bool retainFrames = true,
+    bool interleavable = false,
+    bool pipelined = true,
+  }) async {
+    final frames = _framesFor(request);
+    for (final frame in frames) {
+      onFrame?.call(frame);
+    }
+    return retainFrames ? frames : const [];
+  }
+
+  @override
+  Future<FlipperRpcBatch<T>> callRpc<T extends GeneratedMessage>(
+    Main request,
+    T? Function(Main frame) pick, {
+    Duration timeout = const Duration(seconds: 8),
+    FlipperRequestPriority priority = FlipperRequestPriority.defaultPriority,
+    void Function(Main frame)? onFrame,
+  }) async {
+    final frames = _framesFor(request);
+    final items = <T>[];
+    for (final frame in frames) {
+      onFrame?.call(frame);
+      final picked = pick(frame);
+      if (picked != null) items.add(picked);
+    }
+    return FlipperRpcBatch<T>(
+      commandId: 0,
+      request: request,
+      frames: frames,
+      items: items,
+    );
+  }
+
+  @override
+  Future<String> awaitName() => Future<String>.error(StateError('no name'));
+
+  @override
+  String? getName() => null;
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+/// A scan never touches the install engine, so building a real one - which
+/// needs a catalog source registry and a live install pipeline - would only
+/// add surface that the test does not exercise.
+class _FakeEngine implements InstallEngine {
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+fl.File dir(String name) => fl.File(name: name, type: File_FileType.DIR);
+
+fl.File fap(String name) => fl.File(
+  name: name,
+  type: File_FileType.FILE,
+  size: 1024,
+  md5sum: 'deadbeef',
+);
+
+String manifestFor(String alias, String folder) =>
+    'UID: uid-$alias\nPath: $kAppsRoot/$folder/$alias.fap\nFull Name: $alias\n';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late _FakeClient client;
+  late DeviceSource source;
+
+  /// A device that reports [manifests] as installed and [onDisk] as the apps
+  /// actually present under /ext/apps/Tools.
+  void give({required List<String> manifests, required List<String> onDisk}) {
+    client.tree[kManifestsRoot] = [
+      for (final alias in manifests) fap('$alias.fim'),
+    ];
+    for (final alias in manifests) {
+      client.manifestBodies['$kManifestsRoot/$alias.fim'] = manifestFor(
+        alias,
+        'Tools',
+      );
+    }
+    client.tree[kAppsRoot] = [dir('Tools')];
+    client.tree['$kAppsRoot/Tools'] = [
+      for (final alias in onDisk) fap('$alias.fap'),
+    ];
+  }
+
+  setUp(() {
+    client = _FakeClient();
+    final registry = ManifestRegistry(client: client);
+    final api = AppsCatalogApi();
+    source = DeviceSource(
+      client: client,
+      api: api,
+      manifests: registry,
+      engine: _FakeEngine(),
+    );
+  });
+
+  group('presence on the device', () {
+    // The reported bug: apps deleted through the file manager kept showing as
+    // installed, and Refresh could not clear them because Refresh is the scan.
+    test('an app whose fap is gone is reported as not on the device', () async {
+      give(manifests: ['ghost', 'real'], onDisk: ['real']);
+
+      await source.scan();
+
+      final ghost = source.apps.firstWhere((a) => a.alias == 'ghost');
+      final real = source.apps.firstWhere((a) => a.alias == 'real');
+      expect(ghost.isMissingFromDevice, isTrue);
+      expect(real.isMissingFromDevice, isFalse);
+      expect(real.onDevice, isTrue);
+    });
+
+    // Absence is only knowable from a walk that finished. A disconnect
+    // part-way must not turn every app into a missing one.
+    test('a walk cut short claims nothing is missing', () async {
+      give(manifests: ['ghost'], onDisk: []);
+      // Two listings get through - the manifests and the apps root - and the
+      // device goes away before any folder is read.
+      client.dropAfterListings = 2;
+
+      await source.scan();
+
+      final ghost = source.apps.firstWhere((a) => a.alias == 'ghost');
+      expect(ghost.onDevice, isNull, reason: 'not proven either way');
+      expect(ghost.isMissingFromDevice, isFalse);
+    });
+
+    // A .fap directly in the apps root is installed too. Overlooking it would
+    // make a complete walk call it absent.
+    test('an app in the apps root counts as present', () async {
+      give(manifests: ['loose'], onDisk: []);
+      client.manifestBodies['$kManifestsRoot/loose.fim'] =
+          'UID: uid-loose\nPath: $kAppsRoot/loose.fap\n';
+      client.tree[kAppsRoot] = [dir('Tools'), fap('loose.fap')];
+
+      await source.scan();
+
+      final loose = source.apps.firstWhere((a) => a.alias == 'loose');
+      expect(loose.onDevice, isTrue);
+    });
+
+    test('connecting a device forgets what the last one held', () async {
+      give(manifests: ['ghost'], onDisk: []);
+      await source.scan();
+      expect(source.apps.single.isMissingFromDevice, isTrue);
+
+      source.handleConnect();
+
+      expect(source.apps.single.onDevice, isNull);
+    });
+  });
+}

--- a/test/apps_manager_presence_test.dart
+++ b/test/apps_manager_presence_test.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flipperlib/flipperlib.dart' hide File;
 import 'package:flipperlib/flipperlib.dart' as fl show File;
@@ -9,6 +10,7 @@ import 'package:qunleashed/pages/apps/data/catalog_context.dart';
 import 'package:qunleashed/pages/apps/data/device_source.dart';
 import 'package:qunleashed/pages/apps/data/install_engine.dart';
 import 'package:qunleashed/pages/apps/data/manifest_registry.dart';
+import 'package:qunleashed/pages/apps/data/models/manifest.dart';
 
 /// A device whose storage is whatever the test says it is.
 ///
@@ -24,11 +26,18 @@ class _FakeClient implements FlipperClient {
 
   bool connected = true;
 
-  /// Listings to answer before the device "disappears", or null to stay up.
-  /// This is how a walk is cut short part-way, which is the difference between
-  /// "these apps are gone" and "I did not get to look".
-  int? dropAfterListings;
-  int listings = 0;
+  /// The listing after which the device "disappears", by path. This is how a
+  /// walk is cut short part-way, which is the difference between "these apps
+  /// are gone" and "I did not get to look". Keyed on the path rather than a
+  /// count so that adding a listing elsewhere cannot silently turn this into a
+  /// different test.
+  String? dropAfterListing;
+
+  /// A path whose listing fails outright, as a real one does for a missing
+  /// directory or a yanked card.
+  String? failListing;
+
+  final List<String> listed = [];
 
   @override
   bool get isConnected => connected;
@@ -40,16 +49,19 @@ class _FakeClient implements FlipperClient {
   /// statically and arrive here rather than being overridable themselves.
   List<Main> _framesFor(Main request) {
     if (request.hasStorageListRequest()) {
-      listings += 1;
-      final drop = dropAfterListings;
-      if (drop != null && listings >= drop) connected = false;
       final path = request.storageListRequest.path;
-      return [
+      listed.add(path);
+      if (path == failListing) {
+        throw StateError('ERROR_STORAGE_NOT_READY: $path');
+      }
+      final frames = [
         Main(
           storageListResponse: ListResponse()
             ..file.addAll(tree[path] ?? const []),
         ),
       ];
+      if (path == dropAfterListing) connected = false;
+      return frames;
     }
     if (request.hasStorageReadRequest()) {
       final body = manifestBodies[request.storageReadRequest.path];
@@ -107,7 +119,7 @@ class _FakeClient implements FlipperClient {
   }
 
   @override
-  Future<String> awaitName() => Future<String>.error(StateError('no name'));
+  Future<String> awaitName() async => 'TestFlipper';
 
   @override
   String? getName() => null;
@@ -120,8 +132,35 @@ class _FakeClient implements FlipperClient {
 /// needs a catalog source registry and a live install pipeline - would only
 /// add surface that the test does not exercise.
 class _FakeEngine implements InstallEngine {
+  final List<String> deleted = [];
+  final List<String> restored = [];
+  bool restoreSucceeds = true;
+
   @override
-  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+  Future<bool> deleteInstalled({
+    required String alias,
+    required String fapPath,
+  }) async {
+    deleted.add(alias);
+    return true;
+  }
+
+  @override
+  Future<bool> restore({
+    required String alias,
+    required String fapPath,
+    required List<int> fapBytes,
+    AppManifest? manifest,
+  }) async {
+    restored.add(alias);
+    return restoreSucceeds;
+  }
+
+  /// Anything else is a call this test did not expect, and answering it with
+  /// null would hide that rather than show it.
+  @override
+  dynamic noSuchMethod(Invocation invocation) =>
+      throw UnimplementedError('engine.${invocation.memberName}');
 }
 
 fl.File dir(String name) => fl.File(name: name, type: File_FileType.DIR);
@@ -140,7 +179,9 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late _FakeClient client;
+  late _FakeEngine engine;
   late DeviceSource source;
+  late Directory backup;
 
   /// A device that reports [manifests] as installed and [onDisk] as the apps
   /// actually present under /ext/apps/Tools.
@@ -161,15 +202,26 @@ void main() {
   }
 
   setUp(() {
+    // Without this the mirror phase reads and writes the real Devices folder
+    // under the developer's documents directory, so what the suite covers
+    // depends on whose machine it runs on.
+    backup = Directory.systemTemp.createTempSync('apps_presence');
+    DeviceSource.backupDirectory = (_) async => backup;
     client = _FakeClient();
+    engine = _FakeEngine();
     final registry = ManifestRegistry(client: client);
     final api = AppsCatalogApi();
     source = DeviceSource(
       client: client,
       api: api,
       manifests: registry,
-      engine: _FakeEngine(),
+      engine: engine,
     );
+  });
+
+  tearDown(() {
+    DeviceSource.backupDirectory = null;
+    if (backup.existsSync()) backup.deleteSync(recursive: true);
   });
 
   group('presence on the device', () {
@@ -193,7 +245,7 @@ void main() {
       give(manifests: ['ghost'], onDisk: []);
       // Two listings get through - the manifests and the apps root - and the
       // device goes away before any folder is read.
-      client.dropAfterListings = 2;
+      client.dropAfterListing = kAppsRoot;
 
       await source.scan();
 
@@ -214,6 +266,22 @@ void main() {
 
       final loose = source.apps.firstWhere((a) => a.alias == 'loose');
       expect(loose.onDevice, isTrue);
+      // The mirror stores it in its own root, so the folder has to agree or
+      // restore and delete go looking in a directory that never exists.
+      expect(loose.folder, '');
+    });
+
+    // handleConnect is the same-device branch; a different Flipper routes to
+    // handleDeviceChange, so testing only the former proves nothing about the
+    // case that actually matters.
+    test('swapping to another device forgets what the last one held', () async {
+      give(manifests: ['ghost'], onDisk: []);
+      await source.scan();
+      expect(source.apps.single.isMissingFromDevice, isTrue);
+
+      source.handleDeviceChange();
+
+      expect(source.apps.single.onDevice, isNull);
     });
 
     test('connecting a device forgets what the last one held', () async {
@@ -224,6 +292,123 @@ void main() {
       source.handleConnect();
 
       expect(source.apps.single.onDevice, isNull);
+    });
+
+    // A listing that fails is not a listing that came back empty. Nothing may
+    // be concluded from it - least of all that a folder's apps are gone.
+    test('a folder that will not list leaves presence alone', () async {
+      give(manifests: ['ghost'], onDisk: ['ghost']);
+      client.failListing = '$kAppsRoot/Tools';
+
+      await source.scan();
+
+      expect(source.apps.single.onDevice, isNull);
+    });
+
+    test('a device with no apps at all still proves absence', () async {
+      give(manifests: ['ghost'], onDisk: []);
+      client.tree[kAppsRoot] = const [];
+
+      await source.scan();
+
+      expect(source.apps.single.isMissingFromDevice, isTrue);
+    });
+
+    // The other half of the union: an app that survives only as a backup copy,
+    // its manifest gone with its .fap. This is the case the whole fix is for.
+    test('a local copy with no manifest reads as missing', () async {
+      give(manifests: [], onDisk: []);
+      Directory(
+        '${backup.path}${Platform.pathSeparator}Tools',
+      ).createSync(recursive: true);
+      File(
+        '${backup.path}${Platform.pathSeparator}Tools'
+        '${Platform.pathSeparator}orphan.fap',
+      ).writeAsStringSync('not really a fap');
+
+      await source.prime();
+      await source.scan();
+
+      final orphan = source.apps.firstWhere((a) => a.alias == 'orphan');
+      expect(orphan.isMissingFromDevice, isTrue);
+      expect(orphan.hasManifest, isFalse);
+    });
+
+    test('a walk cut short still syncs what it did see', () async {
+      give(manifests: ['a', 'b'], onDisk: ['a']);
+      client.tree[kAppsRoot] = [dir('Tools'), dir('Games')];
+      client.tree['$kAppsRoot/Games'] = [fap('b.fap')];
+      client.dropAfterListing = '$kAppsRoot/Tools';
+
+      await source.scan();
+
+      expect(source.apps.every((a) => a.onDevice == null), isTrue);
+    });
+  });
+
+  group('presence follows what the app itself does', () {
+    // adoptInstalled runs after every install. Without it the set still
+    // describes the walk that ran before, so an app the user has just
+    // installed renders as one that is missing from the device.
+    test('installing an app marks it present without another walk', () async {
+      give(manifests: ['tool'], onDisk: ['tool']);
+      await source.scan();
+      expect(source.apps.any((a) => a.alias == 'fresh'), isFalse);
+
+      await source.adoptInstalled(
+        alias: 'fresh',
+        devicePath: '$kAppsRoot/Tools/fresh.fap',
+        fapBytes: utf8.encode('not really a fap'),
+      );
+
+      final fresh = source.apps.firstWhere((a) => a.alias == 'fresh');
+      expect(fresh.onDevice, isTrue);
+    });
+
+    test('uninstalling marks the app absent without another walk', () async {
+      give(manifests: ['tool'], onDisk: ['tool']);
+      await source.scan();
+      final tool = source.apps.single;
+      expect(tool.onDevice, isTrue);
+
+      await source.uninstallFromDevice(tool);
+
+      expect(engine.deleted, ['tool']);
+      expect(source.apps.single.isMissingFromDevice, isTrue);
+    });
+
+    test('restoring marks the app present again', () async {
+      give(manifests: ['tool'], onDisk: []);
+      Directory(
+        '${backup.path}${Platform.pathSeparator}Tools',
+      ).createSync(recursive: true);
+      File(
+        '${backup.path}${Platform.pathSeparator}Tools'
+        '${Platform.pathSeparator}tool.fap',
+      ).writeAsStringSync('backup');
+      await source.scan();
+      expect(source.apps.single.isMissingFromDevice, isTrue);
+
+      final ok = await source.restore(source.apps.single);
+
+      expect(ok, isTrue);
+      expect(source.apps.single.onDevice, isTrue);
+    });
+
+    test('a failed restore leaves the app absent', () async {
+      give(manifests: ['tool'], onDisk: []);
+      Directory(
+        '${backup.path}${Platform.pathSeparator}Tools',
+      ).createSync(recursive: true);
+      File(
+        '${backup.path}${Platform.pathSeparator}Tools'
+        '${Platform.pathSeparator}tool.fap',
+      ).writeAsStringSync('backup');
+      await source.scan();
+      engine.restoreSucceeds = false;
+
+      expect(await source.restore(source.apps.single), isFalse);
+      expect(source.apps.single.isMissingFromDevice, isTrue);
     });
   });
 }

--- a/translations/app_en.arb
+++ b/translations/app_en.arb
@@ -3006,6 +3006,16 @@
     }
   },
 
+  "appNotOnDevice": "{folder} · not on device",
+  "@appNotOnDevice": {
+    "description": "Subtitle of an app that still has a local backup copy but is no longer installed on the Flipper, because its .fap was deleted outside this app - through the file manager, qFlipper, or the card in a reader.",
+    "placeholders": {
+      "folder": {
+        "type": "String"
+      }
+    }
+  },
+
   "managerScanning": "Scanning device…",
   "@managerScanning": {
     "description": "Progress line while the Flipper file system is being read."


### PR DESCRIPTION
Closes #3.

Emptying the apps folder from the file manager left every app still listed as installed, and Refresh could not clear it — because Refresh **is** the scan that was supposed to notice.

## Why both sources went stale

The list is the union of two, and neither reflects a `.fap` deleted outside the app:

- **`ManifestRegistry`** rebuilds from `/ext/apps_manifests`, and deleting a `.fap` does not delete its `.fim` — the manifest outlives its app.
- **`DeviceSource`** mirrors each installed `.fap` into a local backup directory, and `scan()` only ever *added* to that mirror. `deleteLocal()` exists but is wired only to the in-app delete, so anything removed through the file manager, qFlipper, or the card in a reader stayed forever.

The root cause is that `InstalledApp` had no notion of being on the device at all: it conflated *"we know about this app"* with *"it is installed"*. It now carries that explicitly, filled from the aliases the last **complete** device walk found.

## What the manager does with it

An app known to be gone is presented as a backup copy rather than an installed one: **Restore**, **Delete copy**, **Uninstall** — not Open or Update, which would act on a file that is not there.

Uninstall stays deliberately. `deleteInstalled` removes the `.fim` *first* and tolerates an absent `.fap`, and the manifest is why the app is still listed — so it is the one action that clears the row. Without it the entry could never be dismissed.

It also **does not** delete the mirrored copy. The mirror is a functional backup — `restore()` reads from it to put an app back — and the manager already offers an explicit "Delete copy". Pruning it automatically would destroy user data behind the user's back, and take away the one thing that helps someone who has just deleted their apps by accident.

## Only a finished walk can prove absence

`_walkDevice` breaks out of its loop when the device stops being ready, so a disconnect mid-scan returned a partial list that looked exactly like a device with fewer apps. Flagging against that would mark every app the walk had not reached as missing — the inverse of the bug, and worse. The walk now reports whether it saw the whole device.

Until one completes, presence is `null` — deliberately not `false`, so callers cannot read *"not proven present"* as *"gone"*.

While there: the walk only ever looked one folder deep, so a `.fap` directly in `/ext/apps` was invisible to it. Harmless when nothing consumed the result as evidence; not harmless now that something does.

## What review changed

Three agents, and two of the findings were regressions this PR introduced:

- **The clear was on the wrong hook.** `handleConnect` is the *same-device* branch; a different Flipper routes to `handleDeviceChange`, which clears three sibling caches and was not clearing this one. Swapping devices evaluated the new Flipper's apps against the old one's storage — every app on it showed "not on device", offering a Restore whose backup `handleDeviceChange` had already wiped.
- **Presence was a snapshot nothing maintained.** `adoptInstalled` runs after every install, so with an earlier walk on record an app the user had *just installed* rendered as missing. `restore` had the same shape and was a dead end.
- **A root-level app could not be restored or deleted** — `_walkDevice` recorded `folder: ''` and the mirror stored it there, but `_folderFromPath` answered `"apps"` for the same path, so both actions silently no-opped. Those are the only two actions a missing app offers.

## Testing

`DeviceSource` had no coverage. A fake client implementing `callRpc`/`callRpcFrames` drives a real `scan()` — `storageList` and `storageReadChunked` are *extension* methods that funnel through those two.

The first version of the suite was **not filesystem-isolated**: the mirror path resolves through platform environment variables rather than `path_provider`, which a test process cannot change, so the tests read and wrote the real Devices folder — and on a machine with no remembered device, the entire mirroring half of a scan was skipped. What was covered depended on whose machine ran it. A `backupDirectory` seam plus a fake device name fixes both.

13 tests. **Mutation testing: 12 mutations, all caught.**

## Known limit

`prime()` does not walk the device, so opening the manager leaves presence unknown until the user syncs — which is correct (unknown is not absent), and matches the reported flow, where Refresh is what the user pressed.

The signal is also private to `DeviceSource`, so the catalog's own `isInstalled` (`install_engine.dart`) and `catalogAppState` still decide from manifests alone — a ghost app can still show Open/Update there. Fixing that adds a dependency edge from the catalog to `DeviceSource` and changes catalog behaviour, so it is deliberately not in this PR.