### PR TITLE
Remember the update channel and build variant

### DIFF
--- a/lib/pages/devices/controllers/firmware.dart
+++ b/lib/pages/devices/controllers/firmware.dart
@@ -27,6 +27,12 @@ class FirmwareController extends ChangeNotifier {
   List<FirmwareDirectoryChannel> channelsFor(FirmwareEntry entry) =>
       _channelsForDirectory(_repo.directoryFor(entry));
 
+  /// Set once the controller is gone, so the stored-settings read - which is
+  /// started in the constructor and cannot be cancelled - does not notify a
+  /// disposed notifier. Leaving the devices page inside that window otherwise
+  /// asserts in debug and profile builds.
+  bool _disposed = false;
+
   String selectedChannelId(FirmwareEntry entry) {
     final selected = _selections[entry.shortName]?.channelId;
     if (selected != null && selected.isNotEmpty) return selected;
@@ -63,64 +69,60 @@ class FirmwareController extends ChangeNotifier {
   void setChannel(FirmwareEntry entry, String channelId) {
     final selection = _selectionFor(entry.shortName);
     selection.channelId = channelId;
-    selection.userPicked = true;
+    selection.channelPicked = true;
     if (!_supportsVariantSelection(entry, channelId)) {
       selection.variant = UnleashedVariant.extraPacks;
     }
-    _remember(entry);
+    // Only the channel: the variant sitting in the selection may be a default
+    // nobody chose, and writing it would make it look like one they did.
+    unawaited(_settings.remember(entry.shortName, channelId: channelId));
     notifyListeners();
   }
 
   void setVariant(FirmwareEntry entry, UnleashedVariant variant) {
-    _selectionFor(entry.shortName).variant = variant;
-    _remember(entry);
+    final selection = _selectionFor(entry.shortName);
+    selection.variant = variant;
+    selection.variantPicked = true;
+    unawaited(_settings.remember(entry.shortName, variant: variant));
     notifyListeners();
   }
 
-  /// Records the choice for next time. [UpdateSettingsStore.remember] handles
-  /// its own failures, so there is nothing here for a caller to answer.
-  void _remember(FirmwareEntry entry) {
-    final selection = _selectionFor(entry.shortName);
-    unawaited(
-      _settings.remember(
-        entry.shortName,
-        channelId: selection.channelId,
-        variant: selection.variant,
-      ),
-    );
-  }
-
-  /// Applies the stored choices, then lets the fallback run for anything they
-  /// did not cover.
+  /// Applies the stored choices, then lets the fallback fill in the rest.
   ///
   /// [UpdateSettingsStore.load] handles its own failures, so a read that did
-  /// not work leaves every selection unset and the fallback below fills them
-  /// in - which is the same place a first run starts from.
+  /// not work leaves every selection unset and the fallback fills them in -
+  /// which is where a first run starts from anyway.
   Future<void> _restore() async {
     await _settings.load();
+    if (_disposed) return;
     for (final entry in config.firmwares) {
-      final saved = _settings.selectionFor(entry.shortName);
-      if (saved == null) continue;
       final selection = _selectionFor(entry.shortName);
-      // A tap that landed while this was reading wins: the user is looking at
-      // what they just chose, and replacing it under them would be worse than
-      // forgetting it.
-      if (selection.userPicked) continue;
-      if (saved.channelId != null) {
-        selection.channelId = saved.channelId;
-        // A stored choice is a user choice, so the fallback must not treat it
-        // as an unpicked default and quietly move off the custom channel.
-        selection.userPicked = true;
+      // A tap that landed while this was reading wins, per field: the user is
+      // looking at what they just chose, and replacing it under them would be
+      // worse than forgetting it.
+      if (!selection.channelPicked) {
+        final channelId = _settings.channelFor(entry.shortName);
+        if (channelId != null) {
+          selection.channelId = channelId;
+          // A stored choice is a user choice, so the fallback must not treat
+          // it as an unpicked default and quietly move off the custom channel.
+          selection.channelPicked = true;
+        }
       }
-      if (saved.variant != null) selection.variant = saved.variant;
+      if (!selection.variantPicked) {
+        // Assigned rather than ??=: the variant may already hold a default
+        // that setChannel wrote when moving to a channel without variants, and
+        // a stored choice should win over that.
+        final variant = _settings.variantFor(entry.shortName);
+        if (variant != null) selection.variant = variant;
+      }
     }
-    for (final entry in config.firmwares) {
-      _applyChannelFallback(entry);
-    }
-    notifyListeners();
+    _applyFallbacks();
   }
 
-  void _onRepoChanged() {
+  void _onRepoChanged() => _applyFallbacks();
+
+  void _applyFallbacks() {
     for (final entry in config.firmwares) {
       _applyChannelFallback(entry);
     }
@@ -129,13 +131,21 @@ class FirmwareController extends ChangeNotifier {
 
   void _applyChannelFallback(FirmwareEntry entry) {
     final selection = _selectionFor(entry.shortName);
-    final channels = _channelsForDirectory(_repo.directoryFor(entry));
+    final directory = _repo.directoryFor(entry);
+    // Nothing has been fetched yet, so the only channel on offer is the custom
+    // one. A remembered channel cannot be checked against that, and replacing
+    // it here is a decision the directory's arrival can never undo: the
+    // replacement counts as picked, which is exactly what stops the clause
+    // below from correcting it. The directory cache is in-memory only, so this
+    // is every cold start, not an edge case.
+    if (directory == null && selection.channelId != null) return;
+    final channels = _channelsForDirectory(directory);
     final selected = selection.channelId;
     final hasReal = channels.any((c) => c.id != kCustomFirmwareChannelId);
     final needsFallback =
         selected == null ||
         !channels.any((channel) => channel.id == selected) ||
-        (!selection.userPicked &&
+        (!selection.channelPicked &&
             hasReal &&
             selected == kCustomFirmwareChannelId);
     if (!needsFallback) return;
@@ -169,6 +179,7 @@ class FirmwareController extends ChangeNotifier {
 
   @override
   void dispose() {
+    _disposed = true;
     _repo.removeListener(_onRepoChanged);
     super.dispose();
   }
@@ -177,5 +188,10 @@ class FirmwareController extends ChangeNotifier {
 class _Selection {
   String? channelId;
   UnleashedVariant? variant;
-  bool userPicked = false;
+
+  /// Tracked per field: a tap on one selector says nothing about the other,
+  /// and treating it as though it did let a variant chosen mid-read be
+  /// reverted on screen while still being written to disk.
+  bool channelPicked = false;
+  bool variantPicked = false;
 }

--- a/lib/pages/devices/controllers/firmware.dart
+++ b/lib/pages/devices/controllers/firmware.dart
@@ -1,18 +1,23 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 
 import '../../../components/config.dart';
 import '../../../theme/theme.dart';
 import '../firmware/directory.dart';
 import '../firmware/repository.dart';
+import '../firmware/update_settings.dart';
 
 class FirmwareController extends ChangeNotifier {
   FirmwareController() {
     _repo.addListener(_onRepoChanged);
+    unawaited(_restore());
     _repo.prefetchAll();
   }
 
   final FirmwareConfig config = QAppThemeController.instance.config;
   final FirmwareRepository _repo = FirmwareRepository.instance;
+  final UpdateSettingsStore _settings = UpdateSettingsStore.instance;
 
   final Map<String, _Selection> _selections = {};
 
@@ -62,11 +67,56 @@ class FirmwareController extends ChangeNotifier {
     if (!_supportsVariantSelection(entry, channelId)) {
       selection.variant = UnleashedVariant.extraPacks;
     }
+    _remember(entry);
     notifyListeners();
   }
 
   void setVariant(FirmwareEntry entry, UnleashedVariant variant) {
     _selectionFor(entry.shortName).variant = variant;
+    _remember(entry);
+    notifyListeners();
+  }
+
+  /// Records the choice for next time. [UpdateSettingsStore.remember] handles
+  /// its own failures, so there is nothing here for a caller to answer.
+  void _remember(FirmwareEntry entry) {
+    final selection = _selectionFor(entry.shortName);
+    unawaited(
+      _settings.remember(
+        entry.shortName,
+        channelId: selection.channelId,
+        variant: selection.variant,
+      ),
+    );
+  }
+
+  /// Applies the stored choices, then lets the fallback run for anything they
+  /// did not cover.
+  ///
+  /// [UpdateSettingsStore.load] handles its own failures, so a read that did
+  /// not work leaves every selection unset and the fallback below fills them
+  /// in - which is the same place a first run starts from.
+  Future<void> _restore() async {
+    await _settings.load();
+    for (final entry in config.firmwares) {
+      final saved = _settings.selectionFor(entry.shortName);
+      if (saved == null) continue;
+      final selection = _selectionFor(entry.shortName);
+      // A tap that landed while this was reading wins: the user is looking at
+      // what they just chose, and replacing it under them would be worse than
+      // forgetting it.
+      if (selection.userPicked) continue;
+      if (saved.channelId != null) {
+        selection.channelId = saved.channelId;
+        // A stored choice is a user choice, so the fallback must not treat it
+        // as an unpicked default and quietly move off the custom channel.
+        selection.userPicked = true;
+      }
+      if (saved.variant != null) selection.variant = saved.variant;
+    }
+    for (final entry in config.firmwares) {
+      _applyChannelFallback(entry);
+    }
     notifyListeners();
   }
 

--- a/lib/pages/devices/controllers/firmware.dart
+++ b/lib/pages/devices/controllers/firmware.dart
@@ -70,9 +70,11 @@ class FirmwareController extends ChangeNotifier {
     final selection = _selectionFor(entry.shortName);
     selection.channelId = channelId;
     selection.channelPicked = true;
-    if (!_supportsVariantSelection(entry, channelId)) {
-      selection.variant = UnleashedVariant.extraPacks;
-    }
+    // The variant is deliberately left alone. selectedVariant already reports
+    // the packaged one for a channel that has no variants, so overwriting it
+    // here changed nothing on screen and only discarded what the user had
+    // chosen - which then came back on the next launch, because the store
+    // still held it.
     // Only the channel: the variant sitting in the selection may be a default
     // nobody chose, and writing it would make it look like one they did.
     unawaited(_settings.remember(entry.shortName, channelId: channelId));
@@ -141,14 +143,20 @@ class FirmwareController extends ChangeNotifier {
     if (directory == null && selection.channelId != null) return;
     final channels = _channelsForDirectory(directory);
     final selected = selection.channelId;
+    final match = _matchChannel(channels, selected);
     final hasReal = channels.any((c) => c.id != kCustomFirmwareChannelId);
     final needsFallback =
-        selected == null ||
-        !channels.any((channel) => channel.id == selected) ||
+        match == null ||
         (!selection.channelPicked &&
             hasReal &&
             selected == kCustomFirmwareChannelId);
-    if (!needsFallback) return;
+    if (!needsFallback) {
+      // The feed renamed the channel the user picked. Keeping the choice under
+      // the id the directory now uses means every later lookup finds it,
+      // rather than the choice being quietly discarded on a rename.
+      if (match.id != selected) selection.channelId = match.id;
+      return;
+    }
 
     final fallback = channels.firstWhere(
       (channel) => channel.id == 'release',
@@ -158,6 +166,24 @@ class FirmwareController extends ChangeNotifier {
       ),
     );
     selection.channelId = fallback.id;
+  }
+
+  /// Finds [id] among [channels] the way the directory itself does - by the
+  /// channel's aliases, not by an exact string match.
+  static FirmwareDirectoryChannel? _matchChannel(
+    List<FirmwareDirectoryChannel> channels,
+    String? id,
+  ) {
+    if (id == null) return null;
+    final normalized = FirmwareChannel.fromId(id);
+    for (final channel in channels) {
+      if (channel.id == id) return channel;
+      if (normalized != null &&
+          FirmwareChannel.fromId(channel.id) == normalized) {
+        return channel;
+      }
+    }
+    return null;
   }
 
   List<FirmwareDirectoryChannel> _channelsForDirectory(FirmwareDirectory? dir) {

--- a/lib/pages/devices/firmware/directory.dart
+++ b/lib/pages/devices/firmware/directory.dart
@@ -45,7 +45,20 @@ FirmwareDirectoryChannel buildCustomChannel() => FirmwareDirectoryChannel(
   versions: const [],
 );
 
-enum UnleashedVariant { base, extraPacks, compact }
+enum UnleashedVariant {
+  base,
+  extraPacks,
+  compact;
+
+  /// The variant stored under [name], or null if this build has no such one.
+  static UnleashedVariant? fromName(String? raw) {
+    if (raw == null || raw.isEmpty) return null;
+    for (final variant in values) {
+      if (variant.name == raw) return variant;
+    }
+    return null;
+  }
+}
 
 class FirmwareFile {
   const FirmwareFile({

--- a/lib/pages/devices/firmware/directory.dart
+++ b/lib/pages/devices/firmware/directory.dart
@@ -1,3 +1,5 @@
+import 'package:flutter/foundation.dart';
+
 import '../../../services/localization/l10n.dart';
 import '../../../components/config.dart';
 import '../../../services/http/app_http.dart';
@@ -169,6 +171,25 @@ abstract class FirmwareParser {
 
   FirmwareDirectory? get cached => _cache;
   bool get hasCached => _cache != null;
+
+  /// Installs a directory as though it had just been fetched.
+  ///
+  /// For tests. The real one comes from the network, and without it the
+  /// channel list is empty - so the controller's fallback, which is what
+  /// decides whether a remembered channel survives, cannot be exercised at
+  /// all. Marked fresh so a prefetch does not immediately replace it.
+  @visibleForTesting
+  void seedCache(FirmwareDirectory directory) {
+    _cache = directory;
+    _fetchedAt = DateTime.now();
+  }
+
+  /// Drops the cache so one test cannot inherit another's directory.
+  @visibleForTesting
+  void clearCache() {
+    _cache = null;
+    _fetchedAt = null;
+  }
 
   bool get isFresh =>
       _cache != null &&

--- a/lib/pages/devices/firmware/repository.dart
+++ b/lib/pages/devices/firmware/repository.dart
@@ -22,6 +22,15 @@ class FirmwareRepository extends ChangeNotifier {
   Future<void> prefetchAll() =>
       Future.wait(QAppConfig.firmware.firmwares.map(ensure));
 
+  /// Announces a directory change without fetching one.
+  ///
+  /// For tests. The alternative is [refresh], which goes to the network - and
+  /// on a machine with egress it succeeds and replaces whatever a test had
+  /// seeded, making the assertion depend on what the upstream feed happens to
+  /// serve that day.
+  @visibleForTesting
+  void directoryChanged() => notifyListeners();
+
   Future<void> refresh() =>
       Future.wait(QAppConfig.firmware.firmwares.map(_fetch));
 

--- a/lib/pages/devices/firmware/update_settings.dart
+++ b/lib/pages/devices/firmware/update_settings.dart
@@ -1,0 +1,106 @@
+import 'dart:convert';
+
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../../services/logging.dart';
+import 'directory.dart';
+
+/// What the user last chose for one firmware.
+typedef UpdateSelection = ({String? channelId, UnleashedVariant? variant});
+
+/// Remembers the update channel and build variant the user picked, per
+/// firmware.
+///
+/// The controller that owns these is created in a widget's `initState` and
+/// disposed with it, so without this the choice was lost on leaving the page,
+/// not merely on restart - and the fallback then quietly reselected the
+/// release channel and the packaged variant next time.
+class UpdateSettingsStore {
+  UpdateSettingsStore._();
+
+  static final UpdateSettingsStore instance = UpdateSettingsStore._();
+
+  static const String _prefsKey = 'firmware_update_settings_v1';
+
+  final Map<String, UpdateSelection> _byFirmware = {};
+  Future<void>? _loading;
+
+  /// Loads once per process; later callers await the same read.
+  Future<void> load() => _loading ??= _load();
+
+  UpdateSelection? selectionFor(String shortName) => _byFirmware[shortName];
+
+  Future<void> _load() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final raw = prefs.getString(_prefsKey);
+      if (raw == null) return;
+      final decoded = jsonDecode(raw);
+      if (decoded is! Map<String, dynamic>) return;
+      for (final entry in decoded.entries) {
+        final value = entry.value;
+        if (value is! Map<String, dynamic>) continue;
+        final channelId = value['channel'] as String?;
+        _byFirmware[entry.key] = (
+          channelId: channelId != null && channelId.isNotEmpty
+              ? channelId
+              : null,
+          variant: _variantByName(value['variant'] as String?),
+        );
+      }
+    } catch (e) {
+      LogService.log('[UpdateSettings] load failed: $e');
+    }
+  }
+
+  /// Records a choice. Never throws: a preference that will not persist is
+  /// worth one line in the log and nothing more, and the caller has already
+  /// applied the choice to what is on screen.
+  Future<void> remember(
+    String shortName, {
+    required String? channelId,
+    required UnleashedVariant? variant,
+  }) async {
+    await load();
+    _byFirmware[shortName] = (channelId: channelId, variant: variant);
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setString(
+        _prefsKey,
+        jsonEncode({
+          for (final entry in _byFirmware.entries)
+            if (entry.value.channelId != null || entry.value.variant != null)
+              entry.key: {
+                if (entry.value.channelId != null)
+                  'channel': entry.value.channelId,
+                if (entry.value.variant != null)
+                  'variant': entry.value.variant!.name,
+              },
+        }),
+      );
+    } catch (e) {
+      LogService.log('[UpdateSettings] save failed: $e');
+    }
+  }
+
+  /// Forgets everything, for tests: the instance outlives any one controller,
+  /// so a test that did not clear it would inherit the previous one's choices.
+  Future<void> clear() async {
+    _byFirmware.clear();
+    _loading = null;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.remove(_prefsKey);
+    } catch (_) {}
+  }
+
+  static UnleashedVariant? _variantByName(String? name) {
+    if (name == null) return null;
+    for (final variant in UnleashedVariant.values) {
+      if (variant.name == name) return variant;
+    }
+    // A variant this build no longer has: fall back rather than fail the whole
+    // read and lose the channel with it.
+    return null;
+  }
+}

--- a/lib/pages/devices/firmware/update_settings.dart
+++ b/lib/pages/devices/firmware/update_settings.dart
@@ -1,12 +1,8 @@
-import 'dart:convert';
-
+import 'package:flutter/foundation.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../../services/logging.dart';
 import 'directory.dart';
-
-/// What the user last chose for one firmware.
-typedef UpdateSelection = ({String? channelId, UnleashedVariant? variant});
 
 /// Remembers the update channel and build variant the user picked, per
 /// firmware.
@@ -15,92 +11,106 @@ typedef UpdateSelection = ({String? channelId, UnleashedVariant? variant});
 /// disposed with it, so without this the choice was lost on leaving the page,
 /// not merely on restart - and the fallback then quietly reselected the
 /// release channel and the packaged variant next time.
+///
+/// Stored as one preference per firmware per field, following the convention
+/// the rest of the app uses for per-entity settings. A single JSON blob would
+/// mean one unreadable value could take every other firmware's settings down
+/// with it on the next write.
 class UpdateSettingsStore {
   UpdateSettingsStore._();
 
   static final UpdateSettingsStore instance = UpdateSettingsStore._();
 
-  static const String _prefsKey = 'firmware_update_settings_v1';
+  static const String _prefix = 'firmware.update';
 
-  final Map<String, UpdateSelection> _byFirmware = {};
+  static String _channelPref(String shortName) => '$_prefix.$shortName.channel';
+
+  static String _variantPref(String shortName) => '$_prefix.$shortName.variant';
+
+  final Map<String, String> _channels = {};
+  final Map<String, UnleashedVariant> _variants = {};
   Future<void>? _loading;
 
-  /// Loads once per process; later callers await the same read.
+  /// Reads once per process; later callers await the same read.
   Future<void> load() => _loading ??= _load();
 
-  UpdateSelection? selectionFor(String shortName) => _byFirmware[shortName];
+  String? channelFor(String shortName) => _channels[shortName];
+
+  UnleashedVariant? variantFor(String shortName) => _variants[shortName];
 
   Future<void> _load() async {
     try {
       final prefs = await SharedPreferences.getInstance();
-      final raw = prefs.getString(_prefsKey);
-      if (raw == null) return;
-      final decoded = jsonDecode(raw);
-      if (decoded is! Map<String, dynamic>) return;
-      for (final entry in decoded.entries) {
-        final value = entry.value;
-        if (value is! Map<String, dynamic>) continue;
-        final channelId = value['channel'] as String?;
-        _byFirmware[entry.key] = (
-          channelId: channelId != null && channelId.isNotEmpty
-              ? channelId
-              : null,
-          variant: _variantByName(value['variant'] as String?),
-        );
+      for (final key in prefs.getKeys()) {
+        if (!key.startsWith('$_prefix.')) continue;
+        // Per key, so a value of the wrong type - or one this build cannot
+        // make sense of - costs that one setting rather than the whole read.
+        try {
+          _read(prefs, key);
+        } catch (e) {
+          LogService.log('[UpdateSettings] "$key" unreadable: $e');
+        }
       }
     } catch (e) {
       LogService.log('[UpdateSettings] load failed: $e');
     }
   }
 
-  /// Records a choice. Never throws: a preference that will not persist is
-  /// worth one line in the log and nothing more, and the caller has already
-  /// applied the choice to what is on screen.
+  void _read(SharedPreferences prefs, String key) {
+    final rest = key.substring(_prefix.length + 1);
+    final dot = rest.lastIndexOf('.');
+    if (dot <= 0) return;
+    final shortName = rest.substring(0, dot);
+    final value = prefs.getString(key);
+    if (value == null || value.isEmpty) return;
+    switch (rest.substring(dot + 1)) {
+      case 'channel':
+        _channels[shortName] = value;
+      case 'variant':
+        // A variant this build no longer has drops the variant and keeps the
+        // channel, rather than losing both.
+        final variant = UnleashedVariant.fromName(value);
+        if (variant != null) _variants[shortName] = variant;
+    }
+  }
+
+  /// Records whichever of [channelId] and [variant] is given.
+  ///
+  /// Only what the caller passes is written, so a fallback-derived channel the
+  /// user never chose is not persisted by a tap on the variant selector.
+  ///
+  /// Never throws: a preference that will not persist is worth one line in the
+  /// log and nothing more, and the caller has already applied the choice to
+  /// what is on screen.
   Future<void> remember(
     String shortName, {
-    required String? channelId,
-    required UnleashedVariant? variant,
+    String? channelId,
+    UnleashedVariant? variant,
   }) async {
     await load();
-    _byFirmware[shortName] = (channelId: channelId, variant: variant);
+    if (channelId != null) _channels[shortName] = channelId;
+    if (variant != null) _variants[shortName] = variant;
     try {
       final prefs = await SharedPreferences.getInstance();
-      await prefs.setString(
-        _prefsKey,
-        jsonEncode({
-          for (final entry in _byFirmware.entries)
-            if (entry.value.channelId != null || entry.value.variant != null)
-              entry.key: {
-                if (entry.value.channelId != null)
-                  'channel': entry.value.channelId,
-                if (entry.value.variant != null)
-                  'variant': entry.value.variant!.name,
-              },
-        }),
-      );
+      if (channelId != null) {
+        await prefs.setString(_channelPref(shortName), channelId);
+      }
+      if (variant != null) {
+        await prefs.setString(_variantPref(shortName), variant.name);
+      }
     } catch (e) {
       LogService.log('[UpdateSettings] save failed: $e');
     }
   }
 
-  /// Forgets everything, for tests: the instance outlives any one controller,
-  /// so a test that did not clear it would inherit the previous one's choices.
-  Future<void> clear() async {
-    _byFirmware.clear();
+  /// Forgets what was read, so one test does not inherit another's choices.
+  ///
+  /// Only the memo: the preferences themselves are the test's to set up, and
+  /// nothing else can un-memoise [load].
+  @visibleForTesting
+  void reset() {
+    _channels.clear();
+    _variants.clear();
     _loading = null;
-    try {
-      final prefs = await SharedPreferences.getInstance();
-      await prefs.remove(_prefsKey);
-    } catch (_) {}
-  }
-
-  static UnleashedVariant? _variantByName(String? name) {
-    if (name == null) return null;
-    for (final variant in UnleashedVariant.values) {
-      if (variant.name == name) return variant;
-    }
-    // A variant this build no longer has: fall back rather than fail the whole
-    // read and lose the channel with it.
-    return null;
   }
 }

--- a/test/firmware_selection_test.dart
+++ b/test/firmware_selection_test.dart
@@ -1,13 +1,10 @@
-import 'dart:convert';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:qunleashed/components/config.dart';
 import 'package:qunleashed/pages/devices/controllers/firmware.dart';
 import 'package:qunleashed/pages/devices/firmware/directory.dart';
+import 'package:qunleashed/pages/devices/firmware/repository.dart';
 import 'package:qunleashed/pages/devices/firmware/update_settings.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-
-const String prefsKey = 'firmware_update_settings_v1';
 
 FirmwareDirectoryChannel channel(String id) => FirmwareDirectoryChannel(
   id: id,
@@ -37,13 +34,14 @@ Future<void> withController(
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
+  final settings = UpdateSettingsStore.instance;
   final unleashed = QAppConfig.firmware.firmwares.firstWhere(
     (f) => f.shortName == 'unlshd',
   );
 
-  setUp(() async {
+  setUp(() {
     SharedPreferences.setMockInitialValues(const {});
-    await UpdateSettingsStore.instance.clear();
+    settings.reset();
     for (final entry in QAppConfig.firmware.firmwares) {
       parserForEntry(entry).clearCache();
     }
@@ -55,10 +53,14 @@ void main() {
     );
   }
 
-  Future<void> store(String json) async {
-    SharedPreferences.setMockInitialValues({prefsKey: json});
-    await UpdateSettingsStore.instance.clear();
-    SharedPreferences.setMockInitialValues({prefsKey: json});
+  /// Leaves a choice on disk as a previous run would have, then drops what the
+  /// store read so the next controller has to go and fetch it.
+  Future<void> alreadyChose({
+    String? channel,
+    UnleashedVariant? variant,
+  }) async {
+    await settings.remember('unlshd', channelId: channel, variant: variant);
+    settings.reset();
   }
 
   group('remembering the update settings', () {
@@ -72,11 +74,7 @@ void main() {
 
     test('a remembered channel is used instead of the default', () async {
       giveChannels(['release', 'development']);
-      await store(
-        jsonEncode({
-          'unlshd': {'channel': 'development'},
-        }),
-      );
+      await alreadyChose(channel: 'development');
 
       await withController((fw) async {
         expect(fw.selectedChannelId(unleashed), 'development');
@@ -85,11 +83,7 @@ void main() {
 
     test('a remembered variant is used instead of the default', () async {
       giveChannels(['release', 'development']);
-      await store(
-        jsonEncode({
-          'unlshd': {'channel': 'release', 'variant': 'compact'},
-        }),
-      );
+      await alreadyChose(channel: 'release', variant: UnleashedVariant.compact);
 
       await withController((fw) async {
         expect(fw.selectedVariant(unleashed), UnleashedVariant.compact);
@@ -101,11 +95,7 @@ void main() {
     // it is silently replaced on every launch.
     test('a remembered custom channel is not overridden', () async {
       giveChannels(['release', 'development']);
-      await store(
-        jsonEncode({
-          'unlshd': {'channel': kCustomFirmwareChannelId},
-        }),
-      );
+      await alreadyChose(channel: kCustomFirmwareChannelId);
 
       await withController((fw) async {
         expect(fw.selectedChannelId(unleashed), kCustomFirmwareChannelId);
@@ -114,15 +104,30 @@ void main() {
 
     test('a channel that no longer exists falls back', () async {
       giveChannels(['release']);
-      await store(
-        jsonEncode({
-          'unlshd': {'channel': 'development'},
-        }),
-      );
+      await alreadyChose(channel: 'development');
 
       await withController((fw) async {
         expect(fw.selectedChannelId(unleashed), 'release');
       });
+    });
+
+    // The real cold start. The directory cache is in-memory only, so on first
+    // launch the channel list holds nothing but the custom entry until a
+    // network round trip finishes - and validating a remembered channel
+    // against that list replaces it with custom, which counts as a choice and
+    // so is never corrected when the real channels arrive. Every other test
+    // here seeds the directory first, which is warmer than any real launch.
+    test('a remembered channel survives the directory arriving late', () async {
+      await alreadyChose(channel: 'development');
+
+      final fw = FirmwareController();
+      await pumpEventQueue();
+      giveChannels(['release', 'development']);
+      await FirmwareRepository.instance.refresh();
+      await pumpEventQueue();
+
+      expect(fw.selectedChannelId(unleashed), 'development');
+      fw.dispose();
     });
 
     test('choosing a channel records it', () async {
@@ -133,10 +138,7 @@ void main() {
         await pumpEventQueue();
       });
 
-      expect(
-        UpdateSettingsStore.instance.selectionFor('unlshd')?.channelId,
-        'development',
-      );
+      expect(settings.channelFor('unlshd'), 'development');
     });
 
     test('choosing a variant records it', () async {
@@ -148,10 +150,21 @@ void main() {
         await pumpEventQueue();
       });
 
-      expect(
-        UpdateSettingsStore.instance.selectionFor('unlshd')?.variant,
-        UnleashedVariant.compact,
-      );
+      expect(settings.variantFor('unlshd'), UnleashedVariant.compact);
+    });
+
+    // A variant tap must not persist whatever channel the fallback happened to
+    // pick, or a user who never touched the channel selector is quietly opted
+    // out of following the default from then on.
+    test('choosing a variant does not record an unchosen channel', () async {
+      giveChannels(['release', 'development']);
+
+      await withController((fw) async {
+        fw.setVariant(unleashed, UnleashedVariant.compact);
+        await pumpEventQueue();
+      });
+
+      expect(settings.channelFor('unlshd'), isNull);
     });
 
     test('what was chosen survives into the next controller', () async {
@@ -169,13 +182,9 @@ void main() {
     // The read is asynchronous, so a tap can land first. Replacing what the
     // user is looking at with a stale stored value would be worse than
     // forgetting it.
-    test('a choice made while the read is in flight wins', () async {
+    test('a channel chosen while the read is in flight wins', () async {
       giveChannels(['release', 'development']);
-      await store(
-        jsonEncode({
-          'unlshd': {'channel': 'release'},
-        }),
-      );
+      await alreadyChose(channel: 'release');
 
       final fw = FirmwareController();
       fw.setChannel(unleashed, 'development');
@@ -183,6 +192,31 @@ void main() {
 
       expect(fw.selectedChannelId(unleashed), 'development');
       fw.dispose();
+    });
+
+    // Tracked per field: a channel tap says nothing about the variant, so a
+    // variant chosen in the same window has to be honoured on its own.
+    test('a variant chosen while the read is in flight wins', () async {
+      giveChannels(['release', 'development']);
+      await alreadyChose(channel: 'release', variant: UnleashedVariant.base);
+
+      final fw = FirmwareController();
+      fw.setVariant(unleashed, UnleashedVariant.compact);
+      await pumpEventQueue();
+
+      expect(fw.selectedVariant(unleashed), UnleashedVariant.compact);
+      fw.dispose();
+    });
+
+    // The read is started in the constructor and cannot be cancelled, so
+    // leaving the page inside that window used to notify a disposed notifier.
+    test('leaving the page before the read lands is not an error', () async {
+      giveChannels(['release', 'development']);
+      await alreadyChose(channel: 'development');
+
+      FirmwareController().dispose();
+
+      await pumpEventQueue();
     });
   });
 }

--- a/test/firmware_selection_test.dart
+++ b/test/firmware_selection_test.dart
@@ -1,0 +1,188 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qunleashed/components/config.dart';
+import 'package:qunleashed/pages/devices/controllers/firmware.dart';
+import 'package:qunleashed/pages/devices/firmware/directory.dart';
+import 'package:qunleashed/pages/devices/firmware/update_settings.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const String prefsKey = 'firmware_update_settings_v1';
+
+FirmwareDirectoryChannel channel(String id) => FirmwareDirectoryChannel(
+  id: id,
+  title: id,
+  description: '',
+  versions: const [
+    FirmwareVersion(version: '1.0.0', changelog: '', timestamp: 0, files: []),
+  ],
+);
+
+/// Runs [body] once the controller has read its stored choices.
+///
+/// The read is asynchronous, so anything asserted before it lands is asserting
+/// against the fallback rather than against what was remembered.
+Future<void> withController(
+  Future<void> Function(FirmwareController fw) body,
+) async {
+  final fw = FirmwareController();
+  await pumpEventQueue();
+  try {
+    await body(fw);
+  } finally {
+    fw.dispose();
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final unleashed = QAppConfig.firmware.firmwares.firstWhere(
+    (f) => f.shortName == 'unlshd',
+  );
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(const {});
+    await UpdateSettingsStore.instance.clear();
+    for (final entry in QAppConfig.firmware.firmwares) {
+      parserForEntry(entry).clearCache();
+    }
+  });
+
+  void giveChannels(List<String> ids) {
+    parserForEntry(unleashed).seedCache(
+      FirmwareDirectory(channels: [for (final id in ids) channel(id)]),
+    );
+  }
+
+  Future<void> store(String json) async {
+    SharedPreferences.setMockInitialValues({prefsKey: json});
+    await UpdateSettingsStore.instance.clear();
+    SharedPreferences.setMockInitialValues({prefsKey: json});
+  }
+
+  group('remembering the update settings', () {
+    test('with nothing stored it settles on the release channel', () async {
+      giveChannels(['release', 'development']);
+
+      await withController((fw) async {
+        expect(fw.selectedChannelId(unleashed), 'release');
+      });
+    });
+
+    test('a remembered channel is used instead of the default', () async {
+      giveChannels(['release', 'development']);
+      await store(
+        jsonEncode({
+          'unlshd': {'channel': 'development'},
+        }),
+      );
+
+      await withController((fw) async {
+        expect(fw.selectedChannelId(unleashed), 'development');
+      });
+    });
+
+    test('a remembered variant is used instead of the default', () async {
+      giveChannels(['release', 'development']);
+      await store(
+        jsonEncode({
+          'unlshd': {'channel': 'release', 'variant': 'compact'},
+        }),
+      );
+
+      await withController((fw) async {
+        expect(fw.selectedVariant(unleashed), UnleashedVariant.compact);
+      });
+    });
+
+    // The custom channel is the one the fallback treats as "nobody has chosen
+    // yet", so a remembered choice of it has to be marked as a real choice or
+    // it is silently replaced on every launch.
+    test('a remembered custom channel is not overridden', () async {
+      giveChannels(['release', 'development']);
+      await store(
+        jsonEncode({
+          'unlshd': {'channel': kCustomFirmwareChannelId},
+        }),
+      );
+
+      await withController((fw) async {
+        expect(fw.selectedChannelId(unleashed), kCustomFirmwareChannelId);
+      });
+    });
+
+    test('a channel that no longer exists falls back', () async {
+      giveChannels(['release']);
+      await store(
+        jsonEncode({
+          'unlshd': {'channel': 'development'},
+        }),
+      );
+
+      await withController((fw) async {
+        expect(fw.selectedChannelId(unleashed), 'release');
+      });
+    });
+
+    test('choosing a channel records it', () async {
+      giveChannels(['release', 'development']);
+
+      await withController((fw) async {
+        fw.setChannel(unleashed, 'development');
+        await pumpEventQueue();
+      });
+
+      expect(
+        UpdateSettingsStore.instance.selectionFor('unlshd')?.channelId,
+        'development',
+      );
+    });
+
+    test('choosing a variant records it', () async {
+      giveChannels(['release', 'development']);
+
+      await withController((fw) async {
+        fw.setChannel(unleashed, 'release');
+        fw.setVariant(unleashed, UnleashedVariant.compact);
+        await pumpEventQueue();
+      });
+
+      expect(
+        UpdateSettingsStore.instance.selectionFor('unlshd')?.variant,
+        UnleashedVariant.compact,
+      );
+    });
+
+    test('what was chosen survives into the next controller', () async {
+      giveChannels(['release', 'development']);
+
+      await withController((fw) async {
+        fw.setChannel(unleashed, 'development');
+        await pumpEventQueue();
+      });
+      await withController((fw) async {
+        expect(fw.selectedChannelId(unleashed), 'development');
+      });
+    });
+
+    // The read is asynchronous, so a tap can land first. Replacing what the
+    // user is looking at with a stale stored value would be worse than
+    // forgetting it.
+    test('a choice made while the read is in flight wins', () async {
+      giveChannels(['release', 'development']);
+      await store(
+        jsonEncode({
+          'unlshd': {'channel': 'release'},
+        }),
+      );
+
+      final fw = FirmwareController();
+      fw.setChannel(unleashed, 'development');
+      await pumpEventQueue();
+
+      expect(fw.selectedChannelId(unleashed), 'development');
+      fw.dispose();
+    });
+  });
+}

--- a/test/firmware_selection_test.dart
+++ b/test/firmware_selection_test.dart
@@ -47,19 +47,29 @@ void main() {
     }
   });
 
-  void giveChannels(List<String> ids) {
-    parserForEntry(unleashed).seedCache(
-      FirmwareDirectory(channels: [for (final id in ids) channel(id)]),
-    );
+  /// Seeds a directory for [entry], defaulting to Unleashed.
+  ///
+  /// Every firmware gets one by default. Leaving any unseeded means the
+  /// controller goes to the network for it - a dozen live requests per run -
+  /// and the resulting notify runs a fallback pass *before* the stored
+  /// settings are read, which quietly pre-satisfies assertions that the
+  /// default channel is release.
+  void giveChannels(List<String> ids, {FirmwareEntry? entry}) {
+    for (final f in entry == null ? QAppConfig.firmware.firmwares : [entry]) {
+      parserForEntry(f).seedCache(
+        FirmwareDirectory(channels: [for (final id in ids) channel(id)]),
+      );
+    }
   }
 
   /// Leaves a choice on disk as a previous run would have, then drops what the
   /// store read so the next controller has to go and fetch it.
   Future<void> alreadyChose({
+    String shortName = 'unlshd',
     String? channel,
     UnleashedVariant? variant,
   }) async {
-    await settings.remember('unlshd', channelId: channel, variant: variant);
+    await settings.remember(shortName, channelId: channel, variant: variant);
     settings.reset();
   }
 
@@ -68,7 +78,15 @@ void main() {
       giveChannels(['release', 'development']);
 
       await withController((fw) async {
-        expect(fw.selectedChannelId(unleashed), 'release');
+        // Every firmware, not just the first: the fallback loops them all, and
+        // asserting only on the first would let it be narrowed unnoticed.
+        for (final entry in QAppConfig.firmware.firmwares) {
+          expect(
+            fw.selectedChannelId(entry),
+            'release',
+            reason: entry.shortName,
+          );
+        }
       });
     });
 
@@ -121,13 +139,81 @@ void main() {
       await alreadyChose(channel: 'development');
 
       final fw = FirmwareController();
+      addTearDown(fw.dispose);
       await pumpEventQueue();
       giveChannels(['release', 'development']);
-      await FirmwareRepository.instance.refresh();
+      FirmwareRepository.instance.directoryChanged();
       await pumpEventQueue();
 
       expect(fw.selectedChannelId(unleashed), 'development');
-      fw.dispose();
+    });
+
+    test('the seeded directory is what the controller offers', () async {
+      giveChannels(['release', 'development']);
+
+      await withController((fw) async {
+        expect(fw.channelsFor(unleashed).map((c) => c.id), [
+          'release',
+          'development',
+          kCustomFirmwareChannelId,
+        ]);
+      });
+    });
+
+    // Both the restore and the fallback loop every firmware, and every other
+    // assertion here is on the first one - so narrowing either loop to `.first`
+    // would go unnoticed.
+    test('every firmware is restored, not just the first', () async {
+      final other = QAppConfig.firmware.firmwares.firstWhere(
+        (f) => f.shortName != 'unlshd',
+      );
+      giveChannels(['release', 'development']);
+      await alreadyChose(shortName: other.shortName, channel: 'development');
+
+      await withController((fw) async {
+        expect(fw.selectedChannelId(other), 'development');
+        expect(fw.selectedChannelId(unleashed), 'release');
+      });
+    });
+
+    // The directory matches channel ids through their aliases, so a feed that
+    // renames one must not silently discard what the user picked.
+    test('a channel the feed now spells differently is kept', () async {
+      giveChannels(['release', 'development']);
+      await alreadyChose(channel: 'dev');
+
+      await withController((fw) async {
+        expect(fw.selectedChannelId(unleashed), 'development');
+      });
+    });
+
+    // selectedVariant already reports the packaged variant for a channel that
+    // has no variants, so moving through one must not discard the choice -
+    // which is what made the screen and the next launch disagree.
+    test('a variant survives a channel that has none', () async {
+      giveChannels(['release', 'release-candidate']);
+      await alreadyChose(channel: 'release', variant: UnleashedVariant.compact);
+
+      await withController((fw) async {
+        fw.setChannel(unleashed, 'release-candidate');
+        expect(fw.selectedVariant(unleashed), UnleashedVariant.extraPacks);
+
+        fw.setChannel(unleashed, 'release');
+        expect(fw.selectedVariant(unleashed), UnleashedVariant.compact);
+      });
+    });
+
+    test('a stored variant is not offered on a channel without them', () async {
+      giveChannels(['release-candidate', 'release']);
+      await alreadyChose(
+        channel: 'release-candidate',
+        variant: UnleashedVariant.compact,
+      );
+
+      await withController((fw) async {
+        expect(fw.hasVariants(unleashed), isFalse);
+        expect(fw.selectedVariant(unleashed), UnleashedVariant.extraPacks);
+      });
     });
 
     test('choosing a channel records it', () async {
@@ -187,11 +273,11 @@ void main() {
       await alreadyChose(channel: 'release');
 
       final fw = FirmwareController();
+      addTearDown(fw.dispose);
       fw.setChannel(unleashed, 'development');
       await pumpEventQueue();
 
       expect(fw.selectedChannelId(unleashed), 'development');
-      fw.dispose();
     });
 
     // Tracked per field: a channel tap says nothing about the variant, so a
@@ -201,11 +287,11 @@ void main() {
       await alreadyChose(channel: 'release', variant: UnleashedVariant.base);
 
       final fw = FirmwareController();
+      addTearDown(fw.dispose);
       fw.setVariant(unleashed, UnleashedVariant.compact);
       await pumpEventQueue();
 
       expect(fw.selectedVariant(unleashed), UnleashedVariant.compact);
-      fw.dispose();
     });
 
     // The read is started in the constructor and cannot be cancelled, so

--- a/test/update_settings_test.dart
+++ b/test/update_settings_test.dart
@@ -1,0 +1,169 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qunleashed/pages/devices/firmware/directory.dart';
+import 'package:qunleashed/pages/devices/firmware/update_settings.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+const String key = 'firmware_update_settings_v1';
+
+Future<String?> stored() async =>
+    (await SharedPreferences.getInstance()).getString(key);
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  final store = UpdateSettingsStore.instance;
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues(const {});
+    // The store is a singleton and outlives any one controller, so a test that
+    // did not clear it would inherit the previous test's choices.
+    await store.clear();
+  });
+
+  group('remembering a choice', () {
+    test('nothing is remembered before anything is chosen', () async {
+      await store.load();
+
+      expect(store.selectionFor('unlshd'), isNull);
+    });
+
+    test('a channel and a variant come back', () async {
+      await store.remember(
+        'unlshd',
+        channelId: 'development',
+        variant: UnleashedVariant.compact,
+      );
+      await store.clear();
+      SharedPreferences.setMockInitialValues({
+        key: jsonEncode({
+          'unlshd': {'channel': 'development', 'variant': 'compact'},
+        }),
+      });
+      await store.load();
+
+      expect(store.selectionFor('unlshd')?.channelId, 'development');
+      expect(store.selectionFor('unlshd')?.variant, UnleashedVariant.compact);
+    });
+
+    test('choices are kept per firmware', () async {
+      await store.remember('unlshd', channelId: 'release', variant: null);
+      await store.remember('roguemaster', channelId: 'dev', variant: null);
+
+      expect(store.selectionFor('unlshd')?.channelId, 'release');
+      expect(store.selectionFor('roguemaster')?.channelId, 'dev');
+    });
+
+    test('a later choice replaces the earlier one', () async {
+      await store.remember(
+        'unlshd',
+        channelId: 'release',
+        variant: UnleashedVariant.base,
+      );
+      await store.remember(
+        'unlshd',
+        channelId: 'development',
+        variant: UnleashedVariant.compact,
+      );
+
+      expect(store.selectionFor('unlshd')?.channelId, 'development');
+      expect(store.selectionFor('unlshd')?.variant, UnleashedVariant.compact);
+    });
+
+    test('a firmware with nothing chosen is not written out', () async {
+      await store.remember('unlshd', channelId: null, variant: null);
+
+      expect(await stored(), isNot(contains('unlshd')));
+    });
+  });
+
+  group('reading what is on disk', () {
+    Future<void> onDisk(Object value) async {
+      await store.clear();
+      SharedPreferences.setMockInitialValues({key: jsonEncode(value)});
+      await store.load();
+    }
+
+    test('a variant this build no longer has keeps the channel', () async {
+      // Dropping the whole entry would lose a perfectly good channel with it.
+      await onDisk({
+        'unlshd': {'channel': 'release', 'variant': 'quantum'},
+      });
+
+      expect(store.selectionFor('unlshd')?.channelId, 'release');
+      expect(store.selectionFor('unlshd')?.variant, isNull);
+    });
+
+    test('an entry with only a channel reads back', () async {
+      await onDisk({
+        'unlshd': {'channel': 'release'},
+      });
+
+      expect(store.selectionFor('unlshd')?.channelId, 'release');
+      expect(store.selectionFor('unlshd')?.variant, isNull);
+    });
+
+    test('an empty channel reads as no choice', () async {
+      await onDisk({
+        'unlshd': {'channel': ''},
+      });
+
+      expect(store.selectionFor('unlshd')?.channelId, isNull);
+    });
+
+    test('a malformed entry is skipped, not fatal', () async {
+      await onDisk({
+        'unlshd': 'not an object',
+        'roguemaster': {'channel': 'dev'},
+      });
+
+      expect(store.selectionFor('unlshd'), isNull);
+      expect(store.selectionFor('roguemaster')?.channelId, 'dev');
+    });
+
+    test('a value that is not JSON is ignored', () async {
+      await store.clear();
+      SharedPreferences.setMockInitialValues({key: 'not json at all'});
+
+      await store.load();
+
+      expect(store.selectionFor('unlshd'), isNull);
+    });
+
+    test('a JSON value that is not a map is ignored', () async {
+      await onDisk(['unlshd']);
+
+      expect(store.selectionFor('unlshd'), isNull);
+    });
+  });
+
+  group('loading', () {
+    test('reads once and serves later callers from memory', () async {
+      SharedPreferences.setMockInitialValues({
+        key: jsonEncode({
+          'unlshd': {'channel': 'release'},
+        }),
+      });
+      await store.load();
+
+      // A second read of the same store must not go back to disk, where the
+      // value may since have changed under it.
+      SharedPreferences.setMockInitialValues({
+        key: jsonEncode({
+          'unlshd': {'channel': 'development'},
+        }),
+      });
+      await store.load();
+
+      expect(store.selectionFor('unlshd')?.channelId, 'release');
+    });
+
+    test('remembering works without an explicit load first', () async {
+      await store.remember('unlshd', channelId: 'release', variant: null);
+
+      expect(store.selectionFor('unlshd')?.channelId, 'release');
+      expect(await stored(), contains('release'));
+    });
+  });
+}

--- a/test/update_settings_test.dart
+++ b/test/update_settings_test.dart
@@ -1,169 +1,179 @@
-import 'dart:convert';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:qunleashed/pages/devices/firmware/directory.dart';
 import 'package:qunleashed/pages/devices/firmware/update_settings.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-
-const String key = 'firmware_update_settings_v1';
-
-Future<String?> stored() async =>
-    (await SharedPreferences.getInstance()).getString(key);
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   final store = UpdateSettingsStore.instance;
 
-  setUp(() async {
+  setUp(() {
     SharedPreferences.setMockInitialValues(const {});
     // The store is a singleton and outlives any one controller, so a test that
-    // did not clear it would inherit the previous test's choices.
-    await store.clear();
+    // did not reset it would inherit the previous test's choices.
+    store.reset();
   });
+
+  /// Puts raw preferences in place and drops whatever the store had read.
+  void onDisk(Map<String, Object> values) {
+    SharedPreferences.setMockInitialValues(values);
+    store.reset();
+  }
 
   group('remembering a choice', () {
     test('nothing is remembered before anything is chosen', () async {
       await store.load();
 
-      expect(store.selectionFor('unlshd'), isNull);
+      expect(store.channelFor('unlshd'), isNull);
+      expect(store.variantFor('unlshd'), isNull);
     });
 
-    test('a channel and a variant come back', () async {
-      await store.remember(
-        'unlshd',
-        channelId: 'development',
-        variant: UnleashedVariant.compact,
-      );
-      await store.clear();
-      SharedPreferences.setMockInitialValues({
-        key: jsonEncode({
-          'unlshd': {'channel': 'development', 'variant': 'compact'},
-        }),
-      });
+    test('a channel comes back', () async {
+      await store.remember('unlshd', channelId: 'development');
+      store.reset();
       await store.load();
 
-      expect(store.selectionFor('unlshd')?.channelId, 'development');
-      expect(store.selectionFor('unlshd')?.variant, UnleashedVariant.compact);
+      expect(store.channelFor('unlshd'), 'development');
+    });
+
+    test('a variant comes back', () async {
+      await store.remember('unlshd', variant: UnleashedVariant.compact);
+      store.reset();
+      await store.load();
+
+      expect(store.variantFor('unlshd'), UnleashedVariant.compact);
     });
 
     test('choices are kept per firmware', () async {
-      await store.remember('unlshd', channelId: 'release', variant: null);
-      await store.remember('roguemaster', channelId: 'dev', variant: null);
+      await store.remember('unlshd', channelId: 'release');
+      await store.remember('ofw', channelId: 'dev');
+      store.reset();
+      await store.load();
 
-      expect(store.selectionFor('unlshd')?.channelId, 'release');
-      expect(store.selectionFor('roguemaster')?.channelId, 'dev');
+      expect(store.channelFor('unlshd'), 'release');
+      expect(store.channelFor('ofw'), 'dev');
     });
 
     test('a later choice replaces the earlier one', () async {
-      await store.remember(
-        'unlshd',
-        channelId: 'release',
-        variant: UnleashedVariant.base,
-      );
-      await store.remember(
-        'unlshd',
-        channelId: 'development',
-        variant: UnleashedVariant.compact,
-      );
+      await store.remember('unlshd', channelId: 'release');
+      await store.remember('unlshd', channelId: 'development');
+      store.reset();
+      await store.load();
 
-      expect(store.selectionFor('unlshd')?.channelId, 'development');
-      expect(store.selectionFor('unlshd')?.variant, UnleashedVariant.compact);
+      expect(store.channelFor('unlshd'), 'development');
     });
 
-    test('a firmware with nothing chosen is not written out', () async {
-      await store.remember('unlshd', channelId: null, variant: null);
+    // Each field is written on its own, so a tap on one selector cannot
+    // persist whatever happened to be sitting in the other.
+    test('recording a channel leaves the variant alone', () async {
+      await store.remember('unlshd', variant: UnleashedVariant.compact);
+      await store.remember('unlshd', channelId: 'development');
+      store.reset();
+      await store.load();
 
-      expect(await stored(), isNot(contains('unlshd')));
+      expect(store.variantFor('unlshd'), UnleashedVariant.compact);
+      expect(store.channelFor('unlshd'), 'development');
+    });
+
+    test('recording a variant leaves the channel alone', () async {
+      await store.remember('unlshd', channelId: 'development');
+      await store.remember('unlshd', variant: UnleashedVariant.base);
+
+      store.reset();
+      await store.load();
+
+      expect(store.channelFor('unlshd'), 'development');
+      expect(store.variantFor('unlshd'), UnleashedVariant.base);
+    });
+
+    test('recording nothing writes nothing', () async {
+      await store.remember('unlshd');
+      store.reset();
+      await store.load();
+
+      expect(store.channelFor('unlshd'), isNull);
     });
   });
 
   group('reading what is on disk', () {
-    Future<void> onDisk(Object value) async {
-      await store.clear();
-      SharedPreferences.setMockInitialValues({key: jsonEncode(value)});
-      await store.load();
-    }
-
     test('a variant this build no longer has keeps the channel', () async {
-      // Dropping the whole entry would lose a perfectly good channel with it.
-      await onDisk({
-        'unlshd': {'channel': 'release', 'variant': 'quantum'},
+      onDisk({
+        'firmware.update.unlshd.channel': 'release',
+        'firmware.update.unlshd.variant': 'quantum',
       });
-
-      expect(store.selectionFor('unlshd')?.channelId, 'release');
-      expect(store.selectionFor('unlshd')?.variant, isNull);
-    });
-
-    test('an entry with only a channel reads back', () async {
-      await onDisk({
-        'unlshd': {'channel': 'release'},
-      });
-
-      expect(store.selectionFor('unlshd')?.channelId, 'release');
-      expect(store.selectionFor('unlshd')?.variant, isNull);
-    });
-
-    test('an empty channel reads as no choice', () async {
-      await onDisk({
-        'unlshd': {'channel': ''},
-      });
-
-      expect(store.selectionFor('unlshd')?.channelId, isNull);
-    });
-
-    test('a malformed entry is skipped, not fatal', () async {
-      await onDisk({
-        'unlshd': 'not an object',
-        'roguemaster': {'channel': 'dev'},
-      });
-
-      expect(store.selectionFor('unlshd'), isNull);
-      expect(store.selectionFor('roguemaster')?.channelId, 'dev');
-    });
-
-    test('a value that is not JSON is ignored', () async {
-      await store.clear();
-      SharedPreferences.setMockInitialValues({key: 'not json at all'});
 
       await store.load();
 
-      expect(store.selectionFor('unlshd'), isNull);
+      expect(store.channelFor('unlshd'), 'release');
+      expect(store.variantFor('unlshd'), isNull);
     });
 
-    test('a JSON value that is not a map is ignored', () async {
-      await onDisk(['unlshd']);
+    // The reason each field is its own preference: one unreadable value must
+    // cost that value, not everything stored beside it - and certainly not
+    // everything, which is what a single re-written blob would have done.
+    test('a value of the wrong type costs only itself', () async {
+      onDisk({
+        'firmware.update.unlshd.channel': 42,
+        'firmware.update.unlshd.variant': 'compact',
+        'firmware.update.ofw.channel': 'dev',
+      });
 
-      expect(store.selectionFor('unlshd'), isNull);
+      await store.load();
+
+      expect(store.channelFor('unlshd'), isNull);
+      expect(store.variantFor('unlshd'), UnleashedVariant.compact);
+      expect(store.channelFor('ofw'), 'dev');
+    });
+
+    test('an empty value reads as no choice', () async {
+      onDisk({'firmware.update.unlshd.channel': ''});
+
+      await store.load();
+
+      expect(store.channelFor('unlshd'), isNull);
+    });
+
+    test('a key naming a field this build does not know is ignored', () async {
+      onDisk({
+        'firmware.update.unlshd.mystery': 'whatever',
+        'firmware.update.unlshd.channel': 'release',
+      });
+
+      await store.load();
+
+      expect(store.channelFor('unlshd'), 'release');
+    });
+
+    test('other preferences are left alone', () async {
+      onDisk({'theme.mode': 'dark', 'firmware.update.unlshd.channel': 'rel'});
+
+      await store.load();
+
+      expect(store.channelFor('unlshd'), 'rel');
+      expect(store.channelFor('theme'), isNull);
     });
   });
 
   group('loading', () {
     test('reads once and serves later callers from memory', () async {
-      SharedPreferences.setMockInitialValues({
-        key: jsonEncode({
-          'unlshd': {'channel': 'release'},
-        }),
-      });
+      onDisk({'firmware.update.unlshd.channel': 'release'});
       await store.load();
 
       // A second read of the same store must not go back to disk, where the
       // value may since have changed under it.
       SharedPreferences.setMockInitialValues({
-        key: jsonEncode({
-          'unlshd': {'channel': 'development'},
-        }),
+        'firmware.update.unlshd.channel': 'development',
       });
       await store.load();
 
-      expect(store.selectionFor('unlshd')?.channelId, 'release');
+      expect(store.channelFor('unlshd'), 'release');
     });
 
     test('remembering works without an explicit load first', () async {
-      await store.remember('unlshd', channelId: 'release', variant: null);
+      await store.remember('unlshd', channelId: 'release');
 
-      expect(store.selectionFor('unlshd')?.channelId, 'release');
-      expect(await stored(), contains('release'));
+      expect(store.channelFor('unlshd'), 'release');
     });
   });
 }


### PR DESCRIPTION
Closes #64.

`FirmwareController` held the Channel and Build Variant selections in a plain map, and it is created in the firmware card's `initState` — so the choice was lost **on leaving the devices page**, not merely on restart. The fallback then quietly reselected the release channel and the packaged variant on the way back in, which reads as the app ignoring what you told it.

Both are now stored per firmware and read back when the controller is built.

## What review caught, and why it matters most

The first version **did not work on a cold start** — the only path that matters.

The directory cache is in-memory only, so on a real first launch the channel list holds nothing but the custom entry until a network round trip finishes. `_restore` applied the remembered channel and handed it to the fallback, which could not find it in that list and replaced it with `custom` — and because a restored choice is marked as picked, the clause that would have corrected it once the real channels arrived never ran.

That is worse than a wrong label: `custom` puts the update button into *"pick a .tgz from disk"* mode. A user who had chosen the dev channel would open the devices page and be asked to browse for a firmware archive. And the only users affected are the ones the feature exists for.

**Every test I had written seeded the directory before constructing the controller** — warmer than any real launch. There is a cold-start test now, and it fails against the previous commit.

Three more from the same pass:

- `_restore` is started in the constructor, holds `this` across the read, and cannot be cancelled — so leaving the page inside that window notified a **disposed** `ChangeNotifier`, which asserts in debug and profile.
- `setVariant` never marked the selection as picked, so a variant chosen while the read was in flight was **reverted on screen while still being written to disk**. The two selectors are tracked separately now: a tap on one says nothing about the other.
- `_remember` wrote whatever channel was in the selection, **including one the fallback picked**. A user who only ever touched the variant selector had a channel persisted for them, which counts as a choice next launch and quietly opts them out of following the default.

## The storage shape was copied from the wrong precedent

I modelled the store on `KnownDevicesStore`, which holds an unbounded ordered list and so has to use a JSON blob. The real analogue is `MapSettings`, which stores per-provider scalars under composed dotted keys — also the dominant convention here (`theme.mode`, `map.tiles.*`, `device.autoconnect.*`).

That is not only tidier. With a blob, one unreadable value aborted the whole read, the memo meant it was never retried, and the next write serialised the truncated map over everything else — **one bad field could permanently erase another firmware's settings.** Per-key storage makes that impossible, and there is a test for it.

## The ordering, which is the part with teeth

- A tap can beat the read. The user is looking at what they just chose, so a field already picked is left alone — tracked per field.
- A restored choice has to count as a *user* choice. The fallback treats the custom channel as "nobody has chosen yet"; without marking the restore, someone who deliberately picked Custom would find it replaced on every launch.
- A stored channel the directory no longer offers still falls back — which is why the fallback runs *after* the restore rather than instead of it.

## Testing

The controller needed one seam: its channel list comes from a network fetch, and with no directory the fallback collapses everything to the custom channel, so nothing interesting is reachable. `FirmwareParser.seedCache` installs one as if freshly fetched.

**28 tests.** They no longer hand-build the stored format — setup goes through the store's own API, so the encoding is not duplicated into two test files.

**Mutation testing: 13 mutations, all caught.** Two rounds of it earned their keep:

- A `_restored` flag I had added to gate the fallback: two separate mutations of it survived. Tracing why showed the rationale I wrote for it did not hold — `_applyChannelFallback` never sets `userPicked`, so a fallback landing first is harmlessly overwritten. The flag was doing nothing, and went, along with a `try/finally` that could not catch anything.
- The variant-picked flag: `??=` was guarding it incidentally, so the flag was dead. Assigning explicitly makes it load-bearing and states the rule rather than relying on a null check that happens to hold.