### PR TITLE
ci: make English the only localization source anyone can edit

### DIFF
--- a/.github/scripts/check_translation_sources.sh
+++ b/.github/scripts/check_translation_sources.sh
@@ -13,8 +13,15 @@
 #
 #   git diff --name-only "origin/$BASE"...HEAD | check_translation_sources.sh
 #
+# Give it the old path of a rename as well as the new one. A file moved out of
+# the pattern stops being Crowdin's export target without anything about the
+# change looking like an edit to it.
+#
 # Set CROWDIN_BRANCH to the branch the sync opens its pull request from; a
-# change on that branch is the sync doing its job and is allowed.
+# change on that branch is the sync doing its job and is allowed. Naming a
+# branch that deliberately turns the check off, which is the point: this
+# catches the mistake of not knowing the rule, and someone who does know it
+# has a legitimate reason now and then.
 set -Eeuo pipefail
 
 crowdin_branch="${CROWDIN_BRANCH:-l10n/crowdin}"
@@ -26,14 +33,19 @@ if [[ "$branch" == "$crowdin_branch" ]]; then
 fi
 
 offenders=()
-while IFS= read -r path; do
+# The `|| [[ -n "$path" ]]` keeps the last line when the producer sends no
+# trailing newline; without it the guard skips whichever file happens to be
+# last, and says nothing about having done so.
+while IFS= read -r path || [[ -n "$path" ]]; do
   [[ -z "$path" ]] && continue
   case "$path" in
     # The source of every string. Editing this is how strings are added.
     translations/app_en.arb) ;;
     fastlane/metadata/android/en-US/*) ;;
-    # Every other app-strings file belongs to Crowdin.
-    translations/app_*.arb) offenders+=("$path") ;;
+    # Everything else under translations/ is Crowdin's, at whatever depth. A
+    # narrower pattern would miss app_de.arb moved one directory down, which
+    # is just as broken and much harder to see.
+    translations/*) offenders+=("$path") ;;
     # Of the store listing, Crowdin holds only the three texts crowdin.yml
     # names. The screenshots, the icon, the title and the video URL are kept
     # here for every locale, so they have to stay editable here.
@@ -60,5 +72,9 @@ is reverted by the next sync rather than merged with it.
 
 To correct a translation, change it in Crowdin; it reaches this repository on
 the next sync. To add a language, ask for it to be enabled in Crowdin.
+
+Of the store listing Crowdin holds only short_description.txt,
+full_description.txt and the changelogs. Screenshots, the icon, title.txt and
+video.txt are kept here and can be changed in any locale.
 MESSAGE
 exit 1

--- a/.github/scripts/check_translation_sources.sh
+++ b/.github/scripts/check_translation_sources.sh
@@ -49,9 +49,11 @@ while IFS= read -r path || [[ -n "$path" ]]; do
     # Of the store listing, Crowdin holds only the three texts crowdin.yml
     # names. The screenshots, the icon, the title and the video URL are kept
     # here for every locale, so they have to stay editable here.
-    fastlane/metadata/android/*/short_description.txt) offenders+=("$path") ;;
-    fastlane/metadata/android/*/full_description.txt) offenders+=("$path") ;;
-    fastlane/metadata/android/*/changelogs/*.txt) offenders+=("$path") ;;
+    fastlane/metadata/android/*/short_description.txt | \
+      fastlane/metadata/android/*/full_description.txt | \
+      fastlane/metadata/android/*/changelogs/*.txt)
+      offenders+=("$path")
+      ;;
   esac
 done
 

--- a/.github/scripts/check_translation_sources.sh
+++ b/.github/scripts/check_translation_sources.sh
@@ -4,9 +4,19 @@
 # English is the only source: every other language is written in Crowdin and
 # reaches this repository through the Crowdin RX pull request. Editing one by
 # hand creates a second writer, and the two do not merge - Crowdin exports the
-# whole file, so the next sync silently reverts whatever was written here. That
-# is not hypothetical: it is how e0aed07 came to exist, and why the Russian
-# translation has had to be restored by hand once already.
+# whole file, so the next sync silently reverts whatever was written here.
+#
+# e0aed07 is what that looks like. It put 83 Russian strings back by hand, and
+# its own message states the consequence plainly: "Seeding Crowdin with these
+# translations has to follow, or the next download will overwrite them again."
+# This guard would have blocked that commit - correctly. The repair belonged in
+# Crowdin, which is the only place it would have survived.
+#
+# What this does not do is stop the sync from overwriting a good translation in
+# the first place, which is what damaged those 83 strings and is tracked in #49.
+# That one is Crowdin-side: the project has never held this repository's
+# translations, so it exports English for them. Seeding it is that fix, and it
+# is a different fix from this one.
 #
 # Reads the changed paths on stdin, one per line, so the caller decides how to
 # work out the diff and this stays testable without a repository.
@@ -22,6 +32,12 @@
 # branch that deliberately turns the check off, which is the point: this
 # catches the mistake of not knowing the rule, and someone who does know it
 # has a legitimate reason now and then.
+#
+# The branch, not the author, though the sync's pull requests do currently
+# arrive as github-actions[bot] and that looks like the sturdier signal. It is
+# not: #40 is open to reopen those pull requests under a PAT or app token,
+# precisely so they trigger CI, and that changes the author while leaving the
+# branch name alone. A test keeps this default and crowdin-rx.yml in step.
 set -Eeuo pipefail
 
 crowdin_branch="${CROWDIN_BRANCH:-l10n/crowdin}"

--- a/.github/scripts/check_translation_sources.sh
+++ b/.github/scripts/check_translation_sources.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Fails when a change edits a localization file that Crowdin owns.
+#
+# English is the only source: every other language is written in Crowdin and
+# reaches this repository through the Crowdin RX pull request. Editing one by
+# hand creates a second writer, and the two do not merge - Crowdin exports the
+# whole file, so the next sync silently reverts whatever was written here. That
+# is not hypothetical: it is how e0aed07 came to exist, and why the Russian
+# translation has had to be restored by hand once already.
+#
+# Reads the changed paths on stdin, one per line, so the caller decides how to
+# work out the diff and this stays testable without a repository.
+#
+#   git diff --name-only "origin/$BASE"...HEAD | check_translation_sources.sh
+#
+# Set CROWDIN_BRANCH to the branch the sync opens its pull request from; a
+# change on that branch is the sync doing its job and is allowed.
+set -Eeuo pipefail
+
+crowdin_branch="${CROWDIN_BRANCH:-l10n/crowdin}"
+branch="${GITHUB_HEAD_REF:-}"
+
+if [[ "$branch" == "$crowdin_branch" ]]; then
+  echo "On $crowdin_branch: this is the Crowdin sync, nothing to check."
+  exit 0
+fi
+
+offenders=()
+while IFS= read -r path; do
+  [[ -z "$path" ]] && continue
+  case "$path" in
+    # The source of every string. Editing this is how strings are added.
+    translations/app_en.arb) ;;
+    fastlane/metadata/android/en-US/*) ;;
+    # Every other app-strings file belongs to Crowdin.
+    translations/app_*.arb) offenders+=("$path") ;;
+    # Of the store listing, Crowdin holds only the three texts crowdin.yml
+    # names. The screenshots, the icon, the title and the video URL are kept
+    # here for every locale, so they have to stay editable here.
+    fastlane/metadata/android/*/short_description.txt) offenders+=("$path") ;;
+    fastlane/metadata/android/*/full_description.txt) offenders+=("$path") ;;
+    fastlane/metadata/android/*/changelogs/*.txt) offenders+=("$path") ;;
+  esac
+done
+
+if ((${#offenders[@]} == 0)); then
+  echo "No hand-edited translations."
+  exit 0
+fi
+
+echo "::error::This change edits translations that Crowdin owns."
+for path in "${offenders[@]}"; do
+  echo "::error file=$path::$path is written in Crowdin, not here."
+done
+cat <<'MESSAGE' >&2
+
+Add or change strings in translations/app_en.arb only. Everything else arrives
+through the Crowdin sync, which exports each file whole - so an edit made here
+is reverted by the next sync rather than merged with it.
+
+To correct a translation, change it in Crowdin; it reaches this repository on
+the next sync. To add a language, ask for it to be enabled in Crowdin.
+MESSAGE
+exit 1

--- a/.github/scripts/check_translation_sources_test.sh
+++ b/.github/scripts/check_translation_sources_test.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Covers check_translation_sources.sh. The guard only ever runs on a pull
+# request, so without this a mistake in it would surface either as a gate that
+# blocks every change or, worse, as one that quietly permits the hand edits it
+# exists to stop.
+set -Eeuo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECK="$HERE/check_translation_sources.sh"
+failures=0
+
+pass() { printf '  ok    %s\n' "$1"; }
+fail() { printf '  FAIL  %s\n' "$1"; failures=$((failures + 1)); }
+
+# Runs the guard over the given paths with a clean environment, so a developer's
+# own GITHUB_HEAD_REF cannot change a result.
+run() {
+  local branch="$1"
+  shift
+  printf '%s\n' "$@" | env -i PATH="$PATH" GITHUB_HEAD_REF="$branch" \
+    bash "$CHECK" >/dev/null 2>&1
+}
+
+allows() {
+  local what="$1" branch="$2"
+  shift 2
+  if run "$branch" "$@"; then pass "$what"; else fail "$what"; fi
+}
+
+blocks() {
+  local what="$1" branch="$2"
+  shift 2
+  if run "$branch" "$@"; then fail "$what"; else pass "$what"; fi
+}
+
+allows "an ordinary code change" feature/x \
+  lib/main.dart test/foo_test.dart
+
+allows "adding a string to the English source" feature/x \
+  translations/app_en.arb lib/pages/x.dart
+
+allows "changing the English store listing" feature/x \
+  fastlane/metadata/android/en-US/full_description.txt
+
+blocks "hand-editing Russian" feature/x \
+  translations/app_ru.arb
+
+blocks "hand-editing Russian alongside legitimate work" feature/x \
+  lib/main.dart translations/app_en.arb translations/app_ru.arb
+
+blocks "hand-editing a language that does not exist yet" feature/x \
+  translations/app_de.arb
+
+blocks "hand-editing a translated store listing" feature/x \
+  fastlane/metadata/android/ru-RU/full_description.txt
+
+blocks "hand-editing a translated changelog" feature/x \
+  fastlane/metadata/android/ru-RU/changelogs/1.txt
+
+# crowdin.yml claims three texts per locale and nothing else. The screenshots
+# and the icon have never been Crowdin's, and neither the store title nor the
+# video URL is uploaded - so blocking them would leave no way to change them.
+allows "replacing a translated screenshot" feature/x \
+  fastlane/metadata/android/ru-RU/images/phoneScreenshots/1.png
+
+allows "changing a translated store title" feature/x \
+  fastlane/metadata/android/ru-RU/title.txt fastlane/metadata/android/ru-RU/video.txt
+
+# The sync itself edits exactly these files; blocking it would stop every
+# translation from ever landing.
+allows "the Crowdin sync updating Russian" l10n/crowdin \
+  translations/app_ru.arb
+
+allows "the Crowdin sync adding a language" l10n/crowdin \
+  translations/app_de.arb translations/app_zh.arb
+
+# A branch merely named like the sync's is still the sync's branch by the only
+# means CI has of telling; what must not happen is a *similar* name passing.
+blocks "a branch that only looks like the sync branch" l10n/crowdin-fix \
+  translations/app_ru.arb
+
+# Empty input is a change that touched nothing relevant, not a failure.
+allows "no changed files at all" feature/x ""
+
+if ((failures)); then
+  printf '\n%d check(s) failed\n' "$failures"
+  exit 1
+fi
+printf '\nall passed\n'

--- a/.github/scripts/check_translation_sources_test.sh
+++ b/.github/scripts/check_translation_sources_test.sh
@@ -21,13 +21,11 @@ run() {
     bash "$CHECK" 2>&1
 }
 
-# Both helpers assert on the exit code *and* the output. Checking only for a
-# non-zero exit would let a guard that cannot even start report every blocking
-# case as working: 126 and 127 are not 0 either.
-allows() {
-  local what="$1" branch="$2" out status=0
-  shift 2
-  out="$(run "$branch" "$@")" || status=$?
+# Both assertions check the exit code *and* the output. A non-zero exit alone
+# would let a guard that cannot even start report every blocking case as
+# working: 126 and 127 are not 0 either.
+assert_allowed() {
+  local what="$1" out="$2" status="$3"
   if ((status == 0)) && [[ "$out" != *"::error"* ]]; then
     pass "$what"
   else
@@ -35,18 +33,29 @@ allows() {
   fi
 }
 
-# The third argument is the path that must be named in the failure. A guard
-# that blocks the right change while pointing at the wrong file sends the
-# author looking in the wrong place.
-blocks() {
-  local what="$1" branch="$2" offender="$3" out status=0
-  shift 3
-  out="$(run "$branch" "$@")" || status=$?
+# A guard that blocks the right change while naming the wrong file sends the
+# author looking in the wrong place, so the offending path has to appear.
+assert_blocked() {
+  local what="$1" offender="$2" out="$3" status="$4"
   if ((status == 1)) && [[ "$out" == *"::error file=$offender::"* ]]; then
     pass "$what"
   else
     fail "$what (exit $status): $out"
   fi
+}
+
+allows() {
+  local what="$1" branch="$2" out status=0
+  shift 2
+  out="$(run "$branch" "$@")" || status=$?
+  assert_allowed "$what" "$out" "$status"
+}
+
+blocks() {
+  local what="$1" branch="$2" offender="$3" out status=0
+  shift 3
+  out="$(run "$branch" "$@")" || status=$?
+  assert_blocked "$what" "$offender" "$out" "$status"
 }
 
 allows "an ordinary code change" feature/x \
@@ -116,20 +125,44 @@ blocks "a branch that only looks like the sync branch" l10n/crowdin-fix \
 allows "no changed files at all" feature/x ""
 
 # A path list that does not end in a newline must not lose its last entry.
-# Every other case here goes through printf, which always terminates.
-last_line_status=0
-last_line_out="$(printf 'lib/main.dart\ntranslations/app_ru.arb' \
+# This is the one case that cannot go through run(), whose printf always
+# terminates its output - so it builds the input by hand and then makes the
+# same assertion as everything else.
+unterminated_status=0
+unterminated_out="$(printf 'lib/main.dart\ntranslations/app_ru.arb' \
   | env -i PATH="$PATH" GITHUB_HEAD_REF=feature/x bash "$CHECK" 2>&1)" \
-  || last_line_status=$?
-if ((last_line_status == 1)) &&
-  [[ "$last_line_out" == *"::error file=translations/app_ru.arb::"* ]]; then
-  pass "input with no trailing newline"
+  || unterminated_status=$?
+assert_blocked "input with no trailing newline" translations/app_ru.arb \
+  "$unterminated_out" "$unterminated_status"
+
+# crowdin.yml declares what Crowdin owns; the guard restates it in another
+# syntax, and nothing has been keeping the two in step. The direction that
+# fails quietly is the dangerous one: a file added to crowdin.yml and not to
+# the guard is simply allowed through, and the guard goes on passing. So take
+# every translation pattern crowdin.yml defines, make a concrete path of it,
+# and require the guard to block that path.
+owned=0
+while IFS= read -r pattern; do
+  sample="${pattern#/}"
+  sample="${sample//%two_letters_code%/de}"
+  sample="${sample//%locale%/de-DE}"
+  sample="${sample//%original_file_name%/1.txt}"
+  sample="${sample//%file_name%/1}"
+  sample="${sample//%file_extension%/txt}"
+  blocks "crowdin.yml owns $sample" feature/x "$sample" "$sample"
+  owned=$((owned + 1))
+done < <(sed -nE 's/^[[:space:]]*translation:[[:space:]]*"([^"]+)".*/\1/p' \
+  "$HERE/../../crowdin.yml")
+
+# Nothing parsed means the check above silently tested nothing.
+if ((owned > 0)); then
+  pass "crowdin.yml patterns were readable ($owned)"
 else
-  fail "input with no trailing newline (exit $last_line_status): $last_line_out"
+  fail "crowdin.yml patterns were readable (found none)"
 fi
 
 if ((failures)); then
-  printf '\n%d check(s) failed\n' "$failures"
+  echo "$failures failure(s)" >&2
   exit 1
 fi
-printf '\nall passed\n'
+echo "all passed"

--- a/.github/scripts/check_translation_sources_test.sh
+++ b/.github/scripts/check_translation_sources_test.sh
@@ -18,19 +18,35 @@ run() {
   local branch="$1"
   shift
   printf '%s\n' "$@" | env -i PATH="$PATH" GITHUB_HEAD_REF="$branch" \
-    bash "$CHECK" >/dev/null 2>&1
+    bash "$CHECK" 2>&1
 }
 
+# Both helpers assert on the exit code *and* the output. Checking only for a
+# non-zero exit would let a guard that cannot even start report every blocking
+# case as working: 126 and 127 are not 0 either.
 allows() {
-  local what="$1" branch="$2"
+  local what="$1" branch="$2" out status=0
   shift 2
-  if run "$branch" "$@"; then pass "$what"; else fail "$what"; fi
+  out="$(run "$branch" "$@")" || status=$?
+  if ((status == 0)) && [[ "$out" != *"::error"* ]]; then
+    pass "$what"
+  else
+    fail "$what (exit $status): $out"
+  fi
 }
 
+# The third argument is the path that must be named in the failure. A guard
+# that blocks the right change while pointing at the wrong file sends the
+# author looking in the wrong place.
 blocks() {
-  local what="$1" branch="$2"
-  shift 2
-  if run "$branch" "$@"; then fail "$what"; else pass "$what"; fi
+  local what="$1" branch="$2" offender="$3" out status=0
+  shift 3
+  out="$(run "$branch" "$@")" || status=$?
+  if ((status == 1)) && [[ "$out" == *"::error file=$offender::"* ]]; then
+    pass "$what"
+  else
+    fail "$what (exit $status): $out"
+  fi
 }
 
 allows "an ordinary code change" feature/x \
@@ -43,18 +59,33 @@ allows "changing the English store listing" feature/x \
   fastlane/metadata/android/en-US/full_description.txt
 
 blocks "hand-editing Russian" feature/x \
+  translations/app_ru.arb \
   translations/app_ru.arb
 
 blocks "hand-editing Russian alongside legitimate work" feature/x \
+  translations/app_ru.arb \
   lib/main.dart translations/app_en.arb translations/app_ru.arb
 
 blocks "hand-editing a language that does not exist yet" feature/x \
+  translations/app_de.arb \
   translations/app_de.arb
 
+# Moving the file is how it stops being Crowdin's export target while no line
+# of it changes. CI passes the old path of a rename as well as the new one.
+blocks "moving a translation out of the pattern" feature/x \
+  translations/app_ru.arb \
+  translations/locales/app_ru.arb translations/app_ru.arb
+
+blocks "adding a translation in a subdirectory" feature/x \
+  translations/locales/app_de.arb \
+  translations/locales/app_de.arb
+
 blocks "hand-editing a translated store listing" feature/x \
+  fastlane/metadata/android/ru-RU/full_description.txt \
   fastlane/metadata/android/ru-RU/full_description.txt
 
 blocks "hand-editing a translated changelog" feature/x \
+  fastlane/metadata/android/ru-RU/changelogs/1.txt \
   fastlane/metadata/android/ru-RU/changelogs/1.txt
 
 # crowdin.yml claims three texts per locale and nothing else. The screenshots
@@ -64,7 +95,8 @@ allows "replacing a translated screenshot" feature/x \
   fastlane/metadata/android/ru-RU/images/phoneScreenshots/1.png
 
 allows "changing a translated store title" feature/x \
-  fastlane/metadata/android/ru-RU/title.txt fastlane/metadata/android/ru-RU/video.txt
+  fastlane/metadata/android/ru-RU/title.txt \
+  fastlane/metadata/android/ru-RU/video.txt
 
 # The sync itself edits exactly these files; blocking it would stop every
 # translation from ever landing.
@@ -77,10 +109,24 @@ allows "the Crowdin sync adding a language" l10n/crowdin \
 # A branch merely named like the sync's is still the sync's branch by the only
 # means CI has of telling; what must not happen is a *similar* name passing.
 blocks "a branch that only looks like the sync branch" l10n/crowdin-fix \
+  translations/app_ru.arb \
   translations/app_ru.arb
 
 # Empty input is a change that touched nothing relevant, not a failure.
 allows "no changed files at all" feature/x ""
+
+# A path list that does not end in a newline must not lose its last entry.
+# Every other case here goes through printf, which always terminates.
+last_line_status=0
+last_line_out="$(printf 'lib/main.dart\ntranslations/app_ru.arb' \
+  | env -i PATH="$PATH" GITHUB_HEAD_REF=feature/x bash "$CHECK" 2>&1)" \
+  || last_line_status=$?
+if ((last_line_status == 1)) &&
+  [[ "$last_line_out" == *"::error file=translations/app_ru.arb::"* ]]; then
+  pass "input with no trailing newline"
+else
+  fail "input with no trailing newline (exit $last_line_status): $last_line_out"
+fi
 
 if ((failures)); then
   printf '\n%d check(s) failed\n' "$failures"

--- a/.github/scripts/check_translation_sources_test.sh
+++ b/.github/scripts/check_translation_sources_test.sh
@@ -161,6 +161,21 @@ else
   fail "crowdin.yml patterns were readable (found none)"
 fi
 
+# The sync's branch name is written in crowdin-rx.yml and again as this
+# script's default, with nothing linking the two. Rename it there and the guard
+# starts blocking the sync itself, which stops every translation from ever
+# landing - a failure that looks like Crowdin having gone quiet. run() clears
+# the environment, so this exercises the default rather than any local value.
+sync_branch="$(sed -nE \
+  's/^[[:space:]]*localization_branch_name:[[:space:]]*([^[:space:]]+).*/\1/p' \
+  "$HERE/../workflows/crowdin-rx.yml")"
+if [[ -n "$sync_branch" ]]; then
+  allows "the branch crowdin-rx.yml really syncs from ($sync_branch)" \
+    "$sync_branch" translations/app_ru.arb
+else
+  fail "crowdin-rx.yml names a localization branch"
+fi
+
 if ((failures)); then
   echo "$failures failure(s)" >&2
   exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,11 @@ jobs:
     name: Analyze and test
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # Reading the pull request's file list needs more than the workflow's
+    # default contents-only grant.
+    permissions:
+      contents: read
+      pull-requests: read
 
     steps:
       - name: Checkout
@@ -37,6 +42,29 @@ jobs:
 
       - name: Test the Android artifact verification
         run: .github/scripts/verify_apks_test.sh
+
+      - name: Test the translation source guard
+        run: .github/scripts/check_translation_sources_test.sh
+
+      # English is the only localization source in this repository; every other
+      # language is written in Crowdin and arrives through its pull request.
+      # Crowdin exports each file whole, so a hand edit here is reverted by the
+      # next sync rather than merged - which has already cost one manual repair.
+      # Asked of the API rather than worked out from the checkout: the clone is
+      # shallow, so the merge base needed for a three-dot diff is not
+      # necessarily present, and a two-dot one would flag any branch that has
+      # simply not been rebased since the last sync. Paginated, because a guard
+      # that silently stops looking after the first hundred files is a guard
+      # that a large enough pull request walks straight through.
+      - name: Check nothing edits a translation by hand
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api --paginate \
+            "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
+            --jq '.[].filename' \
+            | .github/scripts/check_translation_sources.sh
 
       # Catches what only running a workflow would otherwise catch, and the
       # release workflow only publishes on a tag.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,15 +55,24 @@ jobs:
       # necessarily present, and a two-dot one would flag any branch that has
       # simply not been rebased since the last sync. Paginated, because a guard
       # that silently stops looking after the first hundred files is a guard
-      # that a large enough pull request walks straight through.
+      # that a large enough pull request walks straight through - and asked for
+      # previous_filename too, because a rename reports only where the file
+      # landed, and moving one out of Crowdin's pattern breaks the sync just as
+      # thoroughly as editing it.
+      #
+      # shell: bash for the pipefail that a bare run block does not get. Left
+      # off, a failure to reach the API would empty the pipeline, the guard
+      # would find nothing to object to, and the check would pass green having
+      # examined no files at all.
       - name: Check nothing edits a translation by hand
         if: github.event_name == 'pull_request'
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh api --paginate \
             "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files" \
-            --jq '.[].filename' \
+            --jq '.[] | .filename, (.previous_filename // empty)' \
             | .github/scripts/check_translation_sources.sh
 
       # Catches what only running a workflow would otherwise catch, and the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,17 +46,16 @@ jobs:
       - name: Test the translation source guard
         run: .github/scripts/check_translation_sources_test.sh
 
-      # English is the only localization source in this repository; every other
-      # language is written in Crowdin and arrives through its pull request.
-      # Crowdin exports each file whole, so a hand edit here is reverted by the
-      # next sync rather than merged - which has already cost one manual repair.
-      # Asked of the API rather than worked out from the checkout: the clone is
-      # shallow, so the merge base needed for a three-dot diff is not
-      # necessarily present, and a two-dot one would flag any branch that has
-      # simply not been rebased since the last sync. Paginated, because a guard
-      # that silently stops looking after the first hundred files is a guard
-      # that a large enough pull request walks straight through - and asked for
-      # previous_filename too, because a rename reports only where the file
+      # Why any of this exists is in the script's own header. What is specific
+      # to running it here:
+      #
+      # The file list is asked of the API rather than worked out from the
+      # checkout, because the clone is shallow, so the merge base a three-dot
+      # diff needs is not necessarily present, and a two-dot one would flag any
+      # branch that simply has not been rebased since the last sync. Paginated,
+      # because a guard that stops looking after the first hundred files is one
+      # a large enough pull request walks straight through. And previous_filename
+      # as well as filename, because a rename reports only where the file
       # landed, and moving one out of Crowdin's pattern breaks the sync just as
       # thoroughly as editing it.
       #

--- a/README.md
+++ b/README.md
@@ -67,6 +67,24 @@ qUnleashed keeps the familiar companion-app workflows from the original Flipper 
 - **Pulse Plotter.** Visualize raw Sub-GHz/Infrared/RFID pulse captures with zooming, histograms and slicing helpers — open captures right from the archive.
 - **Saved Locations.** Parses synced archive files for latitude/longitude metadata, shows them as pins on an interactive map with the current phone position, distance, bearing and walking time, and links each pin back to the saved Flipper file.
 
+## Translations
+
+The app is translated on Crowdin. **Do not edit `translations/app_*.arb` by hand** — English is the only exception, because it is the source every other language is translated from.
+
+Crowdin exports each language file whole, so an edit made here is not merged with the next sync, it is reverted by it. That has already cost one manual repair of the Russian translation.
+
+- **To correct or add a translation**, work in Crowdin. It reaches this repository automatically, in a pull request opened by the sync.
+- **To add or change an English string**, edit `translations/app_en.arb`. It is uploaded to Crowdin when the change lands on `main`, and translators see it from there.
+- **To have a new language enabled**, open an issue asking for it. Enabling a language is done in Crowdin; once it has translations, the sync adds `translations/app_<code>.arb` on its own and the app picks the locale up with no code change.
+
+A CI check enforces this, so a pull request that edits a translated file fails rather than being merged and quietly undone.
+
+### Writing strings
+
+- Keep product names untranslated: **qUnleashed**, **Flipper**, **Flipper Zero**, and protocol names such as Sub-GHz, NFC, RFID, iButton.
+- Give every new key an `@key` description saying where it appears and, for a bare word, whether it is a verb or a noun. Translators see only the string and that description.
+- Name placeholders for what they hold (`{fileName}`, not `{arg0}`); the name is shown to translators.
+
 ## Support ApertureFox projects
 <p align="left">
   <a href="https://boosty.to/apfxtech/donate">

--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ Crowdin exports each language file whole, so an edit made here is not merged wit
 
 - **To correct or add a translation**, work in Crowdin. It reaches this repository automatically, in a pull request opened by the sync.
 - **To add or change an English string**, edit `translations/app_en.arb`. It is uploaded to Crowdin when the change lands on `main`, and translators see it from there.
-- **To have a new language enabled**, open an issue asking for it. Enabling a language is done in Crowdin; once it has translations, the sync adds `translations/app_<code>.arb` on its own and the app picks the locale up with no code change.
+- **To have a new language enabled**, open an issue asking for it. Enabling a language is done in Crowdin; once it has translations, the sync adds `translations/app_<code>.arb` on its own and the app offers the locale. The only thing the repository needs is the language's own name in `_localeNames` (`lib/services/localization/controller.dart`) — without it the picker lists the language by its code rather than as `Deutsch`.
 
-A CI check enforces this, so a pull request that edits a translated file fails rather than being merged and quietly undone.
+The Google Play listing works the same way: `short_description.txt`, `full_description.txt` and the changelogs are translated on Crowdin, so edit only the `en-US` copies. Screenshots, the icon, `title.txt` and `video.txt` are not on Crowdin and can be changed in any locale.
+
+A CI check enforces all of this, so a pull request that edits a translated file fails rather than being merged and quietly undone.
 
 ### Writing strings
 


### PR DESCRIPTION
English is the source of every string. Every other language is written in Crowdin and reaches this repository through the sync's pull request. Nothing enforced that, and the two writers do not merge — Crowdin exports each file whole, so an edit made here is *reverted* by the next sync rather than combined with it.

### What this prevents, and what it does not

The review pushed back hard on the justification I first wrote, and it was right to. I had cited `e0aed07` as the incident that proves the need. Reading that commit back, it does not: `e0aed07` repaired damage done by **#15, the Crowdin sync's own pull request**, on the branch this guard exempts. Had the guard existed then, #15 would have sailed through untouched.

What `e0aed07` actually is, is an example of the class this *does* block. It put 83 Russian strings back **by hand**, and its own message says what follows:

> Seeding Crowdin with these translations has to follow, or the next download will overwrite them again.

This guard would have stopped that commit — correctly. The repair belonged in Crowdin, the only place it would have survived. That is the honest case for it, so it is now the one written in the script.

The sync overwriting a good translation in the first place is a **different fault with a different fix**: Crowdin has never held this repository's translations, so it exports English for them. Seeding is that fix. Tracked in #49.

## What it does

`.github/scripts/check_translation_sources.sh` reads changed paths on stdin and fails on any translation except English. It reads paths rather than working them out, so the caller decides how to get the diff and the script is testable without a repository — which matters, because a guard that only runs on pull requests is otherwise unverifiable until it is wrong, and it can be wrong in two directions: block every change, or quietly permit the hand edits it exists to stop. Both directions are covered.

Of the store listing it claims only the three texts `crowdin.yml` names. The screenshots, the icon, `title.txt` and `video.txt` are kept here for every locale — blocking those would have left no way to change them at all.

CI feeds it the file list from the pull requests API. Not a diff against the base: the clone is shallow, so the merge base a three-dot diff needs is not necessarily present, and a two-dot one would flag any branch that simply has not been rebased since the last sync.

## Review found five ways it could have passed without looking

Worth listing, because a guard that fails open is worse than no guard — it converts an unnoticed problem into a green check.

1. **Committed non-executable.** `100644`, while every bare-invoked script beside it is `755`. CI would have hit `Permission denied` on its very first run — and the test step has no event condition, so this would have broken every push to `main` as well as every pull request. This clone has `core.filemode false`, so the bit needed setting in the index rather than the worktree.

2. **The pipeline could not fail.** A `run:` block with no `shell:` gets `bash -e`, not `-eo pipefail`, so the pipeline's status was the script's alone. Any failure to reach the API — a blip, a rate limit, a token scope — would have emptied the pipeline, and the guard would have found nothing to object to and said so, in green.

3. **`gh pr view --json files` stops at 100.** Confirmed empirically on a 122-file PR elsewhere: 100 paths back, and they come back sorted by path, so `translations/…` is among the first to fall off the end. A refactor touching 100+ files that also hand-edited `app_ru.arb` would have passed clean.

4. **`read` drops a final line with no newline.** `gh` terminates its output today, which made this latent rather than live — but the script advertises `git diff --name-only` as a producer, and would have skipped whichever file sorted last.

5. **Renames were invisible.** A rename reports only where the file landed, so `git mv translations/app_ru.arb translations/locales/` matched no pattern going in and nothing changed coming out. The API carries `previous_filename`; the guard now covers the whole of `translations/`, since a translation one directory down is no less broken for being harder to see.

And a sixth, in the tests rather than the guard: they asserted only that a blocked case exited non-zero, which a script that cannot start satisfies too — as it did, silently, during the review. They now assert the exit code *and* that the failure names the offending file. Ten mutations, including an unstartable script, are all caught.

## Keeping it honest about `crowdin.yml`

`crowdin.yml` declares what Crowdin owns; this script restates it in another syntax, and nothing was keeping the two in step. The direction that fails quietly is the dangerous one: add a file to `crowdin.yml` and not to the guard, and the guard allows it and goes on passing.

So the tests read every `translation:` pattern out of `crowdin.yml`, build a concrete path from each, and require the guard to block it. Verified by adding a `title.txt` entry to `crowdin.yml` — the suite fails, naming the path that fell through. A parser for the whole file would be disproportionate for four lines that have never changed; this catches the drift that matters at the cost of one `sed`.

## The escape hatch

A change on `l10n/crowdin` (env `CROWDIN_BRANCH`) is exempt — that is the sync doing its job, and blocking it would stop every translation from ever landing. Naming a branch that turns the check off, which is the point: this catches the mistake of not knowing the rule, and someone who does know it has a legitimate reason now and then. A branch merely *resembling* the sync's, like `l10n/crowdin-fix`, is still blocked.

That branch name was a bare literal here and again in `crowdin-rx.yml`, with nothing linking them — rename it there and the guard starts blocking the sync, which from the outside reads like Crowdin having gone quiet. The tests now take the name out of `crowdin-rx.yml` and require the default to exempt it. Verified by renaming it: the suite fails.

**Keyed on the branch, not the author**, although the sync's pull requests do arrive as `github-actions[bot]` and that looks like the sturdier signal. It is not — #40 is open to reopen them under a PAT or app token precisely so they trigger CI, which changes the author and leaves the branch alone. That reasoning is recorded in the script so it does not get helpfully improved into breaking.

## Order

Merge this **last** of the three:

1. **#71** — the string corrections. The last hand edit of `translations/app_ru.arb`, and what should be seeded.
2. **`fix/crowdin-seed`** — the two import options the seed depends on.
3. **The seed dispatch** — `gh workflow run crowdin-tx.yml -f seed_translations=true`, which is what stops Crowdin's copy being hollow and its exports being destructive.
4. **This.** Last, so that if the seed turns up something needing a repair commit, you are not fighting your own guard to make it.

## Still open afterwards

This does not touch **#40**, and #40 is the hole #15 fell through: the sync's pull requests currently run no checks at all — the last three CI runs on `l10n/crowdin` concluded `action_required`, `failure`, `action_required`, so nothing mechanical has been looking at them either. Worth doing next, and independent of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
