### PR TITLE
crowdin: set the two import options the seed depends on

### DIFF
--- a/.github/workflows/crowdin-tx.yml
+++ b/.github/workflows/crowdin-tx.yml
@@ -30,12 +30,27 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
 
+      # The two import options below only do anything when upload_translations
+      # is on, which is only ever the seed. They are set here rather than
+      # remembered on the day because getting either wrong is expensive to
+      # undo once 1,236 strings exist in the translation memory.
       - name: Upload sources
         uses: crowdin/github-action@v2
         with:
           config: crowdin.yml
           upload_sources: true
           upload_translations: ${{ inputs.seed_translations || false }}
+          # crowdin.yml sets update_as_unapproved, which is right for a string
+          # changed later but wrong for the seed: it would land a translation
+          # this repository has been shipping for months as something nobody
+          # has looked at, and export_only_approved would then omit all of it.
+          auto_approve_imported: true
+          # Crowdin drops a translation identical to its source unless told
+          # otherwise. Twenty-four messages here are the same in both
+          # languages on purpose - qUnleashed, NFC, Sub-GHz, iButton, OK,
+          # "{provider} · {design}" - and without this they arrive as
+          # untranslated, ready for a translator to helpfully render NFC.
+          import_eq_suggestions: true
           download_translations: false
           create_pull_request: false
         env:


### PR DESCRIPTION
Both options here only take effect when `upload_translations` is on, which is only ever the seed dispatch. So this is inert until that runs, and permanent afterwards. Setting them now rather than remembering on the day: getting either wrong is cheap to fix before 1,236 strings exist in a translation memory and expensive after.

I verified both inputs exist in `crowdin/github-action@v2` rather than assuming — an unknown input is silently ignored by GitHub Actions, so a typo here would have seeded incorrectly with no error anywhere.

## `auto_approve_imported: true`

`crowdin.yml` sets `update_option: update_as_unapproved`. That is the right default for a string edited later, and the wrong one for the seed: it would land a translation this repository has been shipping for months as something nobody has reviewed. Anything later gated on `export_only_approved` would then omit every word of it.

## `import_eq_suggestions: true`

Crowdin drops an uploaded translation that is identical to its source unless told otherwise. **24 messages are deliberately identical in both languages** — they are product names, abbreviations and pure-ICU compositions:

```
qUnleashed   NFC          Sub-GHz      iButton      Bad USB      U2F
JavaScript   Wardriving   DFU          OK           HW           Base64
Pixel Draw   All-the-plugins           DE AD ?? EF  a, b, c
fw {version}              UID {uid}    {category} · {brand}
{label} · {count}         {provider} · {design}
```

Without this they arrive as *untranslated*: the project sits ~2% short of complete for reasons nobody can see from the UI, and each one waits in a translator's queue inviting someone to render `NFC` into Russian.

## Order

Merge **after** #71, and dispatch the seed only once #71 is on `main`. The seed uploads from the repository checkout of `main`, so "seed from the local version" means landing the corrections first — otherwise the uncorrected strings are what enters the translation memory, and correcting them afterwards means correcting them in Crowdin instead.

Then:

```
gh workflow run crowdin-tx.yml -f seed_translations=true
```

The run summary prints translated and approved percentages per language, which is how to confirm 1,236 strings landed rather than 1,212.

## Afterwards

- The `seed_translations` input should be retired once used. A second run would push repository content over Crowdin's, which after #72 is backwards.
- #49 becomes testable: with Crowdin no longer holding an empty Russian, its exports stop being destructive. Worth checking `skip_untranslated_strings` against one RX output at that point, though after a complete seed it buys little — Crowdin exports the English source for an untranslated string, which is exactly what `gen-l10n` backfills anyway.
- #40 is the next real gap: the sync's pull requests still run no checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
