### PR TITLE
crowdin: retire the seed input now that it has been used

### DIFF
--- a/.github/workflows/crowdin-tx.yml
+++ b/.github/workflows/crowdin-tx.yml
@@ -9,11 +9,6 @@ on:
       - "fastlane/metadata/android/en-US/**"
       - "crowdin.yml"
   workflow_dispatch:
-    inputs:
-      seed_translations:
-        description: "Upload translations already in the repo (first run only)"
-        type: boolean
-        default: false
 
 permissions:
   contents: read
@@ -30,27 +25,19 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v7
 
-      # The two import options below only do anything when upload_translations
-      # is on, which is only ever the seed. They are set here rather than
-      # remembered on the day because getting either wrong is expensive to
-      # undo once 1,236 strings exist in the translation memory.
+      # Sources only, in one direction. Crowdin holds the translations now -
+      # seeded from this repository on 2026-09-11, run 34567567053, 1,241
+      # strings at 100% - so uploading them from here again would push a copy
+      # over the original. There is deliberately no way to ask for it: the
+      # seed_translations input this workflow used to carry has been removed
+      # now that it has served its one purpose, because the next person to
+      # find it would reasonably assume it was safe to run.
       - name: Upload sources
         uses: crowdin/github-action@v2
         with:
           config: crowdin.yml
           upload_sources: true
-          upload_translations: ${{ inputs.seed_translations || false }}
-          # crowdin.yml sets update_as_unapproved, which is right for a string
-          # changed later but wrong for the seed: it would land a translation
-          # this repository has been shipping for months as something nobody
-          # has looked at, and export_only_approved would then omit all of it.
-          auto_approve_imported: true
-          # Crowdin drops a translation identical to its source unless told
-          # otherwise. Twenty-four messages here are the same in both
-          # languages on purpose - qUnleashed, NFC, Sub-GHz, iButton, OK,
-          # "{provider} · {design}" - and without this they arrive as
-          # untranslated, ready for a translator to helpfully render NFC.
-          import_eq_suggestions: true
+          upload_translations: false
           download_translations: false
           create_pull_request: false
         env:


### PR DESCRIPTION
The seed has run — [run 34567567053](https://github.com/DarkFlippers/qUnleashed/actions/runs/34567567053), 1,241 strings, 100% translated and 100% approved — and #74 confirmed the round trip: RX came back proposing a single `@description` line, with zero Russian values reverted to English.

So Crowdin holds the translations now, and uploading them from here again would push a copy over the original.

## Why removed rather than switched off

An input labelled *"Upload translations already in the repo (first run only)"* reads like something safe to try. Whoever finds it next will not know that the direction has since reversed — that the repository is no longer the authority on anything but English. Leaving it present and defaulted to `false` preserves the invitation.

`workflow_dispatch` still works and still sends sources, which is the only direction that remains.

`auto_approve_imported` and `import_eq_suggestions` go with it. They applied only while translations were being uploaded, and configuration left behind after it stops doing anything invites the next reader to work out why it is there.

## Not included

An earlier version of this branch also added a glossary to the repository with a script to import it. Dropped: terminology belongs to the translators working in Crowdin, where the glossary lives natively and they can maintain it without a pull request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
