### PR TITLE
Make the ATP pack unpack survive a bad entry, and stop writing empty apps

### DIFF
--- a/lib/components/archive_unpack.dart
+++ b/lib/components/archive_unpack.dart
@@ -1,0 +1,33 @@
+/// What one unpack did with the archive entries it considered.
+///
+/// Every considered entry lands in exactly one of the three counts, which is
+/// what makes a quietly lost entry impossible to hide: a caller that reports
+/// only successes cannot tell a clean run from one that dropped half the
+/// archive on the floor.
+///
+/// Which entries are considered is the caller's to define and to document —
+/// the IR library weighs every file entry the decoder produced, while a plugin
+/// pack weighs only the `.fap` entries and ignores the rest outright.
+class UnpackTally {
+  const UnpackTally({
+    required this.extracted,
+    required this.skipped,
+    required this.dropped,
+    this.firstError,
+  });
+
+  /// Entries written to disk.
+  final int extracted;
+
+  /// Entries that resolved to a path but could not be written or read. Every
+  /// one is a file the user does not get.
+  final int skipped;
+
+  /// Entries the name check declined, such as a `..` traversal or anything
+  /// resolving outside the destination root. Real archives have some, so
+  /// these are not on their own a sign of trouble.
+  final int dropped;
+
+  /// The first failure, entry name included, for the log and the error message.
+  final String? firstError;
+}

--- a/lib/pages/apps/data/atp/atp_source.dart
+++ b/lib/pages/apps/data/atp/atp_source.dart
@@ -169,7 +169,10 @@ class AtpArchive {
 
   static final AtpArchive instance = AtpArchive._();
 
-  final Map<String, Future<void>> _unpacking = {};
+  /// Packs being unpacked right now, so two apps from the same pack share
+  /// one download rather than racing each other. Carries the tally so the
+  /// second caller gets the same reason as the first.
+  final Map<String, Future<UnpackTally>> _unpacking = {};
 
   Future<List<int>> fetchFap(
     AtpEntry entry,
@@ -183,14 +186,32 @@ class AtpArchive {
         '"${entry.archivePath}" is not a path the pack can hold',
       );
     }
+    UnpackTally? tally;
     if (!await file.exists()) {
       final key = '$tag/${entry.pack}';
-      await (_unpacking[key] ??= _unpack(entry.pack, url, tag, onProgress)
-        ..whenComplete(() => _unpacking.remove(key)));
+      // Chained, not cascaded. A cascade would store the unpack and throw away
+      // the future whenComplete returns - and when the unpack fails, that
+      // discarded future fails too, with nothing listening, so the error is
+      // reported to the zone as unhandled on top of the one the caller sees.
+      // Storing the derived future means the one awaited is the one that
+      // carries the cleanup.
+      tally = await (_unpacking[key] ??= _unpack(
+        entry.pack,
+        url,
+        tag,
+        onProgress,
+      ).whenComplete(() => _unpacking.remove(key)));
     }
     if (!await file.exists()) {
+      // Why it is missing, when the unpack knows. Without this the user is
+      // told the app is not in the pack for a problem on their own disk, and
+      // the real reason only reaches LogService - which is compiled out of a
+      // release build unless QLOG is set.
+      final reason = tally?.firstError;
       throw StateError(
-        '"${entry.archivePath}" is not in the ${entry.pack} pack',
+        '"${entry.archivePath}" is not in the ${entry.pack} pack'
+        '${reason == null ? '' : ' (${tally!.skipped} entries failed, '
+                  'first: $reason)'}',
       );
     }
     final bytes = await file.readAsBytes();
@@ -261,8 +282,12 @@ class AtpArchive {
     // and a pack puts many apps under the same few folders.
     final created = <String>{};
     Future<void> ensureDir(String path) async {
-      if (!created.add(path)) return;
+      if (created.contains(path)) return;
       await io.Directory(path).create(recursive: true);
+      // Recorded only on success, so a directory that failed to appear because
+      // something held it for a moment is retried rather than remembered as
+      // done - otherwise one transient lock fails every later app beside it.
+      created.add(path);
     }
 
     var extracted = 0;
@@ -271,7 +296,19 @@ class AtpArchive {
     String? firstError;
 
     for (final file in archive.files) {
-      if (!file.isFile || !file.name.endsWith('.fap')) continue;
+      if (!file.isFile) continue;
+
+      // ZipDecoder does not throw on an entry whose local header it cannot
+      // read: it yields a nameless one. The name is the only thing that says
+      // whether this was an app, so a nameless entry is a possible .fap that
+      // cannot be identified - count it rather than let it fall between the
+      // filter and the tally.
+      if (file.name.isEmpty) {
+        skipped += 1;
+        firstError ??= '<unnamed>: the archive entry could not be read';
+        continue;
+      }
+      if (!file.name.endsWith('.fap')) continue;
 
       final parts = file.name.split('/');
       final start = parts.indexWhere((e) => e.startsWith('artifacts-'));
@@ -288,14 +325,18 @@ class AtpArchive {
       }
 
       try {
-        // A null here means the entry has no readable content. Writing an
-        // empty file instead would leave a 0-byte .fap that exists, so
-        // fetchFap hands the installer an empty app rather than saying the
-        // app is not in the pack.
         final bytes = file.readBytes();
-        if (bytes == null) {
+        // Emptiness, not null, is the check that matters. ZipDecoder builds
+        // every entry with a backing stream, so for anything it produced
+        // readBytes returns an empty list rather than null - a zero-length
+        // entry and one whose payload could not be produced look the same.
+        // Either way a .fap is a compiled binary and is never legitimately
+        // empty, and writing one leaves a 0-byte file that exists: fetchFap
+        // then finds it, skips the unpack forever after, and hands the
+        // installer an empty app instead of saying it is not in the pack.
+        if (bytes == null || bytes.isEmpty) {
           skipped += 1;
-          firstError ??= '${file.name}: the archive entry could not be read';
+          firstError ??= '${file.name}: the archive entry had no content';
           continue;
         }
         final out = io.File(outPath);
@@ -308,11 +349,18 @@ class AtpArchive {
         // them, so without this the whole decompressed pack stays live.
         file.clear();
         extracted += 1;
+      } on FormatException catch (e) {
+        // A truncated or bit-rotted deflate stream, which is how a single
+        // entry most often goes bad - far likelier than the filesystem
+        // refusing it. ArchiveException extends FormatException, so the
+        // decoder's own errors land here too. Uncaught, one of these cost
+        // the whole pack.
+        skipped += 1;
+        firstError ??= '${file.name}: $e';
       } on io.FileSystemException catch (e) {
-        // Narrow on purpose. Every failure this tolerates is a
-        // FileSystemException - a reserved name, a full disk, a collision
-        // with something the archive already wrote there. Catching Object
-        // would fold a decoder bug into "the filesystem refused it".
+        // A reserved name, a full disk, a collision with something the
+        // archive already wrote there. Both arms stay narrow: catching
+        // Object would keep looping through an out-of-memory error.
         skipped += 1;
         firstError ??= '${file.name}: $e';
       }
@@ -326,7 +374,7 @@ class AtpArchive {
     );
   }
 
-  Future<void> _unpack(
+  Future<UnpackTally> _unpack(
     String pack,
     String url,
     String tag,
@@ -341,8 +389,16 @@ class AtpArchive {
         zip.path,
         onProgress: onProgress,
       );
-      final archive = ZipDecoder().decodeStream(InputFileStream(zip.path));
-      final tally = await unpackPackTo(archive, dir.path);
+      // Held so it can be closed. Left open, Windows refuses to delete the
+      // zip below - the failure is swallowed there - and every pack install
+      // leaks a handle and leaves a full copy of the pack behind.
+      final input = InputFileStream(zip.path);
+      final UnpackTally tally;
+      try {
+        tally = await unpackPackTo(ZipDecoder().decodeStream(input), dir.path);
+      } finally {
+        await input.close();
+      }
       final failure = failureFor(tally);
       if (failure != null) {
         throw StateError('the $pack pack could not be unpacked: $failure');
@@ -353,6 +409,7 @@ class AtpArchive {
                   '(first: ${tally.firstError})' : ''}'
         '${tally.dropped > 0 ? ', dropped ${tally.dropped}' : ''}',
       );
+      return tally;
     } finally {
       try {
         if (await zip.exists()) await zip.delete();

--- a/lib/pages/apps/data/atp/atp_source.dart
+++ b/lib/pages/apps/data/atp/atp_source.dart
@@ -5,6 +5,7 @@ import 'dart:io' as io;
 import 'package:archive/archive_io.dart';
 import 'package:flutter/foundation.dart';
 
+import '../../../../components/archive_unpack.dart';
 import '../../../../components/codec/bm.dart';
 import '../../../../components/codec/fap/icon.dart';
 import '../../../../components/path.dart';
@@ -217,6 +218,114 @@ class AtpArchive {
     return path == null ? null : io.File(path);
   }
 
+  /// Why [tally] should be reported as a failure, or null if the pack is
+  /// usable.
+  ///
+  /// Deliberately laxer than the IR library's equivalent, which fails once a
+  /// small share of entries is lost. A pack holds tens of apps rather than
+  /// thousands of remotes, so any share worth setting is either never reached
+  /// or reached by two bad names; and unlike a remote, a missing app is caught
+  /// precisely where it is used — [fetchFap] finds no file and says which app
+  /// is not in which pack. The case that has to fail here is the one that
+  /// check cannot improve on: nothing was written at all, so every app in the
+  /// pack would report itself missing, one at a time.
+  @visibleForTesting
+  static String? failureFor(UnpackTally tally) {
+    if (tally.extracted > 0) return null;
+    if (tally.skipped == 0 && tally.dropped == 0) {
+      return 'it contained no .fap entries';
+    }
+    if (tally.skipped == 0) {
+      return 'all ${tally.dropped} entries resolved outside the pack directory';
+    }
+    return 'all ${tally.skipped + tally.dropped} entries failed '
+        '(first: ${tally.firstError})';
+  }
+
+  /// Writes every `.fap` entry of [archive] under [rootPath], skipping the ones
+  /// that cannot be written or read instead of abandoning the whole pack.
+  ///
+  /// Only `.fap` entries are considered, so `extracted + skipped + dropped` is
+  /// their number and not the archive's — a pack also carries a manifest and
+  /// build logs, and those are ignored rather than counted as losses.
+  ///
+  /// Consumes [archive]: each entry's decompressed bytes are released once
+  /// written.
+  @visibleForTesting
+  static Future<UnpackTally> unpackPackTo(
+    Archive archive,
+    String rootPath, {
+    String? separator,
+  }) async {
+    // create(recursive: true) is not free when the directory is already there,
+    // and a pack puts many apps under the same few folders.
+    final created = <String>{};
+    Future<void> ensureDir(String path) async {
+      if (!created.add(path)) return;
+      await io.Directory(path).create(recursive: true);
+    }
+
+    var extracted = 0;
+    var skipped = 0;
+    var dropped = 0;
+    String? firstError;
+
+    for (final file in archive.files) {
+      if (!file.isFile || !file.name.endsWith('.fap')) continue;
+
+      final parts = file.name.split('/');
+      final start = parts.indexWhere((e) => e.startsWith('artifacts-'));
+      // The pack is a third-party download, so an entry that points out of
+      // the pack directory is dropped rather than written.
+      final outPath = resolveArchivePath(
+        rootPath,
+        parts.sublist(start >= 0 ? start + 1 : 0).join('/'),
+        separator: separator,
+      );
+      if (outPath == null) {
+        dropped += 1;
+        continue;
+      }
+
+      try {
+        // A null here means the entry has no readable content. Writing an
+        // empty file instead would leave a 0-byte .fap that exists, so
+        // fetchFap hands the installer an empty app rather than saying the
+        // app is not in the pack.
+        final bytes = file.readBytes();
+        if (bytes == null) {
+          skipped += 1;
+          firstError ??= '${file.name}: the archive entry could not be read';
+          continue;
+        }
+        final out = io.File(outPath);
+        await ensureDir(out.parent.path);
+        // Deliberately unflushed: the zip is re-downloadable and an
+        // interrupted unpack already leaves a partial tree, so an fsync per
+        // app buys nothing for what it costs.
+        await out.writeAsBytes(bytes);
+        // readBytes caches the inflated bytes on the entry and nothing frees
+        // them, so without this the whole decompressed pack stays live.
+        file.clear();
+        extracted += 1;
+      } on io.FileSystemException catch (e) {
+        // Narrow on purpose. Every failure this tolerates is a
+        // FileSystemException - a reserved name, a full disk, a collision
+        // with something the archive already wrote there. Catching Object
+        // would fold a decoder bug into "the filesystem refused it".
+        skipped += 1;
+        firstError ??= '${file.name}: $e';
+      }
+    }
+
+    return UnpackTally(
+      extracted: extracted,
+      skipped: skipped,
+      dropped: dropped,
+      firstError: firstError,
+    );
+  }
+
   Future<void> _unpack(
     String pack,
     String url,
@@ -233,24 +342,17 @@ class AtpArchive {
         onProgress: onProgress,
       );
       final archive = ZipDecoder().decodeStream(InputFileStream(zip.path));
-      var written = 0;
-      for (final file in archive.files) {
-        if (!file.isFile || !file.name.endsWith('.fap')) continue;
-        final parts = file.name.split('/');
-        final start = parts.indexWhere((e) => e.startsWith('artifacts-'));
-        // The pack is a third-party download, so an entry that points out of
-        // the pack directory is dropped rather than written.
-        final outPath = resolveArchivePath(
-          dir.path,
-          parts.sublist(start >= 0 ? start + 1 : 0).join('/'),
-        );
-        if (outPath == null) continue;
-        final out = io.File(outPath);
-        await out.parent.create(recursive: true);
-        await out.writeAsBytes(file.readBytes() ?? const [], flush: true);
-        written++;
+      final tally = await unpackPackTo(archive, dir.path);
+      final failure = failureFor(tally);
+      if (failure != null) {
+        throw StateError('the $pack pack could not be unpacked: $failure');
       }
-      LogService.log('[ATP] unpacked $written apps from the $pack pack');
+      LogService.log(
+        '[ATP] unpacked ${tally.extracted} apps from the $pack pack'
+        '${tally.skipped > 0 ? ', skipped ${tally.skipped} '
+                  '(first: ${tally.firstError})' : ''}'
+        '${tally.dropped > 0 ? ', dropped ${tally.dropped}' : ''}',
+      );
     } finally {
       try {
         if (await zip.exists()) await zip.delete();

--- a/lib/pages/tools/infrared/local_repo.dart
+++ b/lib/pages/tools/infrared/local_repo.dart
@@ -1,4 +1,3 @@
-import '../../../services/localization/l10n.dart';
 import 'dart:async';
 import 'dart:io' as io;
 import 'dart:isolate';
@@ -6,8 +5,10 @@ import 'dart:isolate';
 import 'package:archive/archive_io.dart';
 import 'package:path_provider/path_provider.dart';
 
+import '../../../components/archive_unpack.dart';
 import '../../../components/path.dart';
 import '../../../services/http/app_http.dart';
+import '../../../services/localization/l10n.dart';
 import '../../../services/logging.dart';
 import '../../../services/storage/paths.dart';
 
@@ -278,6 +279,9 @@ class IrLibLocalRepo {
   /// something the archive itself already wrote there. Any one of those used to
   /// abort the import of the whole library.
   ///
+  /// Every file entry the decoder produced is counted, so
+  /// `extracted + skipped + dropped` is that number exactly.
+  ///
   /// Consumes [archive]: each entry's decompressed bytes are released once
   /// written, so the entries are empty when this returns.
   static UnpackTally unpackWrappedArchiveTo(
@@ -410,34 +414,6 @@ class _UnpackArgs {
   final String rootPath;
   final String sep;
   final SendPort sendPort;
-}
-
-/// What one unpack did with an archive's file entries. Every file entry lands
-/// in exactly one of the three counts, so `extracted + skipped + dropped` is
-/// the number the decoder produced - which is what makes a quietly lost entry
-/// impossible to hide.
-class UnpackTally {
-  const UnpackTally({
-    required this.extracted,
-    required this.skipped,
-    required this.dropped,
-    this.firstError,
-  });
-
-  /// Entries written to disk.
-  final int extracted;
-
-  /// Entries that resolved to a path but could not be written, plus entries the
-  /// decoder could not even name. Every one is a file the user does not get.
-  final int skipped;
-
-  /// Entries the name check declined: the wrapper folder itself, anything
-  /// beside it rather than inside it, and any `..` traversal. Every real
-  /// archive has some, so these are not a loss.
-  final int dropped;
-
-  /// The first failure, entry name included, for the log and the error message.
-  final String? firstError;
 }
 
 /// Progress while the loop runs. Deliberately carries nothing about failures:

--- a/test/atp_unpack_test.dart
+++ b/test/atp_unpack_test.dart
@@ -1,0 +1,226 @@
+import 'dart:io';
+
+import 'package:archive/archive_io.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qunleashed/components/archive_unpack.dart';
+import 'package:qunleashed/pages/apps/data/atp/atp_source.dart';
+
+/// A pack zip wraps its apps in a per-build folder whose name starts with
+/// `artifacts-`; everything before and including it is stripped.
+const String wrapper = 'artifacts-0.0.1';
+
+final String sep = Platform.pathSeparator;
+
+Archive archiveOf(Map<String, String?> entries) {
+  final archive = Archive();
+  entries.forEach((name, content) {
+    if (name.endsWith('/')) {
+      archive.add(ArchiveFile.directory(name));
+    } else if (content == null) {
+      // What the decoder yields for an entry whose content it cannot read:
+      // named, marked a file, and empty. readBytes() returns null for it.
+      archive.add(ArchiveFile.noData(name));
+    } else {
+      archive.add(ArchiveFile.string(name, content));
+    }
+  });
+  return archive;
+}
+
+void main() {
+  late Directory base;
+  late Directory root;
+
+  setUp(() {
+    base = Directory.systemTemp.createTempSync('atp_unpack_test');
+    // root sits inside base so an entry that escapes it still lands somewhere
+    // the test owns and can assert on.
+    root = Directory('${base.path}${sep}pack')..createSync();
+  });
+
+  tearDown(() {
+    if (base.existsSync()) base.deleteSync(recursive: true);
+  });
+
+  Future<UnpackTally> unpack(Map<String, String?> entries) =>
+      AtpArchive.unpackPackTo(archiveOf(entries), root.path, separator: sep);
+
+  String read(String relative) => File(
+    '${root.path}$sep${relative.replaceAll('/', sep)}',
+  ).readAsStringSync();
+
+  bool exists(String relative) =>
+      File('${root.path}$sep${relative.replaceAll('/', sep)}').existsSync();
+
+  group('unpacking a pack', () {
+    test('writes the apps and strips the artifacts wrapper', () async {
+      final tally = await unpack({
+        '$wrapper/hello.fap': 'hello bytes',
+        '$wrapper/games/snake.fap': 'snake bytes',
+      });
+
+      expect(tally.extracted, 2);
+      expect(read('hello.fap'), 'hello bytes');
+      expect(read('games/snake.fap'), 'snake bytes');
+    });
+
+    test('ignores everything that is not a .fap', () async {
+      final tally = await unpack({
+        '$wrapper/hello.fap': 'hello bytes',
+        '$wrapper/manifest.txt': 'not an app',
+        '$wrapper/build.log': 'noise',
+        '$wrapper/logs/': null,
+      });
+
+      // Ignored, not dropped: the pack carries these on purpose, and counting
+      // them as losses would make a healthy pack look damaged.
+      expect(tally.extracted, 1);
+      expect(tally.skipped, 0);
+      expect(tally.dropped, 0);
+      expect(exists('manifest.txt'), isFalse);
+    });
+
+    test('takes an entry that has no wrapper at all', () async {
+      final tally = await unpack({'hello.fap': 'hello bytes'});
+
+      expect(tally.extracted, 1);
+      expect(read('hello.fap'), 'hello bytes');
+    });
+
+    test('strips everything up to and including the wrapper', () async {
+      await unpack({'some/where/$wrapper/deep/hello.fap': 'hello bytes'});
+
+      expect(read('deep/hello.fap'), 'hello bytes');
+    });
+  });
+
+  group('entries that cannot be written', () {
+    // The defect this fixes: one bad entry used to abort the whole pack, so
+    // the user got none of the apps rather than all but one.
+    test('a traversal is dropped and the rest still land', () async {
+      final tally = await unpack({
+        '$wrapper/../escaped.fap': 'nope',
+        '$wrapper/hello.fap': 'hello bytes',
+      });
+
+      expect(tally.extracted, 1);
+      expect(tally.dropped, 1);
+      expect(read('hello.fap'), 'hello bytes');
+      expect(File('${base.path}${sep}escaped.fap').existsSync(), isFalse);
+    });
+
+    // The second defect: `readBytes() ?? const []` wrote a 0-byte .fap and
+    // counted it installed. fetchFap then found a file, so the installer got
+    // an empty app instead of being told the app was not in the pack.
+    test('an unreadable entry is skipped, not written empty', () async {
+      final tally = await unpack({
+        '$wrapper/broken.fap': null,
+        '$wrapper/hello.fap': 'hello bytes',
+      });
+
+      expect(tally.extracted, 1);
+      expect(tally.skipped, 1);
+      expect(exists('broken.fap'), isFalse);
+      expect(tally.firstError, contains('broken.fap'));
+    });
+
+    // The filesystem refusing one entry is what #22 was filed for on the IR
+    // side, and what aborted the whole pack here. A directory sitting where
+    // the .fap must go is the cheapest way to make a real FileSystemException
+    // rather than a simulated one.
+    test(
+      'a write the filesystem refuses is skipped, the rest still land',
+      () async {
+        Directory('${root.path}${sep}blocked.fap').createSync(recursive: true);
+
+        final tally = await unpack({
+          '$wrapper/blocked.fap': 'cannot land',
+          '$wrapper/hello.fap': 'hello bytes',
+        });
+
+        expect(tally.extracted, 1);
+        expect(tally.skipped, 1);
+        expect(tally.firstError, contains('blocked.fap'));
+        expect(read('hello.fap'), 'hello bytes');
+      },
+    );
+
+    test('a parent directory that cannot be made is skipped', () async {
+      // A file where the entry's folder needs to be: creating the directory
+      // fails, which must cost that entry and nothing else.
+      File('${root.path}${sep}games').writeAsStringSync('in the way');
+
+      final tally = await unpack({
+        '$wrapper/games/snake.fap': 'snake bytes',
+        '$wrapper/hello.fap': 'hello bytes',
+      });
+
+      expect(tally.extracted, 1);
+      expect(tally.skipped, 1);
+      expect(read('hello.fap'), 'hello bytes');
+    });
+
+    test('the first failure is the one reported', () async {
+      final tally = await unpack({
+        '$wrapper/first.fap': null,
+        '$wrapper/second.fap': null,
+      });
+
+      expect(tally.skipped, 2);
+      expect(tally.firstError, contains('first.fap'));
+      expect(tally.firstError, isNot(contains('second.fap')));
+    });
+
+    test('every .fap entry is counted exactly once', () async {
+      final tally = await unpack({
+        '$wrapper/good.fap': 'bytes',
+        '$wrapper/broken.fap': null,
+        '$wrapper/../escaped.fap': 'nope',
+        '$wrapper/notes.txt': 'ignored',
+      });
+
+      expect(tally.extracted + tally.skipped + tally.dropped, 3);
+    });
+  });
+
+  group('deciding whether the pack is usable', () {
+    UnpackTally tally({
+      int extracted = 0,
+      int skipped = 0,
+      int dropped = 0,
+      String? firstError,
+    }) => UnpackTally(
+      extracted: extracted,
+      skipped: skipped,
+      dropped: dropped,
+      firstError: firstError,
+    );
+
+    test('one app written is enough, whatever else was lost', () {
+      // Laxer than the IR library on purpose: a missing app is reported by
+      // name when someone tries to install it, so a partial pack is worth
+      // more to the user than no pack at all.
+      expect(AtpArchive.failureFor(tally(extracted: 1, skipped: 99)), isNull);
+    });
+
+    test('a pack carrying no apps fails', () {
+      expect(AtpArchive.failureFor(tally()), contains('no .fap entries'));
+    });
+
+    test('a pack whose entries all escaped fails', () {
+      expect(
+        AtpArchive.failureFor(tally(dropped: 3)),
+        contains('outside the pack directory'),
+      );
+    });
+
+    test('a pack nothing could be written from fails, with the reason', () {
+      expect(
+        AtpArchive.failureFor(
+          tally(skipped: 2, dropped: 1, firstError: 'a.fap: disk full'),
+        ),
+        allOf(contains('all 3 entries failed'), contains('disk full')),
+      );
+    });
+  });
+}

--- a/test/atp_unpack_test.dart
+++ b/test/atp_unpack_test.dart
@@ -1,4 +1,6 @@
+import 'dart:convert';
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:archive/archive_io.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -6,26 +8,17 @@ import 'package:qunleashed/components/archive_unpack.dart';
 import 'package:qunleashed/pages/apps/data/atp/atp_source.dart';
 
 /// A pack zip wraps its apps in a per-build folder whose name starts with
-/// `artifacts-`; everything before and including it is stripped.
+/// `artifacts-`; everything up to and including it is stripped.
 const String wrapper = 'artifacts-0.0.1';
 
 final String sep = Platform.pathSeparator;
 
-Archive archiveOf(Map<String, String?> entries) {
-  final archive = Archive();
-  entries.forEach((name, content) {
-    if (name.endsWith('/')) {
-      archive.add(ArchiveFile.directory(name));
-    } else if (content == null) {
-      // What the decoder yields for an entry whose content it cannot read:
-      // named, marked a file, and empty. readBytes() returns null for it.
-      archive.add(ArchiveFile.noData(name));
-    } else {
-      archive.add(ArchiveFile.string(name, content));
-    }
-  });
-  return archive;
-}
+/// Content large enough that the encoder deflates it rather than storing it,
+/// so corrupting the payload actually breaks an inflate.
+final String compressible = List.filled(
+  400,
+  'the quick brown fox jumps over it. ',
+).join();
 
 void main() {
   late Directory base;
@@ -42,8 +35,87 @@ void main() {
     if (base.existsSync()) base.deleteSync(recursive: true);
   });
 
-  Future<UnpackTally> unpack(Map<String, String?> entries) =>
-      AtpArchive.unpackPackTo(archiveOf(entries), root.path, separator: sep);
+  /// Builds a real zip and reads it back through ZipDecoder, which is the only
+  /// way to get the entry shapes production sees. Hand-built `Archive` objects
+  /// can express entries the decoder never produces - `ArchiveFile.noData`
+  /// gives a null `readBytes()`, while a decoded zero-length entry gives an
+  /// empty list - and a test built on one of those proves nothing about the
+  /// code that has to cope with the other.
+  Archive decodedZip(
+    Map<String, String> entries, {
+    String? corruptPayloadOf,
+    String? breakHeaderOf,
+  }) {
+    final source = Archive();
+    entries.forEach((name, content) {
+      source.add(
+        name.endsWith('/')
+            ? ArchiveFile.directory(name)
+            : ArchiveFile.bytes(name, Uint8List.fromList(utf8.encode(content))),
+      );
+    });
+    final bytes = Uint8List.fromList(ZipEncoder().encode(source));
+
+    /// Where an entry's name starts in its local header.
+    int nameAt(String name) {
+      final marker = utf8.encode(name);
+      for (var i = 0; i + marker.length < bytes.length; i++) {
+        var hit = true;
+        for (var j = 0; j < marker.length; j++) {
+          if (bytes[i + j] != marker[j]) {
+            hit = false;
+            break;
+          }
+        }
+        if (hit) return i;
+      }
+      fail('entry "$name" not found in the encoded zip');
+    }
+
+    if (corruptPayloadOf != null) {
+      // The payload follows the name, so writing well past the name lands
+      // inside the deflate stream and leaves the name and every other entry's
+      // header intact - exactly one entry goes bad, and it goes bad on read.
+      final at = nameAt(corruptPayloadOf) + corruptPayloadOf.length;
+      for (var i = at + 40; i < at + 80 && i < bytes.length; i++) {
+        bytes[i] = 0x00;
+      }
+    }
+
+    if (breakHeaderOf != null) {
+      // A local file header is 30 fixed bytes and then the name, so the
+      // signature sits 30 bytes back. Break it and the decoder cannot read the
+      // header at all: it still lists the entry from the central directory,
+      // but with no name - which is the shape that used to slip past the .fap
+      // filter and be counted nowhere.
+      final signature = nameAt(breakHeaderOf) - 30;
+      expect(signature, greaterThanOrEqualTo(0));
+      for (var i = signature; i < signature + 4; i++) {
+        bytes[i] = 0x00;
+      }
+    }
+
+    final path = '${base.path}${sep}source.zip';
+    File(path).writeAsBytesSync(bytes);
+    final input = InputFileStream(path);
+    final archive = ZipDecoder().decodeStream(input);
+    addTearDown(input.close);
+    return archive;
+  }
+
+  Future<UnpackTally> unpack(
+    Map<String, String> entries, {
+    String? corruptPayloadOf,
+    String? breakHeaderOf,
+  }) => AtpArchive.unpackPackTo(
+    decodedZip(
+      entries,
+      corruptPayloadOf: corruptPayloadOf,
+      breakHeaderOf: breakHeaderOf,
+    ),
+    root.path,
+    separator: sep,
+  );
 
   String read(String relative) => File(
     '${root.path}$sep${relative.replaceAll('/', sep)}',
@@ -69,7 +141,6 @@ void main() {
         '$wrapper/hello.fap': 'hello bytes',
         '$wrapper/manifest.txt': 'not an app',
         '$wrapper/build.log': 'noise',
-        '$wrapper/logs/': null,
       });
 
       // Ignored, not dropped: the pack carries these on purpose, and counting
@@ -95,8 +166,8 @@ void main() {
   });
 
   group('entries that cannot be written', () {
-    // The defect this fixes: one bad entry used to abort the whole pack, so
-    // the user got none of the apps rather than all but one.
+    // The defect: one bad entry used to abort the whole pack, so the user got
+    // none of the apps rather than all but one.
     test('a traversal is dropped and the rest still land', () async {
       final tally = await unpack({
         '$wrapper/../escaped.fap': 'nope',
@@ -109,25 +180,40 @@ void main() {
       expect(File('${base.path}${sep}escaped.fap').existsSync(), isFalse);
     });
 
-    // The second defect: `readBytes() ?? const []` wrote a 0-byte .fap and
-    // counted it installed. fetchFap then found a file, so the installer got
-    // an empty app instead of being told the app was not in the pack.
-    test('an unreadable entry is skipped, not written empty', () async {
+    // The likeliest way a single entry goes bad, and the one a
+    // FileSystemException-only handler misses: readBytes throws
+    // FormatException on a stream it cannot inflate.
+    test('a corrupt payload is skipped and the rest still land', () async {
       final tally = await unpack({
-        '$wrapper/broken.fap': null,
+        '$wrapper/rotten.fap': compressible,
+        '$wrapper/hello.fap': 'hello bytes',
+      }, corruptPayloadOf: '$wrapper/rotten.fap');
+
+      expect(tally.extracted, 1);
+      expect(tally.skipped, 1);
+      expect(tally.firstError, contains('rotten.fap'));
+      expect(exists('rotten.fap'), isFalse);
+      expect(read('hello.fap'), 'hello bytes');
+    });
+
+    // The second defect: `readBytes() ?? const []` wrote a 0-byte .fap and
+    // counted it installed. A decoded zero-length entry yields an empty list
+    // rather than null, so emptiness is what has to be checked - and a .fap
+    // is a compiled binary that is never legitimately empty.
+    test('an entry with no content is skipped, not written empty', () async {
+      final tally = await unpack({
+        '$wrapper/empty.fap': '',
         '$wrapper/hello.fap': 'hello bytes',
       });
 
       expect(tally.extracted, 1);
       expect(tally.skipped, 1);
-      expect(exists('broken.fap'), isFalse);
-      expect(tally.firstError, contains('broken.fap'));
+      expect(exists('empty.fap'), isFalse);
+      expect(tally.firstError, contains('empty.fap'));
     });
 
-    // The filesystem refusing one entry is what #22 was filed for on the IR
-    // side, and what aborted the whole pack here. A directory sitting where
-    // the .fap must go is the cheapest way to make a real FileSystemException
-    // rather than a simulated one.
+    // A directory sitting where the .fap must go is the cheapest way to make
+    // a real FileSystemException rather than a simulated one.
     test(
       'a write the filesystem refuses is skipped, the rest still land',
       () async {
@@ -160,21 +246,40 @@ void main() {
       expect(read('hello.fap'), 'hello bytes');
     });
 
+    // An entry whose local header cannot be read comes back with no name at
+    // all. The name is the only thing that says whether it was an app, so it
+    // has to be counted rather than quietly skipped by the .fap filter - a
+    // pack of 40 good apps and 5 of these would otherwise report 40 unpacked
+    // and no sign that anything was lost.
+    test(
+      'an entry with an unreadable header is counted, not ignored',
+      () async {
+        final tally = await unpack({
+          '$wrapper/headerless.fap': compressible,
+          '$wrapper/hello.fap': 'hello bytes',
+        }, breakHeaderOf: '$wrapper/headerless.fap');
+
+        expect(tally.skipped, 1);
+        expect(tally.firstError, contains('unnamed'));
+        expect(read('hello.fap'), 'hello bytes');
+      },
+    );
+
     test('the first failure is the one reported', () async {
       final tally = await unpack({
-        '$wrapper/first.fap': null,
-        '$wrapper/second.fap': null,
+        '$wrapper/aaa.fap': '',
+        '$wrapper/zzz.fap': '',
       });
 
       expect(tally.skipped, 2);
-      expect(tally.firstError, contains('first.fap'));
-      expect(tally.firstError, isNot(contains('second.fap')));
+      expect(tally.firstError, contains('aaa.fap'));
+      expect(tally.firstError, isNot(contains('zzz.fap')));
     });
 
     test('every .fap entry is counted exactly once', () async {
       final tally = await unpack({
         '$wrapper/good.fap': 'bytes',
-        '$wrapper/broken.fap': null,
+        '$wrapper/empty.fap': '',
         '$wrapper/../escaped.fap': 'nope',
         '$wrapper/notes.txt': 'ignored',
       });

--- a/test/ir_unpack_test.dart
+++ b/test/ir_unpack_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:archive/archive_io.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:qunleashed/components/archive_unpack.dart';
 import 'package:qunleashed/pages/tools/infrared/local_repo.dart';
 
 /// The IRDB zip wraps its whole tree in one top-level folder, which


### PR DESCRIPTION
The loop in `lib/pages/apps/data/atp/atp_source.dart` is the same shape the IR library unpack was before #61, and carried the same two defects #22 and #24 described — in a place neither issue looked.

**The first commit on this branch did not actually fix either of them.** Review caught it; the second commit does. That is worth reading before the rest, because the reason is not obvious and the tests were complicit.

## What the decoder actually produces

Both of my original guards were written against failure shapes `ZipDecoder` never emits. Probed against `archive` 4.0.9 rather than argued:

```
untouched zero-length entry  ->  readBytes = len 0, not null
corrupted deflate payload    ->  readBytes THREW FormatException, isFSE=false
ArchiveFile.noData           ->  readBytes = NULL   (decoder never builds one)
```

So:

- **`bytes == null` was dead code.** The 0-byte `.fap` was still written and still counted installed. And the tests passed because they built entries with `ArchiveFile.noData`, which *does* return null — a constructor `ZipDecoder` never uses. A green suite concealing the exact bug it was written for.
- **`on io.FileSystemException` missed the likeliest bad entry there is.** A truncated or bit-rotted deflate stream throws `FormatException`, which walked straight out of the loop and cost the whole pack — precisely the defect being fixed.

The tests are now built on real zips: encoded with `ZipEncoder`, corrupted at a computed offset, and read back through `ZipDecoder`.

## One unwritable entry aborted the whole pack

No per-entry handler. The only `try` was the outer one whose `finally` deletes the temp zip, so any failure propagated and the user got **none** of the apps rather than all but one.

Now caught per entry, in two narrow arms — `FormatException` for a payload that will not inflate (`ArchiveException` extends it, so the decoder's own errors land there too) and `FileSystemException` for a reserved name, a full disk, or a collision. Nothing wider: catching `Object` would keep looping through an out-of-memory error.

## A 0-byte `.fap` that looked installed

`file.readBytes() ?? const []` wrote an empty file and counted it. Tracing it through the consumer shows why that is worse than it reads — `fetchFap` decides an app is present by asking `file.exists()`:

```dart
if (!await file.exists()) {
  throw StateError('"${entry.archivePath}" is not in the ${entry.pack} pack');
}
final bytes = await file.readAsBytes();   // -> []
```

The file existed, the guard passed, the installer got an empty app. And it was **sticky**: `fetchFap` only re-unpacks when the file is *absent*, so the 0-byte file survived every retry, with no way back short of wiping the ATP cache.

Emptiness is the check that matters, not nullness — a `.fap` is a compiled binary and is never legitimately empty.

## Three more the review found

- **Nameless entries vanished.** An entry whose local header cannot be read comes back with no name; the name is the only thing that says whether it was an app, so it slipped past the `.fap` filter and was counted nowhere. Forty good apps and five of these reported "unpacked 40" with no sign anything was lost.
- **The `InputFileStream` was never closed.** Windows then refuses to delete the temp zip, the failure is swallowed by the `catch (_)` around it, and every pack install leaks a handle and leaves a full copy of the pack behind. The IR path closes its own; this one now does too.
- **`ensureDir` recorded a directory before creating it**, so one transient lock failed every later app beside it instead of being retried. The IR version records only on success and says why.

## Reporting, and a disk error that blamed the pack

The unpack returns a tally — written, skipped, dropped, first error — and fails the pack only when nothing was written. That is **deliberately laxer than the IR library's** floor-and-share policy, and the reasoning is in the code: a pack holds tens of apps rather than thousands of remotes, so any share worth setting is either never reached or reached by two bad names, and a missing app is already reported by name at the point of installation.

But the review found the flaw in resting on that: the evidence went only to `LogService`, which is `bool.fromEnvironment('QLOG', defaultValue: kDebugMode)` — **compiled out of release builds**. So a full disk reached the user as *"this app is not in the pack"*, blaming the pack maintainer for a problem on their own disk. `fetchFap` now carries the tally's first error into what it throws.

## Also fixed: a doubled error on every failure

`fetchFap` memoised the unpack with a cascade:

```dart
await (_unpacking[key] ??= _unpack(...)..whenComplete(() => _unpacking.remove(key)));
```

The cascade stores the *original* future and discards the one `whenComplete` returns — so when the unpack fails, that discarded future fails too with nothing listening, and the error is reported to the zone as unhandled *on top of* the one the caller sees. Demonstrated:

```
chained (.whenComplete) : escaped=0  keyRemoved=true
cascade (..whenComplete): escaped=1  keyRemoved=true
```

Pre-existing, but this change makes `_unpack` throw where it never used to, so it would have started firing. One character.

## `UnpackTally` moves to `components/`

Written for the IR library but says nothing specific to it, and the alternative was a second identical value type.

Moving it exposed something: the class documented an invariant — `extracted + skipped + dropped` equals every file entry the decoder produced — that is **false for ATP**, which ignores the manifest and build logs rather than counting them as losses. The denominator now lives on each loop, where it can be stated accurately.

## Tests

None existed for this file. There are now 16, on real decoded zips.

Checked against the code they replace rather than trusted because they pass — **five mutations, all caught**:

| Mutation | Caught by |
|---|---|
| the exact original loop body (no empty check, no `FormatException` arm) | the corrupt-payload and no-content tests |
| `FileSystemException` only — my own first broken guard | a corrupt payload is skipped and the rest still land |
| nameless entry not counted | an entry with an unreadable header is counted, not ignored |
| containment check made a silent `continue` | a traversal is dropped and the rest still land |
| `failureFor` never fails | the three policy tests |

## Scope

Two things checked and deliberately left out:

- **#62's atomicity fix does not transfer.** `IrLibLocalRepo.download()` deletes the whole library before fetching a byte; ATP's `_unpack` deletes nothing, and `fetchFap` only unpacks when a specific app is missing, so an interrupted unpack self-heals on the next request.
- **Sharing the loop with the IR unpack** stays out, as #61 and #63 both already argued: different wrapper algorithms, different entry filters, different decoder failure signals, sync-in-isolate versus async-on-main, different failure policies.

Closes #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
