### PR TITLE
Stop a reconnect that races the initial open from being dropped

### DIFF
--- a/lib/pages/tools/remote/desktop/session.dart
+++ b/lib/pages/tools/remote/desktop/session.dart
@@ -116,11 +116,24 @@ class RemoteSession extends ChangeNotifier {
         // this one runs asks for another after it.
         _restartWanted = false;
         try {
+          // All three at rightNow, and checked for teardown between each. The
+          // queue sorts by priority before arrival order, so a subscribe left
+          // at the default would be overtaken by the rightNow unsubscribe that
+          // shutdown sends — the device would then be told to start pushing
+          // desktop status after being told to stop, and _stopRemote latches
+          // itself off, so nothing would ever unsubscribe it again.
           await _client.guiStartScreenStream(
             priority: FlipperRequestPriority.rightNow,
           );
-          await _client.desktopStatusSubscribe();
-          final frames = await _client.desktopIsLocked();
+          if (_disposed) return;
+          await _client.desktopStatusSubscribe(
+            priority: FlipperRequestPriority.rightNow,
+          );
+          if (_disposed) return;
+          final frames = await _client.desktopIsLocked(
+            priority: FlipperRequestPriority.rightNow,
+          );
+          if (_disposed) return;
           for (final f in frames) {
             if (f.hasDesktopStatus()) _applyStatus(f.desktopStatus);
           }

--- a/lib/pages/tools/remote/desktop/session.dart
+++ b/lib/pages/tools/remote/desktop/session.dart
@@ -50,6 +50,7 @@ class RemoteSession extends ChangeNotifier {
   Timer? _unlockedFlashTimer;
   bool _isDisconnected = false;
   bool _starting = false;
+  bool _restartWanted = false;
   bool _disposed = false;
   bool _stopped = false;
 
@@ -82,24 +83,45 @@ class RemoteSession extends ChangeNotifier {
 
   /// Asks for the stream straight away — a stale "not connected" flag must not
   /// keep the page from trying, so the verdict comes from the call itself.
+  ///
+  /// The guard keeps two opens from running at once, each costing three RPCs,
+  /// but a request that arrives while one is in flight is not a duplicate of
+  /// it: the running one was issued against a session that has since ended, so
+  /// whether it succeeds says nothing about the link that exists now. Dropping
+  /// it left a reconnect with nothing behind it — no stream was ever asked for
+  /// on the new session, so no frame arrived, and since a frame is what clears
+  /// [_isDisconnected] the page stayed blank for good. So remember the request
+  /// and run once more instead.
   Future<void> _start() async {
-    if (_starting) return;
+    if (_starting) {
+      _restartWanted = true;
+      return;
+    }
     _starting = true;
     try {
-      await _client.guiStartScreenStream(
-        priority: FlipperRequestPriority.rightNow,
-      );
-      await _client.desktopStatusSubscribe();
-      final frames = await _client.desktopIsLocked();
-      for (final f in frames) {
-        if (f.hasDesktopStatus()) _applyStatus(f.desktopStatus);
-      }
-    } catch (_) {
-      if (_disposed) return;
-      if (!_isDisconnected) {
-        _isDisconnected = true;
-        _safeNotify();
-      }
+      do {
+        // Cleared before the attempt, so only a request that arrives while
+        // this one runs asks for another after it.
+        _restartWanted = false;
+        try {
+          await _client.guiStartScreenStream(
+            priority: FlipperRequestPriority.rightNow,
+          );
+          await _client.desktopStatusSubscribe();
+          final frames = await _client.desktopIsLocked();
+          for (final f in frames) {
+            if (f.hasDesktopStatus()) _applyStatus(f.desktopStatus);
+          }
+        } catch (_) {
+          if (_disposed) return;
+          if (!_isDisconnected) {
+            _isDisconnected = true;
+            _safeNotify();
+          }
+        }
+        // Inside the try, so a failed attempt still honours a reconnect that
+        // landed during it - that being the case where retrying matters most.
+      } while (_restartWanted && !_disposed);
     } finally {
       _starting = false;
     }

--- a/lib/pages/tools/remote/desktop/session.dart
+++ b/lib/pages/tools/remote/desktop/session.dart
@@ -50,6 +50,14 @@ class RemoteSession extends ChangeNotifier {
   Timer? _unlockedFlashTimer;
   bool _isDisconnected = false;
   bool _starting = false;
+
+  /// A start asked for while one was already running.
+  ///
+  /// Not a duplicate of it: the running one was issued against a session that
+  /// has since ended, so whether it succeeds says nothing about the link that
+  /// exists now. Cleared before each attempt, so only a request that arrives
+  /// during one asks for another after it — five connection events during a
+  /// single open cost one more open, not five.
   bool _restartWanted = false;
   bool _disposed = false;
   bool _stopped = false;
@@ -84,14 +92,18 @@ class RemoteSession extends ChangeNotifier {
   /// Asks for the stream straight away — a stale "not connected" flag must not
   /// keep the page from trying, so the verdict comes from the call itself.
   ///
-  /// The guard keeps two opens from running at once, each costing three RPCs,
-  /// but a request that arrives while one is in flight is not a duplicate of
-  /// it: the running one was issued against a session that has since ended, so
-  /// whether it succeeds says nothing about the link that exists now. Dropping
-  /// it left a reconnect with nothing behind it — no stream was ever asked for
-  /// on the new session, so no frame arrived, and since a frame is what clears
-  /// [_isDisconnected] the page stayed blank for good. So remember the request
-  /// and run once more instead.
+  /// Exactly one open runs at a time, each costing three RPCs. A request that
+  /// arrives during one is held in [_restartWanted] and run afterwards rather
+  /// than dropped: dropping it left a reconnect with nothing behind it — no
+  /// stream was ever asked for on the new session, so no frame arrived, and
+  /// since a frame is what clears [_isDisconnected] the page stayed blank for
+  /// good.
+  ///
+  /// That opens never overlap is what makes a single flag enough. Were they
+  /// ever made concurrent — to hide the latency of three sequential round
+  /// trips, say — a stale open could finish after a newer one and overwrite
+  /// what it had already applied, and this would need to know which link each
+  /// attempt belonged to rather than merely that one is outstanding.
   Future<void> _start() async {
     if (_starting) {
       _restartWanted = true;

--- a/lib/pages/tools/remote/desktop/session.dart
+++ b/lib/pages/tools/remote/desktop/session.dart
@@ -92,12 +92,11 @@ class RemoteSession extends ChangeNotifier {
   /// Asks for the stream straight away — a stale "not connected" flag must not
   /// keep the page from trying, so the verdict comes from the call itself.
   ///
-  /// Exactly one open runs at a time, each costing three RPCs. A request that
-  /// arrives during one is held in [_restartWanted] and run afterwards rather
-  /// than dropped: dropping it left a reconnect with nothing behind it — no
-  /// stream was ever asked for on the new session, so no frame arrived, and
-  /// since a frame is what clears [_isDisconnected] the page stayed blank for
-  /// good.
+  /// Exactly one open runs at a time, nominally three RPCs — fewer if the page
+  /// goes away mid-flight. A request arriving during one is held in
+  /// [_restartWanted] and run afterwards rather than dropped: dropping it left
+  /// a reconnect with nothing behind it, and since a frame is the only thing
+  /// that clears [_isDisconnected], the page stayed blank for good.
   ///
   /// That opens never overlap is what makes a single flag enough. Were they
   /// ever made concurrent — to hide the latency of three sequential round
@@ -116,12 +115,19 @@ class RemoteSession extends ChangeNotifier {
         // this one runs asks for another after it.
         _restartWanted = false;
         try {
-          // All three at rightNow, and checked for teardown between each. The
-          // queue sorts by priority before arrival order, so a subscribe left
-          // at the default would be overtaken by the rightNow unsubscribe that
-          // shutdown sends — the device would then be told to start pushing
-          // desktop status after being told to stop, and _stopRemote latches
-          // itself off, so nothing would ever unsubscribe it again.
+          // Checked for teardown between each, and all three at rightNow.
+          //
+          // For the subscribe that is correctness, not tidiness: the queue
+          // sorts by priority before arrival, so left at foreground it would
+          // be overtaken by the rightNow unsubscribe shutdown sends. The
+          // device would be told to start pushing desktop status after being
+          // told to stop, and _stopRemote latches itself off, so nothing would
+          // ever unsubscribe it again. The same reasoning already applied to
+          // the stream, which guiStopScreenStream undoes at rightNow too.
+          //
+          // desktopIsLocked has nothing that undoes it, so its priority only
+          // buys latency on a path the user is waiting out — but the three
+          // belong to one operation and are easier to reason about together.
           await _client.guiStartScreenStream(
             priority: FlipperRequestPriority.rightNow,
           );

--- a/test/remote_session_test.dart
+++ b/test/remote_session_test.dart
@@ -12,6 +12,16 @@ class _FakeClient implements FlipperClient {
   bool connected = false;
   bool failCalls = false;
 
+  /// Gate for the first call, so a test can hold the initial open in flight
+  /// and deliver a connection event while it is still between awaits. Without
+  /// this every call resolves on a microtask and the race cannot happen.
+  Completer<void>? gate;
+
+  void openGate() {
+    gate?.complete();
+    gate = null;
+  }
+
   int get startStreamCalls =>
       requests.where((r) => r.hasGuiStartScreenStreamRequest()).length;
 
@@ -39,6 +49,8 @@ class _FakeClient implements FlipperClient {
     bool pipelined = true,
   }) async {
     requests.add(request);
+    final held = gate;
+    if (held != null) await held.future;
     if (failCalls) throw StateError('no active session');
     return const <Main>[];
   }
@@ -82,5 +94,118 @@ void main() {
 
     await Future<void>.delayed(const Duration(milliseconds: 50));
     expect(client.startStreamCalls, 1, reason: 'nothing automatic behind it');
+  });
+
+  FlipperConnectionState link({required bool connected}) =>
+      FlipperConnectionState(
+        mode: connected ? FlipperMode.rpc : FlipperMode.disconnected,
+        device: null,
+        connected: connected,
+      );
+
+  test(
+    'a reconnect racing the initial open still restarts the stream',
+    () async {
+      final client = _FakeClient()
+        ..connected = true
+        ..gate = Completer<void>();
+      final session = RemoteSession(client: client);
+      addTearDown(session.dispose);
+
+      await Future<void>.delayed(Duration.zero);
+      expect(
+        client.startStreamCalls,
+        1,
+        reason: 'the initial open is in flight',
+      );
+
+      // The link drops and comes back while that open is still between awaits -
+      // which is exactly when a reconnect arrives.
+      client.connection.add(link(connected: false));
+      await Future<void>.delayed(Duration.zero);
+      client.connection.add(link(connected: true));
+      await Future<void>.delayed(Duration.zero);
+
+      client.openGate();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(
+        client.startStreamCalls,
+        2,
+        reason:
+            'the reconnect needs a stream of its own; the one in flight was '
+            'issued against the session that just ended',
+      );
+    },
+  );
+
+  // The headline behaviour of the reconnect handling, which #17 left without
+  // coverage when it removed the test that drove the old requestSession API.
+  test('a reconnect restarts the stream', () async {
+    final client = _FakeClient()..connected = true;
+    final session = RemoteSession(client: client);
+    addTearDown(session.dispose);
+
+    await Future<void>.delayed(Duration.zero);
+    expect(client.startStreamCalls, 1);
+
+    client.connection.add(link(connected: false));
+    await Future<void>.delayed(Duration.zero);
+    client.connection.add(link(connected: true));
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    expect(client.startStreamCalls, 2);
+  });
+
+  test('a reconnect during a failed open is still honoured', () async {
+    final client = _FakeClient()
+      ..connected = true
+      ..failCalls = true
+      ..gate = Completer<void>();
+    final session = RemoteSession(client: client);
+    addTearDown(session.dispose);
+
+    await Future<void>.delayed(Duration.zero);
+    client.connection.add(link(connected: false));
+    await Future<void>.delayed(Duration.zero);
+    client.connection.add(link(connected: true));
+    await Future<void>.delayed(Duration.zero);
+
+    client.openGate();
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    expect(
+      client.startStreamCalls,
+      2,
+      reason:
+          'the attempt that failed was against the old session, so the '
+          'reconnect still needs one of its own',
+    );
+  });
+
+  test('one open runs at a time however many requests arrive', () async {
+    final client = _FakeClient()
+      ..connected = true
+      ..gate = Completer<void>();
+    final session = RemoteSession(client: client);
+    addTearDown(session.dispose);
+
+    await Future<void>.delayed(Duration.zero);
+    for (var i = 0; i < 5; i++) {
+      client.connection.add(link(connected: true));
+    }
+    await Future<void>.delayed(Duration.zero);
+    expect(client.startStreamCalls, 1, reason: 'still only the one in flight');
+
+    client.openGate();
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    expect(
+      client.startStreamCalls,
+      2,
+      reason:
+          'five requests during one open ask for one more, not five - the '
+          'guard is what keeps three RPCs per open from piling up',
+    );
   });
 }

--- a/test/remote_session_test.dart
+++ b/test/remote_session_test.dart
@@ -59,6 +59,13 @@ class _FakeClient implements FlipperClient {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+FlipperConnectionState _link({required bool connected}) =>
+    FlipperConnectionState(
+      mode: connected ? FlipperMode.rpc : FlipperMode.disconnected,
+      device: null,
+      connected: connected,
+    );
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
@@ -96,13 +103,6 @@ void main() {
     expect(client.startStreamCalls, 1, reason: 'nothing automatic behind it');
   });
 
-  FlipperConnectionState link({required bool connected}) =>
-      FlipperConnectionState(
-        mode: connected ? FlipperMode.rpc : FlipperMode.disconnected,
-        device: null,
-        connected: connected,
-      );
-
   test(
     'a reconnect racing the initial open still restarts the stream',
     () async {
@@ -121,9 +121,9 @@ void main() {
 
       // The link drops and comes back while that open is still between awaits -
       // which is exactly when a reconnect arrives.
-      client.connection.add(link(connected: false));
+      client.connection.add(_link(connected: false));
       await Future<void>.delayed(Duration.zero);
-      client.connection.add(link(connected: true));
+      client.connection.add(_link(connected: true));
       await Future<void>.delayed(Duration.zero);
 
       client.openGate();
@@ -149,9 +149,9 @@ void main() {
     await Future<void>.delayed(Duration.zero);
     expect(client.startStreamCalls, 1);
 
-    client.connection.add(link(connected: false));
+    client.connection.add(_link(connected: false));
     await Future<void>.delayed(Duration.zero);
-    client.connection.add(link(connected: true));
+    client.connection.add(_link(connected: true));
     await Future<void>.delayed(const Duration(milliseconds: 20));
 
     expect(client.startStreamCalls, 2);
@@ -166,9 +166,9 @@ void main() {
     addTearDown(session.dispose);
 
     await Future<void>.delayed(Duration.zero);
-    client.connection.add(link(connected: false));
+    client.connection.add(_link(connected: false));
     await Future<void>.delayed(Duration.zero);
-    client.connection.add(link(connected: true));
+    client.connection.add(_link(connected: true));
     await Future<void>.delayed(Duration.zero);
 
     client.openGate();
@@ -192,7 +192,7 @@ void main() {
 
     await Future<void>.delayed(Duration.zero);
     for (var i = 0; i < 5; i++) {
-      client.connection.add(link(connected: true));
+      client.connection.add(_link(connected: true));
     }
     await Future<void>.delayed(Duration.zero);
     expect(client.startStreamCalls, 1, reason: 'still only the one in flight');

--- a/test/remote_session_test.dart
+++ b/test/remote_session_test.dart
@@ -25,6 +25,16 @@ class _FakeClient implements FlipperClient {
   int get startStreamCalls =>
       requests.where((r) => r.hasGuiStartScreenStreamRequest()).length;
 
+  /// Everything an open issues, which is what must stop once the page is gone.
+  int get openCalls => requests
+      .where(
+        (r) =>
+            r.hasGuiStartScreenStreamRequest() ||
+            r.hasDesktopStatusSubscribeRequest() ||
+            r.hasDesktopIsLockedRequest(),
+      )
+      .length;
+
   @override
   bool get isConnected => connected;
 
@@ -207,5 +217,60 @@ void main() {
           'five requests during one open ask for one more, not five - the '
           'guard is what keeps three RPCs per open from piling up',
     );
+  });
+
+  test('teardown stops the loop rather than finishing the open', () async {
+    final client = _FakeClient()
+      ..connected = true
+      ..gate = Completer<void>();
+    final session = RemoteSession(client: client);
+
+    await Future<void>.delayed(Duration.zero);
+    // A restart is queued behind the open that is still in flight.
+    client.connection.add(_link(connected: false));
+    await Future<void>.delayed(Duration.zero);
+    client.connection.add(_link(connected: true));
+    await Future<void>.delayed(Duration.zero);
+
+    session.dispose();
+    final atTeardown = client.openCalls;
+    client.openGate();
+    await Future<void>.delayed(const Duration(milliseconds: 50));
+
+    expect(
+      client.openCalls,
+      atTeardown,
+      reason:
+          'the queued restart must not outlive the page: _stopRemote runs '
+          'once and latches, so a subscribe landing after it would leave the '
+          'device pushing status with nothing listening and no way back',
+    );
+  });
+
+  // What the user actually sees, rather than a count of RPCs: the indicator
+  // goes out when frames start arriving again, which is the only thing that
+  // clears it.
+  test('a frame after a reconnect clears the disconnected flag', () async {
+    final client = _FakeClient()..connected = true;
+    final session = RemoteSession(client: client);
+    addTearDown(session.dispose);
+
+    await Future<void>.delayed(Duration.zero);
+    client.connection.add(_link(connected: false));
+    await Future<void>.delayed(Duration.zero);
+    expect(session.isDisconnected, isTrue);
+
+    client.connection.add(_link(connected: true));
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+    expect(
+      session.isDisconnected,
+      isTrue,
+      reason: 'the open having succeeded is not yet evidence frames flow',
+    );
+
+    client.broadcast.add(Main(guiScreenFrame: ScreenFrame()));
+    await Future<void>.delayed(const Duration(milliseconds: 20));
+
+    expect(session.isDisconnected, isFalse);
   });
 }

--- a/test/remote_session_test.dart
+++ b/test/remote_session_test.dart
@@ -4,10 +4,35 @@ import 'package:flipperlib/flipperlib.dart' hide DateTime, File;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:qunleashed/pages/tools/remote/desktop/session.dart';
 
+/// One request as it was handed to the client, with what the session's queue
+/// sorts on.
+class _Sent {
+  _Sent(this.request, this.priority, this.seq);
+  final Main request;
+  final FlipperRequestPriority priority;
+  final int seq;
+}
+
 class _FakeClient implements FlipperClient {
   final broadcast = StreamController<Main>.broadcast();
   final connection = StreamController<FlipperConnectionState>.broadcast();
-  final List<Main> requests = [];
+  final List<_Sent> sent = [];
+
+  List<Main> get requests => [for (final s in sent) s.request];
+
+  /// The order these would reach the device. The real queue sorts by priority
+  /// before arrival (`QueuedRequest.compareTo`), so a later `rightNow` request
+  /// overtakes an earlier one at any lower priority. Mirrored here rather than
+  /// exercised through the real queue, which this fake stands in for - enough
+  /// to pin the priorities the session chooses, which is what goes wrong.
+  List<Main> get wireOrder {
+    final ordered = [...sent]
+      ..sort((a, b) {
+        final byPriority = a.priority.index.compareTo(b.priority.index);
+        return byPriority != 0 ? byPriority : a.seq.compareTo(b.seq);
+      });
+    return [for (final s in ordered) s.request];
+  }
 
   bool connected = false;
   bool failCalls = false;
@@ -58,7 +83,7 @@ class _FakeClient implements FlipperClient {
     bool interleavable = false,
     bool pipelined = true,
   }) async {
-    requests.add(request);
+    sent.add(_Sent(request, priority, sent.length));
     final held = gate;
     if (held != null) await held.future;
     if (failCalls) throw StateError('no active session');
@@ -241,36 +266,74 @@ void main() {
       client.openCalls,
       atTeardown,
       reason:
-          'the queued restart must not outlive the page: _stopRemote runs '
-          'once and latches, so a subscribe landing after it would leave the '
-          'device pushing status with nothing listening and no way back',
+          'the queued restart must not outlive the page - teardown has '
+          'already run and _stopRemote latches, so nothing would undo it',
     );
   });
 
-  // What the user actually sees, rather than a count of RPCs: the indicator
-  // goes out when frames start arriving again, which is the only thing that
-  // clears it.
-  test('a frame after a reconnect clears the disconnected flag', () async {
-    final client = _FakeClient()..connected = true;
-    final session = RemoteSession(client: client);
-    addTearDown(session.dispose);
+  // What the user actually sees, rather than a count of RPCs. Note which half
+  // does it: a successful open is not enough, because the indicator tracks
+  // frames arriving rather than RPCs landing - it drives a connection LED, and
+  // lighting it green over a blank screen would say the wrong thing.
+  test(
+    'a frame clears the disconnected flag, a successful open does not',
+    () async {
+      final client = _FakeClient()..connected = true;
+      final session = RemoteSession(client: client);
+      addTearDown(session.dispose);
 
-    await Future<void>.delayed(Duration.zero);
-    client.connection.add(_link(connected: false));
-    await Future<void>.delayed(Duration.zero);
-    expect(session.isDisconnected, isTrue);
+      await Future<void>.delayed(Duration.zero);
+      client.connection.add(_link(connected: false));
+      await Future<void>.delayed(Duration.zero);
+      expect(session.isDisconnected, isTrue);
 
-    client.connection.add(_link(connected: true));
-    await Future<void>.delayed(const Duration(milliseconds: 20));
-    expect(
-      session.isDisconnected,
-      isTrue,
-      reason: 'the open having succeeded is not yet evidence frames flow',
-    );
+      client.connection.add(_link(connected: true));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+      expect(
+        session.isDisconnected,
+        isTrue,
+        reason: 'the open having succeeded is not yet evidence frames flow',
+      );
 
-    client.broadcast.add(Main(guiScreenFrame: ScreenFrame()));
-    await Future<void>.delayed(const Duration(milliseconds: 20));
+      client.broadcast.add(Main(guiScreenFrame: ScreenFrame()));
+      await Future<void>.delayed(const Duration(milliseconds: 20));
 
-    expect(session.isDisconnected, isFalse);
-  });
+      expect(session.isDisconnected, isFalse);
+    },
+  );
+
+  // The priorities are the fix, not decoration. _stopRemote unsubscribes at
+  // rightNow, and the queue sorts by priority before arrival - so a subscribe
+  // left at the default is overtaken by the unsubscribe meant to undo it, and
+  // the device is left pushing status that nothing listens to, with
+  // _stopRemote already latched off.
+  test(
+    'the subscribe cannot be overtaken by the unsubscribe that undoes it',
+    () async {
+      final client = _FakeClient()..connected = true;
+      final session = RemoteSession(client: client);
+
+      await Future<void>.delayed(Duration.zero);
+      session.dispose();
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      final order = client.wireOrder;
+      final subscribe = order.indexWhere(
+        (r) => r.hasDesktopStatusSubscribeRequest(),
+      );
+      final unsubscribe = order.indexWhere(
+        (r) => r.hasDesktopStatusUnsubscribeRequest(),
+      );
+
+      expect(subscribe, isNonNegative, reason: 'the open subscribes');
+      expect(unsubscribe, isNonNegative, reason: 'teardown unsubscribes');
+      expect(
+        subscribe,
+        lessThan(unsubscribe),
+        reason:
+            'a subscribe reaching the device after the unsubscribe leaves it '
+            'pushing status for the rest of the connection',
+      );
+    },
+  );
 }


### PR DESCRIPTION
`_start()` guards against two opens running at once, and `_starting` stays true across three awaits — `guiStartScreenStream`, `desktopStatusSubscribe`, `desktopIsLocked`. A connection event arriving inside that window is exactly what a reconnect looks like, and it hit `if (_starting) return;` and vanished.

## Why that leaves the page dead, not merely late

`_isDisconnected` is cleared in one place only — `_onFrame`. So dropping the restart means no stream is ever asked for on the new session, no frame arrives, the flag never clears, and the connection LED (`page.dart:279`) stays red over a blank screen. Permanently: a test already on `main` records that there is no retry behind it.

## The fix

The guard is worth keeping — three RPCs per open, no reason to run two at once. What was wrong is treating a request that arrives *during* an open as a duplicate of it. The one in flight was issued against a session that has since ended, so whether it succeeds says nothing about the link that exists now.

So the request is held in `_restartWanted` and run once afterwards — once, however many arrived: five connection events during a single open cost one more open, not five.

The re-run sits **inside** the try rather than after it, so an attempt that failed still honours a reconnect that landed during it. That is the case where it matters most, because the failure *is* the old session going away and the reconnect is the thing that would fix it.

## What review found, which was not the race

The loop makes an ordering reachable that a single pass never did: **`desktopStatusSubscribe` landing after `desktopStatusUnsubscribe`**. The device is then told to start pushing desktop status after being told to stop, and `_stopRemote` sets `_stopped` and never runs again — so it pushes for the rest of the connection with nothing listening and no way back.

Two independent ways in, both real:

- **No teardown check between the awaits.** Back out of the page while a re-run sits between `guiStartScreenStream` and `desktopStatusSubscribe`, and the rest of the open still goes out behind the teardown. Checked after each await now.
- **Priority.** `_start` sent the last two at the API default of `foreground` while `shutdown()` unsubscribes at `rightNow`, and `QueuedRequest.compareTo` (`queue.dart`) sorts by `priority.index` *before* sequence — `rightNow` is 0, `foreground` is 1. So the later unsubscribe overtook a subscribe already queued. All three go out at `rightNow` now, which puts them back in order with teardown.

That second one is worth keeping in mind if the `rightNow` on those calls ever looks like tidiness: it is load-bearing.

## Testing

One thing had to be fixed before anything could be tested: **every call in the fake client resolved on a microtask**, so the window this bug lives in did not exist in the suite. No test could have caught it. The fake now takes a gate that holds a call open, and the race was written as a failing test and confirmed failing (`Expected: <2> Actual: <1>`) before the fix was touched.

Six new tests. Alongside the race itself:

- **a plain reconnect restarts the stream** — #17 removed the test covering this when it deleted the `requestSession` API that `2d21335` replaced, and it has been uncovered since. This one passes against the unfixed code by design; it backfills that gap rather than guarding this bug.
- **a reconnect during a *failed* open is still honoured**
- **five events during one open produce one more open, not five**
- **teardown stops the loop rather than finishing the open**
- **a frame after a reconnect clears the flag** — the user-visible outcome rather than a count of RPCs

Mutations caught: restoring the original early return, retrying only on success, removing the guard entirely, and removing the teardown checks. A fifth — never clearing `_restartWanted` — hangs rather than fails, which is the mutation working: it is the one line the loop's termination rests on.

## Considered and deliberately not done

- **A generation counter** instead of a flag. It would be the deeper fix *if* opens could overlap, but they cannot: the guard makes them strictly sequential, so there is no newer open for a stale one to clobber. It would add a field and a comparison without changing behaviour. `_start` now carries a note that this is the constraint, so that anyone parallelising those round trips has to re-solve it first.
- **Letting a successful open clear `_isDisconnected`** rather than waiting for a frame. The flag drives a connection LED, and a successful open proves the three RPCs landed, not that frames are flowing — clearing it early would light the LED green over a blank screen. "A frame is what proves it" is the more honest signal.
- **Collapsing the three round trips.** Filed as #79 instead: whether `desktopIsLocked()` is redundant with the status subscription depends on whether the firmware pushes an initial status on subscribe, which needs checking rather than inferring.

Closes #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
