### PR TITLE
Give the CLI teardown's Ctrl-C a handler that can actually fire

### DIFF
--- a/lib/pages/tools/remote/cli/page.dart
+++ b/lib/pages/tools/remote/cli/page.dart
@@ -1,3 +1,4 @@
+import '../../../../services/localization/l10n.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io' show Platform;
@@ -11,7 +12,6 @@ import 'package:xterm/xterm.dart';
 import 'package:qunleashed/components/appbar.dart';
 import '../../../../components/dialogs/connection_error.dart';
 import '../../../../components/dialogs/connection.dart';
-import '../../../../services/localization/l10n.dart';
 import '../../../../services/logging.dart';
 
 const _kBackgroundColor = Color(0xFF000000);
@@ -20,10 +20,8 @@ const _kForegroundColor = Color(0xFFE0E0E0);
 class CliPage extends StatefulWidget {
   const CliPage({super.key, this.client});
 
-  /// Supplied by tests only; the app always uses the shared client. The same
-  /// seam [RemoteSession] takes, and for the same reason — the teardown path
-  /// is otherwise unreachable from a test.
-  @visibleForTesting
+  /// Supplied by tests only; the app always uses the shared client, which is
+  /// otherwise reached through a singleton no test can replace.
   final FlipperClient? client;
 
   @override
@@ -59,43 +57,45 @@ class _CliPageState extends State<CliPage> {
     WidgetsBinding.instance.addPostFrameCallback((_) => _bootstrap());
   }
 
+  /// Sends something to the device that nobody can be told about — teardown,
+  /// or a keystroke the terminal has already echoed — and records why it did
+  /// not arrive.
+  ///
+  /// [Future.sync] is the point. `FlipperClient.writeCliBytes` is not async,
+  /// so a session that is gone throws before there is a future to attach a
+  /// handler to, while a session whose transport has been torn down, one
+  /// already back in RPC mode, and the write itself all reject instead. Both
+  /// StateErrors read "No active transport", so the difference is easy to
+  /// miss; running the call inside Future.sync puts both in the same place.
+  void _fireAndLog(Future<void> Function() send, String what) {
+    unawaited(
+      Future.sync(send).catchError(
+        (Object e, StackTrace st) =>
+            LogService.error('[CLI] $what failed: $e\n$st'),
+      ),
+    );
+  }
+
   @override
   void dispose() {
     _textSub?.cancel();
     _connSub?.cancel();
     if (_awaitingInterrupt) {
-      // Two failures, two paths, and only one was being caught. Resolving the
-      // session goes through _requireActiveSession, which throws synchronously
-      // when there is no transport at all — that is what this catch has always
-      // caught. But the session's own writeCliBytes is async, so a transport
-      // that cannot do CLI, a session already back in RPC mode, or the write
-      // itself failing all reject a future instead, and teardown — with the
-      // link very often already gone — is exactly when those happen.
-      //
-      // _sendCtrlC sends this same byte and handles both. This is the outlier.
-      try {
-        unawaited(
-          _client
-              .writeCliBytes(Uint8List.fromList([0x03]))
-              .catchError(
-                (Object e) =>
-                    LogService.log('[CLI] ctrl-c on dispose failed: $e'),
-              ),
-        );
-      } catch (e) {
-        LogService.log('[CLI] ctrl-c on dispose failed: $e');
-      }
+      // dispose() cannot be async, so there is nowhere to await this and no
+      // UI left to report into if it fails. Best effort, logged.
+      _fireAndLog(
+        () => _client.writeCliBytes(Uint8List.fromList([0x03])),
+        'ctrl-c on dispose',
+      );
     }
+    // Stays ahead of enterRpcMode: switchToRpcMode refuses outright while
+    // cliExclusive is set, so reordering these two breaks every USB teardown.
     _client.cliExclusive = false;
     if (_client.connectedDevice?.isBle != true) {
-      // enterRpcMode deliberately does not throw synchronously — its own
-      // comment says callers fire it unawaited — but the mode switch it
-      // returns can still fail, and that rejection had nothing listening.
-      unawaited(
-        _client.enterRpcMode().catchError(
-          (Object e) => LogService.log('[CLI] leaving cli mode failed: $e'),
-        ),
-      );
+      // enterRpcMode returns quietly when the session is already gone, but the
+      // switch it returns can still reject, and unawaited silences the lint
+      // rather than the error.
+      _fireAndLog(_client.enterRpcMode, 'leaving cli mode');
     }
     _terminalController.dispose();
     _terminalFocusNode.dispose();
@@ -115,11 +115,7 @@ class _CliPageState extends State<CliPage> {
   void _onTerminalOutput(String data) {
     if (!_ready) return;
     final bytes = Uint8List.fromList(utf8.encode(data));
-    unawaited(
-      _client.writeCliBytes(bytes).catchError((Object e) {
-        LogService.log('[CLI] write error: $e');
-      }),
-    );
+    _fireAndLog(() => _client.writeCliBytes(bytes), 'write');
   }
 
   Future<void> _bootstrap() async {
@@ -234,10 +230,9 @@ class _CliPageState extends State<CliPage> {
 
   void _sendCtrlC() {
     if (!_ready) return;
-    unawaited(
-      _client
-          .writeCliBytes(Uint8List.fromList([0x03]))
-          .catchError((Object e) => LogService.log('[CLI] ctrl-c failed: $e')),
+    _fireAndLog(
+      () => _client.writeCliBytes(Uint8List.fromList([0x03])),
+      'ctrl-c',
     );
     _terminalFocusNode.requestFocus();
   }

--- a/lib/pages/tools/remote/cli/page.dart
+++ b/lib/pages/tools/remote/cli/page.dart
@@ -1,4 +1,3 @@
-import '../../../../services/localization/l10n.dart';
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io' show Platform;
@@ -12,20 +11,27 @@ import 'package:xterm/xterm.dart';
 import 'package:qunleashed/components/appbar.dart';
 import '../../../../components/dialogs/connection_error.dart';
 import '../../../../components/dialogs/connection.dart';
+import '../../../../services/localization/l10n.dart';
 import '../../../../services/logging.dart';
 
 const _kBackgroundColor = Color(0xFF000000);
 const _kForegroundColor = Color(0xFFE0E0E0);
 
 class CliPage extends StatefulWidget {
-  const CliPage({super.key});
+  const CliPage({super.key, this.client});
+
+  /// Supplied by tests only; the app always uses the shared client. The same
+  /// seam [RemoteSession] takes, and for the same reason — the teardown path
+  /// is otherwise unreachable from a test.
+  @visibleForTesting
+  final FlipperClient? client;
 
   @override
   State<CliPage> createState() => _CliPageState();
 }
 
 class _CliPageState extends State<CliPage> {
-  final FlipperClient _client = FlipperOneClient().get();
+  late final FlipperClient _client = widget.client ?? FlipperOneClient().get();
   final FocusNode _terminalFocusNode = FocusNode(debugLabel: 'cli-terminal');
 
   late final Terminal _terminal;
@@ -58,13 +64,38 @@ class _CliPageState extends State<CliPage> {
     _textSub?.cancel();
     _connSub?.cancel();
     if (_awaitingInterrupt) {
+      // Two failures, two paths, and only one was being caught. Resolving the
+      // session goes through _requireActiveSession, which throws synchronously
+      // when there is no transport at all — that is what this catch has always
+      // caught. But the session's own writeCliBytes is async, so a transport
+      // that cannot do CLI, a session already back in RPC mode, or the write
+      // itself failing all reject a future instead, and teardown — with the
+      // link very often already gone — is exactly when those happen.
+      //
+      // _sendCtrlC sends this same byte and handles both. This is the outlier.
       try {
-        _client.writeCliBytes(Uint8List.fromList([0x03]));
-      } catch (_) {}
+        unawaited(
+          _client
+              .writeCliBytes(Uint8List.fromList([0x03]))
+              .catchError(
+                (Object e) =>
+                    LogService.log('[CLI] ctrl-c on dispose failed: $e'),
+              ),
+        );
+      } catch (e) {
+        LogService.log('[CLI] ctrl-c on dispose failed: $e');
+      }
     }
     _client.cliExclusive = false;
     if (_client.connectedDevice?.isBle != true) {
-      unawaited(_client.enterRpcMode());
+      // enterRpcMode deliberately does not throw synchronously — its own
+      // comment says callers fire it unawaited — but the mode switch it
+      // returns can still fail, and that rejection had nothing listening.
+      unawaited(
+        _client.enterRpcMode().catchError(
+          (Object e) => LogService.log('[CLI] leaving cli mode failed: $e'),
+        ),
+      );
     }
     _terminalController.dispose();
     _terminalFocusNode.dispose();

--- a/test/cli_teardown_test.dart
+++ b/test/cli_teardown_test.dart
@@ -45,6 +45,11 @@ class _FakeClient implements FlipperClient {
   int writeCalls = 0;
   int enterRpcModeCalls = 0;
 
+  /// What dispose did, in order. cliExclusive has to be cleared before the
+  /// RPC switch — switchToRpcMode refuses outright while it is set — and a
+  /// fake that only counted calls could not tell.
+  final List<String> events = [];
+
   @override
   Stream<String> get textStream => text.stream;
 
@@ -55,11 +60,12 @@ class _FakeClient implements FlipperClient {
   FlipperDevice? get connectedDevice => _device(link);
 
   @override
-  set cliExclusive(bool value) {}
+  set cliExclusive(bool value) => events.add('cliExclusive=$value');
 
   @override
   Future<void> writeCliBytes(Uint8List bytes) {
     writeCalls += 1;
+    events.add('write');
     switch (writeFailure) {
       case _WriteFailure.throwsSynchronously:
         throw StateError('No active transport');
@@ -73,6 +79,7 @@ class _FakeClient implements FlipperClient {
   @override
   Future<void> enterRpcMode() {
     enterRpcModeCalls += 1;
+    events.add('enterRpcMode');
     return enterRpcModeRejects
         ? Future<void>.error(StateError('rpc switch failed'))
         : Future<void>.value();
@@ -94,13 +101,30 @@ Widget _wrap(Widget child) => MaterialApp(
   home: child,
 );
 
+/// Collects what LogService writes, so a test can assert the handler ran
+/// rather than only that nothing blew up. Restored inline rather than through
+/// addTearDown, which flutter_test rejects as changing a debug variable.
+Future<List<String>> recordingLogs(Future<void> Function() body) async {
+  final lines = <String>[];
+  final previous = debugPrint;
+  debugPrint = (String? message, {int? wrapWidth}) {
+    if (message != null) lines.add(message);
+  };
+  try {
+    await body();
+  } finally {
+    debugPrint = previous;
+  }
+  return lines;
+}
+
 void main() {
   /// Opens the page, lets the device say [lastOutput], then disposes it.
   ///
-  /// An unhandled rejection during dispose fails the test, but only while the
-  /// test is still running — after that flutter_test charges it to whatever
-  /// comes next. The trailing pump is what keeps it inside this test, so the
-  /// assertions below deliberately also check the call was made at all.
+  /// An unhandled rejection during dispose fails the test outright, which is
+  /// most of what these assert. That is a side channel though, so the two
+  /// teardown cases also read the log back: an assertion that says what it
+  /// wants cannot quietly become vacuous.
   Future<void> openThenDispose(
     WidgetTester tester,
     _FakeClient client, {
@@ -123,9 +147,14 @@ void main() {
       ..writeFailure = _WriteFailure.throwsSynchronously;
     addTearDown(client.text.close);
 
-    await openThenDispose(tester, client);
+    final logs = await recordingLogs(() => openThenDispose(tester, client));
 
     expect(client.writeCalls, 1);
+    expect(
+      logs.where((l) => l.contains('ctrl-c on dispose failed')),
+      isNotEmpty,
+      reason: 'the handler ran, rather than the failure merely not surfacing',
+    );
   });
 
   // The case the old handler could not see. dispose() is not async, so its
@@ -138,9 +167,13 @@ void main() {
     final client = _FakeClient()..writeFailure = _WriteFailure.rejects;
     addTearDown(client.text.close);
 
-    await openThenDispose(tester, client);
+    final logs = await recordingLogs(() => openThenDispose(tester, client));
 
     expect(client.writeCalls, 1);
+    expect(
+      logs.where((l) => l.contains('ctrl-c on dispose failed')),
+      isNotEmpty,
+    );
   });
 
   testWidgets('no ctrl-c is sent when the prompt is already back', (
@@ -183,5 +216,50 @@ void main() {
     await openThenDispose(tester, client);
 
     expect(client.enterRpcModeCalls, 0);
+  });
+
+  // The ordering dispose() documents as load-bearing: switchToRpcMode returns
+  // an error while cliExclusive is still set, so clearing it has to come
+  // first. Counting calls could not see this; deleting the assignment
+  // altogether left every other test green.
+  testWidgets('cli mode is released before the switch back to RPC', (
+    tester,
+  ) async {
+    final client = _FakeClient(link: FlipperLink.usb);
+    addTearDown(client.text.close);
+
+    await tester.pumpWidget(_wrap(CliPage(client: client)));
+    await tester.pump(const Duration(milliseconds: 600));
+    await tester.pumpWidget(_wrap(const SizedBox.shrink()));
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(client.events, contains('cliExclusive=false'));
+    expect(
+      client.events.indexOf('cliExclusive=false'),
+      lessThan(client.events.indexOf('enterRpcMode')),
+    );
+  });
+
+  // _sendCtrlC is one of the two sites that carried the mirror-image bug -
+  // a handler for the rejection and nothing for the synchronous throw, which
+  // would leave it escaping the button's callback.
+  testWidgets('the ctrl-c button survives a session that is already gone', (
+    tester,
+  ) async {
+    final client = _FakeClient(link: FlipperLink.usb);
+    addTearDown(client.text.close);
+
+    await tester.pumpWidget(_wrap(CliPage(client: client)));
+    await tester.pump(const Duration(milliseconds: 600));
+
+    client.writeFailure = _WriteFailure.throwsSynchronously;
+    final before = client.writeCalls;
+    final logs = await recordingLogs(() async {
+      await tester.tap(find.byIcon(Icons.stop_circle_outlined));
+      await tester.pump();
+    });
+
+    expect(client.writeCalls, before + 1, reason: 'the button is live');
+    expect(logs.where((l) => l.contains('ctrl-c failed')), isNotEmpty);
   });
 }

--- a/test/cli_teardown_test.dart
+++ b/test/cli_teardown_test.dart
@@ -1,0 +1,134 @@
+import 'dart:async';
+import 'dart:typed_data';
+
+import 'package:flipperlib/flipperlib.dart' hide DateTime, File;
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qunleashed/pages/tools/remote/cli/page.dart';
+import 'package:qunleashed/theme/theme.dart';
+
+class _FakeDiscovered implements DiscoveredDevice {
+  @override
+  String get id => 'fake';
+  @override
+  String get name => 'Flipper';
+  @override
+  DeviceTransport get transport => DeviceTransport.ble;
+}
+
+/// A BLE device, so `_bootstrap` takes its early exit rather than trying to
+/// open a USB session the fake cannot provide.
+final _device = FlipperDevice(
+  id: 'fake',
+  name: 'Flipper',
+  link: FlipperLink.ble,
+  source: _FakeDiscovered(),
+);
+
+class _FakeClient implements FlipperClient {
+  final text = StreamController<String>.broadcast();
+  final connection = StreamController<FlipperConnectionState>.broadcast();
+
+  /// How the write fails. Both are real: resolving the session throws
+  /// synchronously when there is no transport, while the session's own write
+  /// is async and rejects instead.
+  bool throwsSynchronously = false;
+  bool rejects = false;
+
+  int writeCalls = 0;
+
+  @override
+  Stream<String> get textStream => text.stream;
+
+  @override
+  Stream<FlipperConnectionState> get connectionStream => connection.stream;
+
+  @override
+  FlipperDevice? get connectedDevice => _device;
+
+  @override
+  set cliExclusive(bool value) {}
+
+  @override
+  Future<void> writeCliBytes(Uint8List bytes) {
+    writeCalls += 1;
+    if (throwsSynchronously) throw StateError('No active transport');
+    if (rejects) return Future<void>.error(StateError('transport is gone'));
+    return Future<void>.value();
+  }
+
+  @override
+  Future<void> enterRpcMode() => Future<void>.value();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Widget _wrap(Widget child) => MaterialApp(
+  theme: buildAppTheme(Brightness.dark, const Color(0xFFCC241D)),
+  home: child,
+);
+
+void main() {
+  /// Opens the page, leaves it mid-command so teardown sends Ctrl-C, then
+  /// disposes it. A failure that escapes here fails the test on its own —
+  /// flutter_test reports an unhandled async error against whatever is
+  /// running — which is exactly the symptom being fixed.
+  Future<_FakeClient> tearDownMidCommand(
+    WidgetTester tester, {
+    bool throwsSynchronously = false,
+    bool rejects = false,
+  }) async {
+    final client = _FakeClient()
+      ..throwsSynchronously = throwsSynchronously
+      ..rejects = rejects;
+
+    await tester.pumpWidget(_wrap(CliPage(client: client)));
+    await tester.pump();
+
+    // Output without the prompt means a command is still running, which is
+    // what arms the interrupt on teardown.
+    client.text.add('doing something long');
+    await tester.pump();
+
+    await tester.pumpWidget(_wrap(const SizedBox.shrink()));
+    await tester.pump(const Duration(milliseconds: 50));
+    return client;
+  }
+
+  testWidgets('a ctrl-c that is refused outright does not escape teardown', (
+    tester,
+  ) async {
+    final client = await tearDownMidCommand(tester, throwsSynchronously: true);
+
+    expect(client.writeCalls, 1);
+  });
+
+  // The one the old handler could not see: dispose() is not async, so its
+  // catch only ever ran over the synchronous prologue, and a rejected write —
+  // the common case, since the link is usually already gone by teardown — had
+  // nothing listening.
+  testWidgets('a ctrl-c the transport rejects does not escape teardown', (
+    tester,
+  ) async {
+    final client = await tearDownMidCommand(tester, rejects: true);
+
+    expect(client.writeCalls, 1);
+  });
+
+  testWidgets('no ctrl-c is sent when the prompt is already back', (
+    tester,
+  ) async {
+    final client = _FakeClient()..rejects = true;
+
+    await tester.pumpWidget(_wrap(CliPage(client: client)));
+    await tester.pump();
+    client.text.add('done >: ');
+    await tester.pump();
+
+    await tester.pumpWidget(_wrap(const SizedBox.shrink()));
+    await tester.pump(const Duration(milliseconds: 50));
+
+    expect(client.writeCalls, 0);
+  });
+}

--- a/test/cli_teardown_test.dart
+++ b/test/cli_teardown_test.dart
@@ -8,34 +8,42 @@ import 'package:qunleashed/pages/tools/remote/cli/page.dart';
 import 'package:qunleashed/theme/theme.dart';
 
 class _FakeDiscovered implements DiscoveredDevice {
+  _FakeDiscovered(this.transport);
   @override
   String get id => 'fake';
   @override
   String get name => 'Flipper';
   @override
-  DeviceTransport get transport => DeviceTransport.ble;
+  final DeviceTransport transport;
 }
 
-/// A BLE device, so `_bootstrap` takes its early exit rather than trying to
-/// open a USB session the fake cannot provide.
-final _device = FlipperDevice(
+FlipperDevice _device(FlipperLink link) => FlipperDevice(
   id: 'fake',
   name: 'Flipper',
-  link: FlipperLink.ble,
-  source: _FakeDiscovered(),
+  link: link,
+  source: _FakeDiscovered(
+    link == FlipperLink.ble ? DeviceTransport.ble : DeviceTransport.usb,
+  ),
 );
 
+/// How the CLI write fails. Both are real and they behave differently:
+/// resolving a session that is gone throws before any future exists, while the
+/// session's own write is async and rejects. They are one field rather than
+/// two booleans so "both at once", which cannot happen, cannot be written.
+enum _WriteFailure { none, throwsSynchronously, rejects }
+
 class _FakeClient implements FlipperClient {
+  _FakeClient({this.link = FlipperLink.ble});
+
+  final FlipperLink link;
   final text = StreamController<String>.broadcast();
   final connection = StreamController<FlipperConnectionState>.broadcast();
 
-  /// How the write fails. Both are real: resolving the session throws
-  /// synchronously when there is no transport, while the session's own write
-  /// is async and rejects instead.
-  bool throwsSynchronously = false;
-  bool rejects = false;
+  _WriteFailure writeFailure = _WriteFailure.none;
+  bool enterRpcModeRejects = false;
 
   int writeCalls = 0;
+  int enterRpcModeCalls = 0;
 
   @override
   Stream<String> get textStream => text.stream;
@@ -44,7 +52,7 @@ class _FakeClient implements FlipperClient {
   Stream<FlipperConnectionState> get connectionStream => connection.stream;
 
   @override
-  FlipperDevice? get connectedDevice => _device;
+  FlipperDevice? get connectedDevice => _device(link);
 
   @override
   set cliExclusive(bool value) {}
@@ -52,13 +60,30 @@ class _FakeClient implements FlipperClient {
   @override
   Future<void> writeCliBytes(Uint8List bytes) {
     writeCalls += 1;
-    if (throwsSynchronously) throw StateError('No active transport');
-    if (rejects) return Future<void>.error(StateError('transport is gone'));
-    return Future<void>.value();
+    switch (writeFailure) {
+      case _WriteFailure.throwsSynchronously:
+        throw StateError('No active transport');
+      case _WriteFailure.rejects:
+        return Future<void>.error(StateError('transport is gone'));
+      case _WriteFailure.none:
+        return Future<void>.value();
+    }
   }
 
   @override
-  Future<void> enterRpcMode() => Future<void>.value();
+  Future<void> enterRpcMode() {
+    enterRpcModeCalls += 1;
+    return enterRpcModeRejects
+        ? Future<void>.error(StateError('rpc switch failed'))
+        : Future<void>.value();
+  }
+
+  @override
+  Future<void> disconnect() async {}
+
+  @override
+  Future<FlipperDevice> connect(FlipperDevice device, {bool autoRpc = true}) =>
+      Future<FlipperDevice>.value(device);
 
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
@@ -70,48 +95,50 @@ Widget _wrap(Widget child) => MaterialApp(
 );
 
 void main() {
-  /// Opens the page, leaves it mid-command so teardown sends Ctrl-C, then
-  /// disposes it. A failure that escapes here fails the test on its own —
-  /// flutter_test reports an unhandled async error against whatever is
-  /// running — which is exactly the symptom being fixed.
-  Future<_FakeClient> tearDownMidCommand(
-    WidgetTester tester, {
-    bool throwsSynchronously = false,
-    bool rejects = false,
+  /// Opens the page, lets the device say [lastOutput], then disposes it.
+  ///
+  /// An unhandled rejection during dispose fails the test, but only while the
+  /// test is still running — after that flutter_test charges it to whatever
+  /// comes next. The trailing pump is what keeps it inside this test, so the
+  /// assertions below deliberately also check the call was made at all.
+  Future<void> openThenDispose(
+    WidgetTester tester,
+    _FakeClient client, {
+    String lastOutput = 'doing something long',
   }) async {
-    final client = _FakeClient()
-      ..throwsSynchronously = throwsSynchronously
-      ..rejects = rejects;
-
     await tester.pumpWidget(_wrap(CliPage(client: client)));
     await tester.pump();
 
-    // Output without the prompt means a command is still running, which is
-    // what arms the interrupt on teardown.
-    client.text.add('doing something long');
+    client.text.add(lastOutput);
     await tester.pump();
 
     await tester.pumpWidget(_wrap(const SizedBox.shrink()));
     await tester.pump(const Duration(milliseconds: 50));
-    return client;
   }
 
-  testWidgets('a ctrl-c that is refused outright does not escape teardown', (
+  testWidgets('a ctrl-c refused before it is sent does not escape teardown', (
     tester,
   ) async {
-    final client = await tearDownMidCommand(tester, throwsSynchronously: true);
+    final client = _FakeClient()
+      ..writeFailure = _WriteFailure.throwsSynchronously;
+    addTearDown(client.text.close);
+
+    await openThenDispose(tester, client);
 
     expect(client.writeCalls, 1);
   });
 
-  // The one the old handler could not see: dispose() is not async, so its
-  // catch only ever ran over the synchronous prologue, and a rejected write —
-  // the common case, since the link is usually already gone by teardown — had
-  // nothing listening.
+  // The case the old handler could not see. dispose() is not async, so its
+  // catch only ever covered the synchronous prologue — and this is the failure
+  // teardown actually produces, because the transport is usually torn down
+  // before the page is.
   testWidgets('a ctrl-c the transport rejects does not escape teardown', (
     tester,
   ) async {
-    final client = await tearDownMidCommand(tester, rejects: true);
+    final client = _FakeClient()..writeFailure = _WriteFailure.rejects;
+    addTearDown(client.text.close);
+
+    await openThenDispose(tester, client);
 
     expect(client.writeCalls, 1);
   });
@@ -119,16 +146,42 @@ void main() {
   testWidgets('no ctrl-c is sent when the prompt is already back', (
     tester,
   ) async {
-    final client = _FakeClient()..rejects = true;
+    final client = _FakeClient()..writeFailure = _WriteFailure.rejects;
+    addTearDown(client.text.close);
+
+    await openThenDispose(tester, client, lastOutput: 'done >: ');
+
+    expect(client.writeCalls, 0);
+  });
+
+  // The other half of the fix, which the tests above cannot reach: dispose
+  // only returns to RPC mode for a non-BLE device.
+  testWidgets('a failed return to RPC mode does not escape teardown', (
+    tester,
+  ) async {
+    final client = _FakeClient(link: FlipperLink.usb)
+      ..enterRpcModeRejects = true;
+    addTearDown(client.text.close);
 
     await tester.pumpWidget(_wrap(CliPage(client: client)));
-    await tester.pump();
-    client.text.add('done >: ');
-    await tester.pump();
+    // Long enough for _enterCliReady's own delay to elapse, so no timer is
+    // left pending when the page goes away.
+    await tester.pump(const Duration(milliseconds: 600));
 
     await tester.pumpWidget(_wrap(const SizedBox.shrink()));
     await tester.pump(const Duration(milliseconds: 50));
 
-    expect(client.writeCalls, 0);
+    expect(client.enterRpcModeCalls, 1);
+  });
+
+  testWidgets('a BLE device is left alone rather than pushed back to RPC', (
+    tester,
+  ) async {
+    final client = _FakeClient();
+    addTearDown(client.text.close);
+
+    await openThenDispose(tester, client);
+
+    expect(client.enterRpcModeCalls, 0);
   });
 }


### PR DESCRIPTION
`_CliPageState.dispose()` sent Ctrl-C like this:

```dart
try {
  _client.writeCliBytes(Uint8List.fromList([0x03]));
} catch (_) {}
```

`dispose()` is not async, so the catch only ever covered the synchronous prologue.

## The issue overstates it, and the reason matters

#21 says the handler "has never fired". It fires for exactly one case — and working out which one is the whole story here.

| | checks | thrown from | behaviour |
|---|---|---|---|
| `_requireActiveSession` | `_active == null` (**session**) | non-async `FlipperClient.writeCliBytes` | **throws synchronously** |
| `_requireTransport` | `transport == null` (**transport**) | `async FlipperSession.writeCliBytes` | **rejects** |

Both raise `StateError('No active transport')` — identical text. And `teardownLocked` nulls the *transport* while keeping the session, so the failure teardown actually produces is the **async** one: precisely the half the old catch could not see. It was missing the failures it was written for while appearing to work.

`Future.sync` settles this rather than explaining it — the call runs inside it, so a synchronous throw becomes a rejection and one handler covers both.

## Review found the fix was a third of the job

The first commit fixed `dispose()` and shipped a comment declaring the other sites fine. They are not — **`_sendCtrlC` and `_onTerminalOutput` have the mirror-image bug**: a `.catchError` and nothing else, so they cover the rejection and miss the synchronous throw.

That window is real. `_dropSessionLocked` nulls the session synchronously, while the disconnected state reaches `_onConnectionState` through a broadcast stream. Until it arrives, `_ready` is still true — so a keystroke in between throws out of xterm's `onOutput` callback with nothing to catch it.

All four sites now go through one helper:

```dart
void _fireAndLog(Future<void> Function() send, String what) {
  unawaited(
    Future.sync(send).catchError(
      (Object e, StackTrace st) =>
          LogService.error('[CLI] $what failed: $e\n$st'),
    ),
  );
}
```

The reuse review had said to leave these inline, on the grounds that a helper would only save boilerplate and the repo has no such idiom. That no longer applies — the helper now carries the `Future.sync` subtlety, which is the thing each site was getting wrong.

Two more from review, both cheap and both real:

- **`LogService.error`, not `log`.** `log` is `info`, which folds off in a build made with `QLOG_LEVEL=error` — exactly the build you would ask a user for when chasing failures without the firehose. The mifare controllers already use `error` for failure paths; this file was the outlier.
- **The stack trace.** Once a pulled cable and a bug in the write path both print the same one line, the trace is the only thing that separates them.

## Also documented: an ordering that is load-bearing

`_client.cliExclusive = false` has to precede `enterRpcMode()`, because `switchToRpcMode` returns `Future.error('RPC switch blocked: CLI session is active')` while the flag is set. Reversing those two lines would break every USB teardown, and nothing said so. Now it does.

## Tests

Five, where there were none — the page needed the same client seam `RemoteSession` already takes.

They distinguish the two failures rather than lumping them: **restoring the original handler leaves the synchronous test passing and fails the rejected one**, which is the bug exactly. Two more cover the half that had no coverage at all — `dispose` only returns to RPC mode for a non-BLE device, so nothing had ever reached that handler.

Three mutations caught: the original sync-only shape, the handler removed, and `enterRpcMode` left bare.

## Dropped after review

- `@visibleForTesting` on the seam — it is **inert**. It sits on the field, while the named argument binds the field-formal parameter, so it neither warns nor enforces. `RemoteSession` does not carry one either.
- The import reorder — unrelated churn. 50 of the 127 files importing `l10n.dart` put it first, so changing one file is inconsistency rather than tidying.

## Deferred, filed rather than folded in

**#80** — a failed keystroke is invisible: `_ready` stays true, nothing is drawn, and in release nothing is logged either, so a dead link looks like a hung Flipper. Also `_bootstrap`'s catch being broader than its message, and a teardown race where Ctrl-C and the RPC switch can each mislabel the other. Those are behaviour changes, not error-handling fixes.

**#23** got the audit it was missing, and a correction: `unawaited_futures` will **not** flag any of the 99 existing sites, because `unawaited()` is the lint's own escape hatch. The two checkboxes solve different problems and neither verifies the other — worth knowing before anyone plans that work.

Closes #21. Part of #23.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
