### PR TITLE
Stop a failed IR library refresh from costing the user their library

### DIFF
--- a/lib/pages/tools/infrared/local_repo.dart
+++ b/lib/pages/tools/infrared/local_repo.dart
@@ -3,6 +3,7 @@ import 'dart:io' as io;
 import 'dart:isolate';
 
 import 'package:archive/archive_io.dart';
+import 'package:flutter/foundation.dart';
 import 'package:path_provider/path_provider.dart';
 
 import '../../../components/archive_unpack.dart';
@@ -49,6 +50,24 @@ class IrLibLocalRepo {
 
   static io.Directory? _cachedRoot;
 
+  /// True while a refresh owns the staging directories.
+  ///
+  /// A page builds its own controller, so opening the library while a download
+  /// runs brings a second one along, and its exists() check used to reach
+  /// straight past the isolate and delete the tree it was unpacking into. The
+  /// unpack does not notice - its created-directory cache stops it re-making
+  /// the parents - so entries land in `skipped` and, if few enough clear the
+  /// tolerance, a truncated library gets sworn in as a whole one.
+  static bool _refreshing = false;
+
+  /// Points the library at [dir] for the duration of a test, and clears the
+  /// refresh flag so one test cannot strand the next.
+  @visibleForTesting
+  static void debugUseRoot(io.Directory? dir) {
+    _cachedRoot = dir;
+    _refreshing = false;
+  }
+
   Future<io.Directory> resolveRoot() async {
     final cached = _cachedRoot;
     if (cached != null) return cached;
@@ -80,10 +99,15 @@ class IrLibLocalRepo {
 
   Future<void> deleteAll() async {
     final dir = await resolveRoot();
+    // Sidecars first, the library last. The other order leaves root missing
+    // while .superseded still stands - the exact signature recoverInterrupted
+    // reads as an interrupted swap - so anything that stopped the delete part
+    // way through would hand the previous library back as though nothing had
+    // been asked for.
     for (final target in [
+      _sidecar(dir, _kIncomingSuffix),
+      _sidecar(dir, _kSupersededSuffix),
       dir,
-      io.Directory('${dir.path}$_kIncomingSuffix'),
-      io.Directory('${dir.path}$_kSupersededSuffix'),
     ]) {
       if (!await target.exists()) continue;
       try {
@@ -103,12 +127,37 @@ class IrLibLocalRepo {
   }) async {
     final root = await resolveRoot();
     await recoverInterrupted(root);
+    _refreshing = true;
+    try {
+      return await _download(
+        root: root,
+        owner: owner,
+        repo: repo,
+        branch: branch,
+        token: token,
+        onProgress: onProgress,
+      );
+    } finally {
+      _refreshing = false;
+    }
+  }
 
+  Future<io.Directory> _download({
+    required io.Directory root,
+    required String owner,
+    required String repo,
+    required String branch,
+    required String token,
+    void Function(IrLibDownloadProgress)? onProgress,
+  }) async {
     // Built beside the library rather than over it. The old one stays whole
     // and usable until there is a complete replacement to put in its place -
     // a refresh that fails for any reason now costs the user nothing, where
     // before it cost them the library they already had.
-    final incoming = io.Directory('${root.path}$_kIncomingSuffix');
+    final incoming = _sidecar(root, _kIncomingSuffix);
+    // Not redundant with the recovery above: that one logs and carries on when
+    // a delete fails, so a tree it could not clear would otherwise be unpacked
+    // straight over.
     if (await incoming.exists()) await incoming.delete(recursive: true);
     await incoming.create(recursive: true);
 
@@ -185,6 +234,16 @@ class IrLibLocalRepo {
   static const String _kIncomingSuffix = '.incoming';
   static const String _kSupersededSuffix = '.superseded';
 
+  /// Where the staging trees live: beside the library, never inside it.
+  ///
+  /// Beside matters. Staging in the OS temp directory would read as tidier and
+  /// is the natural thing to reach for, but it can land on a different mount —
+  /// plausible on Android — and dart:io's rename does not copy across
+  /// filesystems, it fails EXDEV outright. Staging stays on the volume it is
+  /// going to land on.
+  static io.Directory _sidecar(io.Directory root, String suffix) =>
+      io.Directory('${root.path}$suffix');
+
   /// Puts a freshly unpacked tree in place of the library.
   ///
   /// Three renames rather than the one this reads like it should need: no
@@ -194,25 +253,40 @@ class IrLibLocalRepo {
   /// otherwise, which is exactly the state the old library is in. So the old
   /// tree is moved aside first, and all three are metadata operations.
   ///
-  /// Deleting the superseded tree is what used to be on the critical path, and
-  /// it is the expensive part: ~1,578 ms for 14,800 files, measured on NTFS.
-  /// It runs unawaited afterwards, and a run that dies before it finishes
-  /// leaves a directory [recoverInterrupted] clears next time.
+  /// Deleting the superseded tree is the expensive part, and it is what used
+  /// to be on the critical path. It runs unawaited afterwards, and a run that
+  /// dies before it finishes leaves a directory [recoverInterrupted] clears
+  /// next time.
   static Future<void> swapIn(io.Directory root, io.Directory incoming) async {
-    final superseded = io.Directory('${root.path}$_kSupersededSuffix');
+    final superseded = _sidecar(root, _kSupersededSuffix);
     if (await superseded.exists()) {
-      await superseded.delete(recursive: true);
+      try {
+        await superseded.delete(recursive: true);
+      } on io.FileSystemException catch (e) {
+        // Races the previous swap's own background delete of this same path.
+        // Losing that race is not a reason to throw away a library that has
+        // just been fetched and unpacked in full.
+        LogService.error('[IrLib] could not clear the previous library: $e');
+      }
     }
 
     final hadLibrary = await root.exists();
     if (hadLibrary) await root.rename(superseded.path);
     try {
       await incoming.rename(root.path);
-    } catch (e) {
+    } catch (_) {
       // The only moment there is no library at all. Put the old one back
-      // rather than leave the user with nothing.
+      // rather than leave the user with nothing - and in its own guard, so a
+      // rollback that fails does not replace the failure that caused it with
+      // one about renaming a directory nobody has heard of.
       if (hadLibrary && !await root.exists()) {
-        await superseded.rename(root.path);
+        try {
+          await superseded.rename(root.path);
+        } catch (rollbackError) {
+          LogService.error(
+            '[IrLib] could not put the library back: $rollbackError',
+          );
+        }
       }
       rethrow;
     }
@@ -235,9 +309,13 @@ class IrLibLocalRepo {
   /// and its replacement is not yet in place. Dying there is the one case that
   /// loses data, so it is the one checked first.
   static Future<void> recoverInterrupted(io.Directory root) async {
-    final incoming = io.Directory('${root.path}$_kIncomingSuffix');
-    final superseded = io.Directory('${root.path}$_kSupersededSuffix');
+    // Nothing here is leftover while a refresh is using it.
+    if (_refreshing) return;
 
+    final incoming = _sidecar(root, _kIncomingSuffix);
+    final superseded = _sidecar(root, _kSupersededSuffix);
+
+    var restoreFailed = false;
     if (!await root.exists() && await superseded.exists()) {
       try {
         await superseded.rename(root.path);
@@ -245,11 +323,22 @@ class IrLibLocalRepo {
           '[IrLib] put the library back after an interrupted swap',
         );
       } catch (e) {
+        restoreFailed = true;
         LogService.error('[IrLib] could not put the library back: $e');
       }
     }
 
-    for (final leftover in [incoming, superseded]) {
+    // Not superseded, if the restore could not move it: it is then the only
+    // copy of the library there is, which is the whole reason the restore was
+    // being attempted. Leaving it costs disk and the next run tries again;
+    // deleting it is the one thing this routine must never do. Note a failed
+    // recursive delete is not a no-op either - on Windows one locked file
+    // stops it part way through, having already removed what came before.
+    final leftovers = restoreFailed ? [incoming] : [incoming, superseded];
+
+    // Either may already be gone, and superseded will be whenever the restore
+    // above ran.
+    for (final leftover in leftovers) {
       if (!await leftover.exists()) continue;
       try {
         await leftover.delete(recursive: true);

--- a/lib/pages/tools/infrared/local_repo.dart
+++ b/lib/pages/tools/infrared/local_repo.dart
@@ -59,6 +59,7 @@ class IrLibLocalRepo {
 
   Future<bool> exists() async {
     final dir = await resolveRoot();
+    await recoverInterrupted(dir);
     if (!await dir.exists()) return false;
     await for (final _ in dir.list(followLinks: false)) {
       return true;
@@ -79,11 +80,17 @@ class IrLibLocalRepo {
 
   Future<void> deleteAll() async {
     final dir = await resolveRoot();
-    if (!await dir.exists()) return;
-    try {
-      await dir.delete(recursive: true);
-    } on io.PathNotFoundException {
-      return;
+    for (final target in [
+      dir,
+      io.Directory('${dir.path}$_kIncomingSuffix'),
+      io.Directory('${dir.path}$_kSupersededSuffix'),
+    ]) {
+      if (!await target.exists()) continue;
+      try {
+        await target.delete(recursive: true);
+      } on io.PathNotFoundException {
+        continue;
+      }
     }
   }
 
@@ -95,10 +102,15 @@ class IrLibLocalRepo {
     void Function(IrLibDownloadProgress)? onProgress,
   }) async {
     final root = await resolveRoot();
-    if (await root.exists()) {
-      await root.delete(recursive: true);
-    }
-    await root.create(recursive: true);
+    await recoverInterrupted(root);
+
+    // Built beside the library rather than over it. The old one stays whole
+    // and usable until there is a complete replacement to put in its place -
+    // a refresh that fails for any reason now costs the user nothing, where
+    // before it cost them the library they already had.
+    final incoming = io.Directory('${root.path}$_kIncomingSuffix');
+    if (await incoming.exists()) await incoming.delete(recursive: true);
+    await incoming.create(recursive: true);
 
     onProgress?.call(IrLibDownloadProgress(stage: l10n.irDownloading));
 
@@ -144,7 +156,7 @@ class IrLibLocalRepo {
     try {
       await _unpackInIsolate(
         zipPath: tempZip.path,
-        rootPath: root.path,
+        rootPath: incoming.path,
         sep: sep,
         onProgress: (extracted, totalFiles, done) {
           onProgress?.call(
@@ -166,7 +178,85 @@ class IrLibLocalRepo {
       }
     }
 
+    await swapIn(root, incoming);
     return root;
+  }
+
+  static const String _kIncomingSuffix = '.incoming';
+  static const String _kSupersededSuffix = '.superseded';
+
+  /// Puts a freshly unpacked tree in place of the library.
+  ///
+  /// Three renames rather than the one this reads like it should need: no
+  /// platform will rename a directory onto a populated one. Windows throws
+  /// PathExistsException — for an empty destination as well — and POSIX
+  /// `rename(2)` replaces only an empty directory and fails ENOTEMPTY
+  /// otherwise, which is exactly the state the old library is in. So the old
+  /// tree is moved aside first, and all three are metadata operations.
+  ///
+  /// Deleting the superseded tree is what used to be on the critical path, and
+  /// it is the expensive part: ~1,578 ms for 14,800 files, measured on NTFS.
+  /// It runs unawaited afterwards, and a run that dies before it finishes
+  /// leaves a directory [recoverInterrupted] clears next time.
+  static Future<void> swapIn(io.Directory root, io.Directory incoming) async {
+    final superseded = io.Directory('${root.path}$_kSupersededSuffix');
+    if (await superseded.exists()) {
+      await superseded.delete(recursive: true);
+    }
+
+    final hadLibrary = await root.exists();
+    if (hadLibrary) await root.rename(superseded.path);
+    try {
+      await incoming.rename(root.path);
+    } catch (e) {
+      // The only moment there is no library at all. Put the old one back
+      // rather than leave the user with nothing.
+      if (hadLibrary && !await root.exists()) {
+        await superseded.rename(root.path);
+      }
+      rethrow;
+    }
+
+    if (!hadLibrary) return;
+    unawaited(
+      superseded.delete(recursive: true).catchError((Object e) {
+        // Losing this costs disk, not correctness, and the next refresh
+        // clears it. Failing the download over it would be worse.
+        LogService.error('[IrLib] could not remove the old library: $e');
+        return superseded;
+      }),
+    );
+  }
+
+  /// Repairs whatever a process that died mid-refresh left behind.
+  ///
+  /// The swap is only as atomic as two renames back to back, so there is a
+  /// window — short, but not nothing — where the library has been moved aside
+  /// and its replacement is not yet in place. Dying there is the one case that
+  /// loses data, so it is the one checked first.
+  static Future<void> recoverInterrupted(io.Directory root) async {
+    final incoming = io.Directory('${root.path}$_kIncomingSuffix');
+    final superseded = io.Directory('${root.path}$_kSupersededSuffix');
+
+    if (!await root.exists() && await superseded.exists()) {
+      try {
+        await superseded.rename(root.path);
+        LogService.log(
+          '[IrLib] put the library back after an interrupted swap',
+        );
+      } catch (e) {
+        LogService.error('[IrLib] could not put the library back: $e');
+      }
+    }
+
+    for (final leftover in [incoming, superseded]) {
+      if (!await leftover.exists()) continue;
+      try {
+        await leftover.delete(recursive: true);
+      } catch (e) {
+        LogService.error('[IrLib] could not clear ${leftover.path}: $e');
+      }
+    }
   }
 
   /// Inflates the IR database zip and writes every entry to disk inside a

--- a/lib/pages/tools/infrared/local_repo.dart
+++ b/lib/pages/tools/infrared/local_repo.dart
@@ -50,22 +50,48 @@ class IrLibLocalRepo {
 
   static io.Directory? _cachedRoot;
 
-  /// True while a refresh owns the staging directories.
+  /// Serialises everything that moves the library or its staging trees.
   ///
-  /// A page builds its own controller, so opening the library while a download
-  /// runs brings a second one along, and its exists() check used to reach
-  /// straight past the isolate and delete the tree it was unpacking into. The
-  /// unpack does not notice - its created-directory cache stops it re-making
-  /// the parents - so entries land in `skipped` and, if few enough clear the
-  /// tolerance, a truncated library gets sworn in as a whole one.
-  static bool _refreshing = false;
+  /// A page builds its own controller, so a second page opened during a
+  /// refresh brings a second repo along, and these are process-wide
+  /// directories. Two refreshes at once shared one staging path, so the later
+  /// one deleted the tree the earlier was still unpacking into - and the
+  /// unpack does not notice, because its created-directory cache will not
+  /// re-make a parent it has already seen, so entries land in `skipped` and,
+  /// if few enough clear the tolerance, a truncated library is sworn in as a
+  /// whole one. A delete racing a refresh did the same.
+  ///
+  /// Held across the whole of a refresh or a delete, so they queue rather than
+  /// interleave.
+  static Future<void> _chain = Future<void>.value();
+
+  /// True while [_exclusive] is running something, so recovery can decline
+  /// rather than queue behind a download it would otherwise wait out.
+  static bool _busy = false;
+
+  static Future<T> _exclusive<T>(Future<T> Function() body) {
+    final previous = _chain;
+    final released = Completer<void>();
+    _chain = released.future;
+    return previous
+        .then((_) async {
+          _busy = true;
+          try {
+            return await body();
+          } finally {
+            _busy = false;
+          }
+        })
+        .whenComplete(released.complete);
+  }
 
   /// Points the library at [dir] for the duration of a test, and clears the
   /// refresh flag so one test cannot strand the next.
   @visibleForTesting
   static void debugUseRoot(io.Directory? dir) {
     _cachedRoot = dir;
-    _refreshing = false;
+    _busy = false;
+    _chain = Future<void>.value();
   }
 
   Future<io.Directory> resolveRoot() async {
@@ -99,6 +125,12 @@ class IrLibLocalRepo {
 
   Future<void> deleteAll() async {
     final dir = await resolveRoot();
+    // Under the lock: a delete that ran beside a refresh took the staging tree
+    // out from under its unpack.
+    await _exclusive(() => _deleteAll(dir));
+  }
+
+  static Future<void> _deleteAll(io.Directory dir) async {
     // Sidecars first, the library last. The other order leaves root missing
     // while .superseded still stands - the exact signature recoverInterrupted
     // reads as an interrupted swap - so anything that stopped the delete part
@@ -106,7 +138,7 @@ class IrLibLocalRepo {
     // been asked for.
     for (final target in [
       _sidecar(dir, _kIncomingSuffix),
-      _sidecar(dir, _kSupersededSuffix),
+      ...await _supersededTrees(dir),
       dir,
     ]) {
       if (!await target.exists()) continue;
@@ -127,112 +159,120 @@ class IrLibLocalRepo {
   }) async {
     final root = await resolveRoot();
     await recoverInterrupted(root);
-    _refreshing = true;
-    try {
-      return await _download(
-        root: root,
-        owner: owner,
-        repo: repo,
-        branch: branch,
-        token: token,
-        onProgress: onProgress,
+    return _exclusive(() async {
+      // Built beside the library rather than over it. The old one stays whole
+      // and usable until there is a complete replacement to put in its place -
+      // a refresh that fails for any reason now costs the user nothing, where
+      // before it cost them the library they already had.
+      final incoming = _sidecar(root, _kIncomingSuffix);
+      // Not redundant with the recovery above: that one logs and carries on when
+      // a delete fails, so a tree it could not clear would otherwise be unpacked
+      // straight over.
+      if (await incoming.exists()) await incoming.delete(recursive: true);
+      await incoming.create(recursive: true);
+
+      onProgress?.call(IrLibDownloadProgress(stage: l10n.irDownloading));
+
+      final url = Uri.parse(
+        'https://codeload.github.com/$owner/$repo/zip/refs/heads/$branch',
       );
-    } finally {
-      _refreshing = false;
-    }
-  }
-
-  Future<io.Directory> _download({
-    required io.Directory root,
-    required String owner,
-    required String repo,
-    required String branch,
-    required String token,
-    void Function(IrLibDownloadProgress)? onProgress,
-  }) async {
-    // Built beside the library rather than over it. The old one stays whole
-    // and usable until there is a complete replacement to put in its place -
-    // a refresh that fails for any reason now costs the user nothing, where
-    // before it cost them the library they already had.
-    final incoming = _sidecar(root, _kIncomingSuffix);
-    // Not redundant with the recovery above: that one logs and carries on when
-    // a delete fails, so a tree it could not clear would otherwise be unpacked
-    // straight over.
-    if (await incoming.exists()) await incoming.delete(recursive: true);
-    await incoming.create(recursive: true);
-
-    onProgress?.call(IrLibDownloadProgress(stage: l10n.irDownloading));
-
-    final url = Uri.parse(
-      'https://codeload.github.com/$owner/$repo/zip/refs/heads/$branch',
-    );
-    final tempDir = await getTemporaryDirectory();
-    final sep = io.Platform.pathSeparator;
-    final tempZip = io.File(
-      '${tempDir.path}${sep}irdb-${DateTime.now().millisecondsSinceEpoch}.zip',
-    );
-    var received = 0;
-    var total = 0;
-    await AppHttp.downloadToFile(
-      url,
-      tempZip.path,
-      headers: {
-        io.HttpHeaders.userAgentHeader: 'qunleashed-irlib',
-        if (token.trim().isNotEmpty)
-          io.HttpHeaders.authorizationHeader: 'Bearer ${token.trim()}',
-      },
-      onProgress: (bytes, totalBytes) {
-        received = bytes;
-        total = totalBytes ?? 0;
-        onProgress?.call(
-          IrLibDownloadProgress(
-            stage: l10n.irDownloading,
-            received: received,
-            total: total,
-          ),
-        );
-      },
-    );
-
-    onProgress?.call(
-      IrLibDownloadProgress(
-        stage: l10n.irUnpacking,
-        received: received,
-        total: total,
-      ),
-    );
-
-    try {
-      await _unpackInIsolate(
-        zipPath: tempZip.path,
-        rootPath: incoming.path,
-        sep: sep,
-        onProgress: (extracted, totalFiles, done) {
+      final tempDir = await getTemporaryDirectory();
+      final sep = io.Platform.pathSeparator;
+      final tempZip = io.File(
+        '${tempDir.path}${sep}irdb-${DateTime.now().millisecondsSinceEpoch}.zip',
+      );
+      var received = 0;
+      var total = 0;
+      await AppHttp.downloadToFile(
+        url,
+        tempZip.path,
+        headers: {
+          io.HttpHeaders.userAgentHeader: 'qunleashed-irlib',
+          if (token.trim().isNotEmpty)
+            io.HttpHeaders.authorizationHeader: 'Bearer ${token.trim()}',
+        },
+        onProgress: (bytes, totalBytes) {
+          received = bytes;
+          total = totalBytes ?? 0;
           onProgress?.call(
             IrLibDownloadProgress(
-              stage: done ? l10n.irDone : l10n.irUnpacking,
+              stage: l10n.irDownloading,
               received: received,
               total: total,
-              extracted: extracted,
-              totalFiles: totalFiles,
             ),
           );
         },
       );
-    } finally {
-      if (await tempZip.exists()) {
-        try {
-          await tempZip.delete();
-        } catch (_) {}
-      }
-    }
 
-    await swapIn(root, incoming);
-    return root;
+      onProgress?.call(
+        IrLibDownloadProgress(
+          stage: l10n.irUnpacking,
+          received: received,
+          total: total,
+        ),
+      );
+
+      try {
+        await _unpackInIsolate(
+          zipPath: tempZip.path,
+          rootPath: incoming.path,
+          sep: sep,
+          onProgress: (extracted, totalFiles, done) {
+            onProgress?.call(
+              IrLibDownloadProgress(
+                stage: done ? l10n.irDone : l10n.irUnpacking,
+                received: received,
+                total: total,
+                extracted: extracted,
+                totalFiles: totalFiles,
+              ),
+            );
+          },
+        );
+      } finally {
+        if (await tempZip.exists()) {
+          try {
+            await tempZip.delete();
+          } catch (_) {}
+        }
+      }
+
+      await swapIn(root, incoming);
+      return root;
+    });
   }
 
   static const String _kIncomingSuffix = '.incoming';
-  static const String _kSupersededSuffix = '.superseded';
+  static const String _kSupersededPrefix = '.superseded';
+
+  /// A name no other swap will pick.
+  ///
+  /// One fixed name meant the tree being deleted in the background and the
+  /// destination the next swap renames into were the same path. A delete that
+  /// failed part way - one locked file is enough, and a blocked recursive
+  /// delete removes what it reached before it stopped - then left something
+  /// standing there, and every later refresh died renaming onto it. That is
+  /// not recoverable by retrying: it wedges the library until someone finds a
+  /// hidden directory and removes it by hand. A fresh name each time means a
+  /// leftover can only ever be swept up, never collided with.
+  static io.Directory _freshSuperseded(io.Directory root) => io.Directory(
+    '${root.path}$_kSupersededPrefix.${DateTime.now().microsecondsSinceEpoch}',
+  );
+
+  /// Every superseded tree beside the library, newest first.
+  static Future<List<io.Directory>> _supersededTrees(io.Directory root) async {
+    final parent = root.parent;
+    if (!await parent.exists()) return const [];
+    final prefix = '${basename(root.path)}$_kSupersededPrefix';
+    final found = <io.Directory>[];
+    await for (final entity in parent.list(followLinks: false)) {
+      if (entity is io.Directory && basename(entity.path).startsWith(prefix)) {
+        found.add(entity);
+      }
+    }
+    found.sort((a, b) => b.path.compareTo(a.path));
+    return found;
+  }
 
   /// Where the staging trees live: beside the library, never inside it.
   ///
@@ -243,6 +283,25 @@ class IrLibLocalRepo {
   /// going to land on.
   static io.Directory _sidecar(io.Directory root, String suffix) =>
       io.Directory('${root.path}$suffix');
+
+  /// Puts the superseded tree back where the library belongs.
+  ///
+  /// Returns whether it landed. Both the rollback inside [swapIn] and the
+  /// repair in [recoverInterrupted] are this same move, and the caller has to
+  /// know whether it worked: at that moment the superseded tree is the only
+  /// copy of the library there is.
+  static Future<bool> _restoreSuperseded(
+    io.Directory root,
+    io.Directory superseded,
+  ) async {
+    try {
+      await superseded.rename(root.path);
+      return true;
+    } catch (e) {
+      LogService.error('[IrLib] could not put the library back: $e');
+      return false;
+    }
+  }
 
   /// Puts a freshly unpacked tree in place of the library.
   ///
@@ -258,17 +317,9 @@ class IrLibLocalRepo {
   /// dies before it finishes leaves a directory [recoverInterrupted] clears
   /// next time.
   static Future<void> swapIn(io.Directory root, io.Directory incoming) async {
-    final superseded = _sidecar(root, _kSupersededSuffix);
-    if (await superseded.exists()) {
-      try {
-        await superseded.delete(recursive: true);
-      } on io.FileSystemException catch (e) {
-        // Races the previous swap's own background delete of this same path.
-        // Losing that race is not a reason to throw away a library that has
-        // just been fetched and unpacked in full.
-        LogService.error('[IrLib] could not clear the previous library: $e');
-      }
-    }
+    // Named for this swap alone, so it cannot be the tree a previous swap is
+    // still deleting in the background. Nothing has to be cleared first.
+    final superseded = _freshSuperseded(root);
 
     final hadLibrary = await root.exists();
     if (hadLibrary) await root.rename(superseded.path);
@@ -276,29 +327,28 @@ class IrLibLocalRepo {
       await incoming.rename(root.path);
     } catch (_) {
       // The only moment there is no library at all. Put the old one back
-      // rather than leave the user with nothing - and in its own guard, so a
-      // rollback that fails does not replace the failure that caused it with
-      // one about renaming a directory nobody has heard of.
+      // rather than leave the user with nothing, and let the original failure
+      // be the one that surfaces.
       if (hadLibrary && !await root.exists()) {
-        try {
-          await superseded.rename(root.path);
-        } catch (rollbackError) {
-          LogService.error(
-            '[IrLib] could not put the library back: $rollbackError',
-          );
-        }
+        await _restoreSuperseded(root, superseded);
       }
       rethrow;
     }
 
     if (!hadLibrary) return;
     unawaited(
-      superseded.delete(recursive: true).catchError((Object e) {
-        // Losing this costs disk, not correctness, and the next refresh
-        // clears it. Failing the download over it would be worse.
-        LogService.error('[IrLib] could not remove the old library: $e');
-        return superseded;
-      }),
+      superseded.delete(recursive: true).catchError(
+        (Object e) {
+          // Costs disk, not correctness: the tree is named for this swap, so
+          // a leftover is swept up by the next recovery rather than collided
+          // with. Failing a finished download over it would be worse.
+          LogService.error('[IrLib] could not remove the old library: $e');
+          return superseded;
+        },
+        // Narrow, so a fault in this path is not quietly turned into a no-op
+        // by a handler meant for the filesystem refusing a delete.
+        test: (Object e) => e is io.FileSystemException,
+      ),
     );
   }
 
@@ -309,35 +359,39 @@ class IrLibLocalRepo {
   /// and its replacement is not yet in place. Dying there is the one case that
   /// loses data, so it is the one checked first.
   static Future<void> recoverInterrupted(io.Directory root) async {
-    // Nothing here is leftover while a refresh is using it.
-    if (_refreshing) return;
+    // Nothing beside the library is leftover while something is using it.
+    if (_busy) return;
 
     final incoming = _sidecar(root, _kIncomingSuffix);
-    final superseded = _sidecar(root, _kSupersededSuffix);
+    final superseded = await _supersededTrees(root);
 
-    var restoreFailed = false;
-    if (!await root.exists() && await superseded.exists()) {
-      try {
-        await superseded.rename(root.path);
+    // The newest is the one the interrupted swap set aside; anything older is
+    // a background delete that never finished.
+    var kept = <io.Directory>[];
+    if (!await root.exists() && superseded.isNotEmpty) {
+      final live = superseded.first;
+      if (await _restoreSuperseded(root, live)) {
         LogService.log(
           '[IrLib] put the library back after an interrupted swap',
         );
-      } catch (e) {
-        restoreFailed = true;
-        LogService.error('[IrLib] could not put the library back: $e');
+      } else {
+        // It is the only copy of the library there is, which is the whole
+        // reason the restore was being attempted. Leaving it costs disk and
+        // the next run tries again; deleting it is the one thing this routine
+        // must never do - and a failed recursive delete is not a no-op either,
+        // since one locked file stops it having already removed what it
+        // reached first.
+        kept = [live];
       }
     }
 
-    // Not superseded, if the restore could not move it: it is then the only
-    // copy of the library there is, which is the whole reason the restore was
-    // being attempted. Leaving it costs disk and the next run tries again;
-    // deleting it is the one thing this routine must never do. Note a failed
-    // recursive delete is not a no-op either - on Windows one locked file
-    // stops it part way through, having already removed what came before.
-    final leftovers = restoreFailed ? [incoming] : [incoming, superseded];
+    final leftovers = [
+      incoming,
+      for (final tree in superseded)
+        if (!kept.contains(tree)) tree,
+    ];
 
-    // Either may already be gone, and superseded will be whenever the restore
-    // above ran.
+    // A restore consumes the tree it moved, so it is gone by now.
     for (final leftover in leftovers) {
       if (!await leftover.exists()) continue;
       try {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -772,7 +772,7 @@ packages:
     source: hosted
     version: "2.2.1"
   path_provider_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: path_provider_platform_interface
       sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,6 +61,11 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^6.0.0
+  # Lets a test stand in for getTemporaryDirectory. Mocking the method channel
+  # is not enough: path_provider_windows is pure Dart over FFI and never goes
+  # near a channel, so the platform interface is the only seam that works
+  # everywhere.
+  path_provider_platform_interface: ^2.1.2
 
 flutter:
   config:

--- a/test/ir_library_refresh_test.dart
+++ b/test/ir_library_refresh_test.dart
@@ -1,0 +1,212 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
+
+import 'package:archive/archive_io.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
+import 'package:qunleashed/pages/tools/infrared/local_repo.dart';
+
+final String sep = Platform.pathSeparator;
+
+/// Stands in for `getTemporaryDirectory()`.
+///
+/// Through the platform interface rather than the method channel: the Windows
+/// implementation is pure Dart over FFI and never goes near a channel, so a
+/// channel mock works on some platforms and silently does nothing on others.
+class _FakePathProvider extends PathProviderPlatform {
+  _FakePathProvider(this.temp);
+  final String temp;
+
+  @override
+  Future<String?> getTemporaryPath() async => temp;
+}
+
+/// Serves one body to whatever `AppHttp` asks for.
+///
+/// `AppHttp.client` is a lazy `static final`, built on first touch and then
+/// kept for the isolate, so the body has to be reachable through a mutable
+/// hook rather than captured when the client is made.
+class _FakeHttpOverrides extends HttpOverrides {
+  static late List<int> body;
+  static int status = 200;
+
+  @override
+  HttpClient createHttpClient(SecurityContext? context) => _FakeHttpClient();
+}
+
+class _FakeHttpClient implements HttpClient {
+  @override
+  Future<HttpClientRequest> getUrl(Uri url) async => _FakeRequest();
+
+  @override
+  noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeRequest implements HttpClientRequest {
+  @override
+  final HttpHeaders headers = _FakeHeaders();
+
+  @override
+  Future<HttpClientResponse> close() async => _FakeResponse();
+
+  @override
+  noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeHeaders implements HttpHeaders {
+  @override
+  void set(String name, Object value, {bool preserveHeaderCase = false}) {}
+
+  @override
+  noSuchMethod(Invocation invocation) => null;
+}
+
+class _FakeResponse extends Stream<List<int>> implements HttpClientResponse {
+  final _body = _FakeHttpOverrides.body;
+
+  @override
+  int get statusCode => _FakeHttpOverrides.status;
+
+  @override
+  int get contentLength => _body.length;
+
+  @override
+  StreamSubscription<List<int>> listen(
+    void Function(List<int> event)? onData, {
+    Function? onError,
+    void Function()? onDone,
+    bool? cancelOnError,
+  }) => Stream<List<int>>.value(_body).listen(
+    onData,
+    onError: onError,
+    onDone: onDone,
+    cancelOnError: cancelOnError,
+  );
+
+  @override
+  noSuchMethod(Invocation invocation) => null;
+}
+
+/// The shape codeload serves: every entry inside one wrapper folder.
+List<int> irdbZip(
+  Map<String, String> files, {
+  String wrapper = 'Flipper-IRDB-main',
+}) {
+  final archive = Archive();
+  files.forEach((name, content) {
+    archive.add(
+      ArchiveFile.bytes(
+        '$wrapper/$name',
+        Uint8List.fromList(content.codeUnits),
+      ),
+    );
+  });
+  return ZipEncoder().encode(archive);
+}
+
+void main() {
+  late Directory base;
+  late Directory root;
+  late Directory temp;
+
+  setUpAll(() => HttpOverrides.global = _FakeHttpOverrides());
+  tearDownAll(() => HttpOverrides.global = null);
+
+  setUp(() {
+    base = Directory.systemTemp.createTempSync('ir_refresh_test');
+    root = Directory('${base.path}${sep}irlib');
+    temp = Directory('${base.path}${sep}tmp')..createSync();
+    PathProviderPlatform.instance = _FakePathProvider(temp.path);
+    IrLibLocalRepo.debugUseRoot(root);
+    addTearDown(() => IrLibLocalRepo.debugUseRoot(null));
+    _FakeHttpOverrides.status = 200;
+  });
+
+  tearDown(() {
+    if (base.existsSync()) base.deleteSync(recursive: true);
+  });
+
+  Future<Directory> refresh() => IrLibLocalRepo().download(
+    owner: 'Lucaslhm',
+    repo: 'Flipper-IRDB',
+    branch: 'main',
+  );
+
+  String read(String relative) => File(
+    '${root.path}$sep${relative.replaceAll('/', sep)}',
+  ).readAsStringSync();
+
+  test('a refresh unpacks the library and puts it in place', () async {
+    _FakeHttpOverrides.body = irdbZip({'TVs/Sony.ir': 'sony remote'});
+
+    await refresh();
+
+    expect(read('TVs/Sony.ir'), 'sony remote');
+  });
+
+  // The staging is the point: the unpack has to land beside the library, and
+  // only a finished one replaces it. Writing into the root directly would pass
+  // every test that only drives swapIn.
+  test(
+    'an existing library is replaced only once the new one is whole',
+    () async {
+      Directory('${root.path}${sep}TVs').createSync(recursive: true);
+      File('${root.path}${sep}TVs${sep}Old.ir').writeAsStringSync('old remote');
+      _FakeHttpOverrides.body = irdbZip({'TVs/Sony.ir': 'sony remote'});
+
+      await refresh();
+
+      expect(read('TVs/Sony.ir'), 'sony remote');
+      expect(
+        File('${root.path}${sep}TVs${sep}Old.ir').existsSync(),
+        isFalse,
+        reason: 'the whole tree is replaced, not merged into',
+      );
+    },
+  );
+
+  // #62 itself. The old code deleted the library before it fetched a byte, so
+  // anything that went wrong afterwards left the user with nothing.
+  test('a refresh that fails leaves the library exactly as it was', () async {
+    Directory('${root.path}${sep}TVs').createSync(recursive: true);
+    File('${root.path}${sep}TVs${sep}Old.ir').writeAsStringSync('old remote');
+    _FakeHttpOverrides.status = 500;
+
+    await expectLater(refresh(), throwsA(anything));
+
+    expect(read('TVs/Old.ir'), 'old remote');
+  });
+
+  test('a library that will not unpack is not swapped in', () async {
+    Directory('${root.path}${sep}TVs').createSync(recursive: true);
+    File('${root.path}${sep}TVs${sep}Old.ir').writeAsStringSync('old remote');
+    _FakeHttpOverrides.body = const [1, 2, 3, 4, 5];
+
+    await expectLater(refresh(), throwsA(anything));
+
+    expect(read('TVs/Old.ir'), 'old remote');
+  });
+
+  test('the staging tree does not survive a finished refresh', () async {
+    _FakeHttpOverrides.body = irdbZip({'TVs/Sony.ir': 'sony remote'});
+
+    await refresh();
+
+    expect(Directory('${root.path}.incoming').existsSync(), isFalse);
+  });
+
+  // exists() repairs on the way past, and is the most-travelled route into
+  // recovery — it runs whenever the library page opens.
+  test('opening the library repairs a swap that was interrupted', () async {
+    final aside = Directory('${root.path}.superseded.1000')
+      ..createSync(recursive: true);
+    Directory('${aside.path}${sep}TVs').createSync(recursive: true);
+    File('${aside.path}${sep}TVs${sep}Old.ir').writeAsStringSync('old remote');
+
+    final present = await IrLibLocalRepo().exists();
+
+    expect(present, isTrue);
+    expect(read('TVs/Old.ir'), 'old remote');
+  });
+}

--- a/test/ir_library_swap_test.dart
+++ b/test/ir_library_swap_test.dart
@@ -33,10 +33,18 @@ void main() {
   String markerIn(Directory dir) =>
       File('${dir.path}${sep}Brand${sep}tv.ir').readAsStringSync();
 
-  /// The delete of the superseded tree is deliberately not awaited, so give it
-  /// a turn before asserting it is gone.
-  Future<void> settle() =>
-      Future<void>.delayed(const Duration(milliseconds: 50));
+  /// The delete of the superseded tree is deliberately not awaited, so wait
+  /// for it rather than guessing at a duration - it runs on the IO thread
+  /// pool, where a loaded machine can miss any fixed delay.
+  Future<void> waitGone(Directory dir) async {
+    final deadline = DateTime.now().add(const Duration(seconds: 5));
+    while (dir.existsSync()) {
+      if (DateTime.now().isAfter(deadline)) {
+        fail('${dir.path} was still there after 5s');
+      }
+      await Future<void>.delayed(const Duration(milliseconds: 5));
+    }
+  }
 
   group('swapping a new library in', () {
     test('the new tree replaces the old one', () async {
@@ -44,18 +52,17 @@ void main() {
       treeAt(incoming, 'new');
 
       await IrLibLocalRepo.swapIn(root, incoming);
-      await settle();
+      await waitGone(superseded);
 
       expect(markerIn(root), 'new');
       expect(incoming.existsSync(), isFalse);
-      expect(superseded.existsSync(), isFalse, reason: 'cleared afterwards');
     });
 
     test('works when there was no library to replace', () async {
       treeAt(incoming, 'new');
 
       await IrLibLocalRepo.swapIn(root, incoming);
-      await settle();
+      await waitGone(superseded);
 
       expect(markerIn(root), 'new');
     });
@@ -66,7 +73,7 @@ void main() {
       treeAt(superseded, 'older still');
 
       await IrLibLocalRepo.swapIn(root, incoming);
-      await settle();
+      await waitGone(superseded);
 
       expect(markerIn(root), 'new');
     });
@@ -137,6 +144,84 @@ void main() {
       await IrLibLocalRepo.recoverInterrupted(root);
 
       expect(root.existsSync(), isFalse);
+    });
+  });
+
+  group('the states review found unguarded', () {
+    // The restore failing leaves .superseded holding the only copy there is.
+    // Deleting it then - which the first version did, unconditionally - turns
+    // a recoverable interruption into the loss it was there to prevent.
+    test('a library that cannot be put back is kept, not cleared', () async {
+      treeAt(superseded, 'the only copy');
+      // A file where the library goes: the rename cannot land.
+      File(root.path).writeAsStringSync('in the way');
+
+      await IrLibLocalRepo.recoverInterrupted(root);
+
+      expect(
+        Directory(superseded.path).existsSync(),
+        isTrue,
+        reason: 'the last copy of the library must survive a failed restore',
+      );
+      expect(markerIn(superseded), 'the only copy');
+    });
+
+    // Deleting the library first leaves root missing while .superseded stands,
+    // which is indistinguishable from an interrupted swap - so an interrupted
+    // delete used to hand the previous library back.
+    test('a part-finished delete cannot resurrect the old library', () async {
+      treeAt(root, 'current');
+      treeAt(superseded, 'previous');
+      IrLibLocalRepo.debugUseRoot(root);
+      addTearDown(() => IrLibLocalRepo.debugUseRoot(null));
+
+      await IrLibLocalRepo().deleteAll();
+      await IrLibLocalRepo.recoverInterrupted(root);
+
+      expect(root.existsSync(), isFalse, reason: 'the delete stays done');
+      expect(superseded.existsSync(), isFalse);
+    });
+  });
+
+  group('what a refresh does before it fetches anything', () {
+    // #62 in one assertion. download() reaches getTemporaryDirectory, which
+    // has no plugin in a unit test, so it fails in the window the old code
+    // had already deleted the library in.
+    test('a refresh that fails early leaves the library standing', () async {
+      treeAt(root, 'old');
+      IrLibLocalRepo.debugUseRoot(root);
+      addTearDown(() => IrLibLocalRepo.debugUseRoot(null));
+
+      await expectLater(
+        IrLibLocalRepo().download(owner: 'o', repo: 'r', branch: 'b'),
+        throwsA(anything),
+      );
+
+      expect(
+        markerIn(root),
+        'old',
+        reason: 'the library is untouched until there is a replacement',
+      );
+      expect(
+        incoming.existsSync(),
+        isTrue,
+        reason: 'staged beside the library rather than over it',
+      );
+    });
+
+    test('the staging tree is cleared by the next recovery', () async {
+      treeAt(root, 'old');
+      IrLibLocalRepo.debugUseRoot(root);
+      addTearDown(() => IrLibLocalRepo.debugUseRoot(null));
+
+      await expectLater(
+        IrLibLocalRepo().download(owner: 'o', repo: 'r', branch: 'b'),
+        throwsA(anything),
+      );
+      await IrLibLocalRepo.recoverInterrupted(root);
+
+      expect(incoming.existsSync(), isFalse);
+      expect(markerIn(root), 'old');
     });
   });
 }

--- a/test/ir_library_swap_test.dart
+++ b/test/ir_library_swap_test.dart
@@ -5,42 +5,59 @@ import 'package:qunleashed/pages/tools/infrared/local_repo.dart';
 
 final String sep = Platform.pathSeparator;
 
+/// A tree with one marker file, so which tree ended up where is visible.
+Directory _treeAt(Directory dir, String marker) {
+  dir.createSync(recursive: true);
+  Directory('${dir.path}${sep}Brand').createSync(recursive: true);
+  File('${dir.path}${sep}Brand${sep}tv.ir').writeAsStringSync(marker);
+  return dir;
+}
+
+String _markerIn(Directory dir) =>
+    File('${dir.path}${sep}Brand${sep}tv.ir').readAsStringSync();
+
 void main() {
   late Directory base;
   late Directory root;
   late Directory incoming;
-  late Directory superseded;
 
   setUp(() {
     base = Directory.systemTemp.createTempSync('ir_swap_test');
     root = Directory('${base.path}${sep}irlib');
     incoming = Directory('${root.path}.incoming');
-    superseded = Directory('${root.path}.superseded');
   });
 
   tearDown(() {
     if (base.existsSync()) base.deleteSync(recursive: true);
   });
 
-  /// A tree with one marker file, so which tree ended up where is visible.
-  Directory treeAt(Directory dir, String marker) {
-    dir.createSync(recursive: true);
-    Directory('${dir.path}${sep}Brand').createSync(recursive: true);
-    File('${dir.path}${sep}Brand${sep}tv.ir').writeAsStringSync(marker);
-    return dir;
+  /// Each swap names its own superseded tree, so tests look them up rather
+  /// than assume a single fixed name.
+  List<Directory> supersededTrees() => base
+      .listSync()
+      .whereType<Directory>()
+      .where((d) => d.path.startsWith('${root.path}.superseded'))
+      .toList();
+
+  /// One left behind by an earlier run, with the shape a swap would give it.
+  Directory stubSuperseded(String marker, {int at = 1000}) =>
+      _treeAt(Directory('${root.path}.superseded.$at'), marker);
+
+  /// Points the repo at the test's own root, and takes the teardown with it —
+  /// a test that set the root and forgot to clear it would strand the next.
+  void useRoot(Directory dir) {
+    IrLibLocalRepo.debugUseRoot(dir);
+    addTearDown(() => IrLibLocalRepo.debugUseRoot(null));
   }
 
-  String markerIn(Directory dir) =>
-      File('${dir.path}${sep}Brand${sep}tv.ir').readAsStringSync();
-
-  /// The delete of the superseded tree is deliberately not awaited, so wait
-  /// for it rather than guessing at a duration - it runs on the IO thread
-  /// pool, where a loaded machine can miss any fixed delay.
-  Future<void> waitGone(Directory dir) async {
+  /// The superseded tree is deleted unawaited, so wait for it rather than
+  /// guessing at a duration — it runs on the IO thread pool, where a loaded
+  /// machine can miss any fixed delay.
+  Future<void> waitUntilSwept() async {
     final deadline = DateTime.now().add(const Duration(seconds: 5));
-    while (dir.existsSync()) {
+    while (supersededTrees().isNotEmpty) {
       if (DateTime.now().isAfter(deadline)) {
-        fail('${dir.path} was still there after 5s');
+        fail('superseded trees were still there after 5s');
       }
       await Future<void>.delayed(const Duration(milliseconds: 5));
     }
@@ -48,96 +65,116 @@ void main() {
 
   group('swapping a new library in', () {
     test('the new tree replaces the old one', () async {
-      treeAt(root, 'old');
-      treeAt(incoming, 'new');
+      _treeAt(root, 'old');
+      _treeAt(incoming, 'new');
 
       await IrLibLocalRepo.swapIn(root, incoming);
-      await waitGone(superseded);
+      await waitUntilSwept();
 
-      expect(markerIn(root), 'new');
+      expect(_markerIn(root), 'new');
       expect(incoming.existsSync(), isFalse);
     });
 
     test('works when there was no library to replace', () async {
-      treeAt(incoming, 'new');
+      _treeAt(incoming, 'new');
 
       await IrLibLocalRepo.swapIn(root, incoming);
-      await waitGone(superseded);
 
-      expect(markerIn(root), 'new');
+      expect(_markerIn(root), 'new');
     });
 
-    test('a leftover superseded tree does not block the swap', () async {
-      treeAt(root, 'old');
-      treeAt(incoming, 'new');
-      treeAt(superseded, 'older still');
+    // The wedge: while every swap used one fixed name, a superseded tree that
+    // could not be deleted - one locked file is enough, and a blocked
+    // recursive delete removes what it reached before stopping - was the exact
+    // path the next swap had to rename onto. Every later refresh then died
+    // there, permanently, until someone found a hidden directory by hand. The
+    // stub sits at that fixed name on purpose.
+    test('a leftover at the old fixed name does not block the swap', () async {
+      _treeAt(root, 'old');
+      _treeAt(incoming, 'new');
+      final stale = _treeAt(
+        Directory('${root.path}.superseded'),
+        'wedged an earlier run',
+      );
 
       await IrLibLocalRepo.swapIn(root, incoming);
-      await waitGone(superseded);
 
-      expect(markerIn(root), 'new');
+      expect(_markerIn(root), 'new');
+      expect(
+        stale.existsSync(),
+        isTrue,
+        reason: 'left for recovery to sweep, not renamed over',
+      );
     });
 
     test('the old library is put back if the new one cannot move in', () async {
-      treeAt(root, 'old');
-      // No incoming at all: the second rename fails, and the library has
-      // already been moved aside by then.
+      _treeAt(root, 'old');
+
       await expectLater(
         IrLibLocalRepo.swapIn(root, incoming),
         throwsA(isA<FileSystemException>()),
       );
 
       expect(root.existsSync(), isTrue, reason: 'not left with nothing');
-      expect(markerIn(root), 'old');
+      expect(_markerIn(root), 'old');
     });
   });
 
   group('recovering an interrupted refresh', () {
     test('an unpack that never finished is cleared', () async {
-      treeAt(root, 'old');
-      treeAt(incoming, 'half done');
+      _treeAt(root, 'old');
+      _treeAt(incoming, 'half done');
 
       await IrLibLocalRepo.recoverInterrupted(root);
 
       expect(incoming.existsSync(), isFalse);
-      expect(markerIn(root), 'old', reason: 'the library is untouched');
+      expect(_markerIn(root), 'old');
     });
 
-    // The one window that loses data: the old tree has been moved aside and
-    // the new one is not in place yet.
+    // The one window that loses data: the library has been moved aside and
+    // its replacement is not in place yet.
     test(
       'a swap that died between the two renames puts the library back',
       () async {
-        treeAt(superseded, 'old');
+        stubSuperseded('old');
         expect(root.existsSync(), isFalse);
 
         await IrLibLocalRepo.recoverInterrupted(root);
 
-        expect(root.existsSync(), isTrue);
-        expect(markerIn(root), 'old');
-        expect(superseded.existsSync(), isFalse);
+        expect(_markerIn(root), 'old');
+        expect(supersededTrees(), isEmpty);
       },
     );
+
+    test('the newest tree is the one put back', () async {
+      stubSuperseded('older', at: 1000);
+      stubSuperseded('the one that was live', at: 2000);
+
+      await IrLibLocalRepo.recoverInterrupted(root);
+
+      expect(_markerIn(root), 'the one that was live');
+      expect(supersededTrees(), isEmpty, reason: 'the older one is swept');
+    });
 
     test(
       'a delete that never finished is cleared, library left alone',
       () async {
-        treeAt(root, 'current');
-        treeAt(superseded, 'stale');
+        _treeAt(root, 'current');
+        stubSuperseded('stale');
 
         await IrLibLocalRepo.recoverInterrupted(root);
 
-        expect(markerIn(root), 'current');
-        expect(superseded.existsSync(), isFalse);
+        expect(_markerIn(root), 'current');
+        expect(supersededTrees(), isEmpty);
       },
     );
 
     test('does nothing when there is nothing to repair', () async {
-      treeAt(root, 'current');
+      _treeAt(root, 'current');
 
       await IrLibLocalRepo.recoverInterrupted(root);
 
-      expect(markerIn(root), 'current');
+      expect(_markerIn(root), 'current');
     });
 
     test('is safe when there is no library at all', () async {
@@ -145,63 +182,36 @@ void main() {
 
       expect(root.existsSync(), isFalse);
     });
-  });
 
-  group('the states review found unguarded', () {
-    // The restore failing leaves .superseded holding the only copy there is.
-    // Deleting it then - which the first version did, unconditionally - turns
-    // a recoverable interruption into the loss it was there to prevent.
+    // A restore that cannot land leaves that tree holding the only copy of the
+    // library there is. Clearing it then — which the first version did, with
+    // no condition — turns a recoverable interruption into the loss recovery
+    // exists to prevent.
     test('a library that cannot be put back is kept, not cleared', () async {
-      treeAt(superseded, 'the only copy');
-      // A file where the library goes: the rename cannot land.
+      final stub = stubSuperseded('the only copy');
       File(root.path).writeAsStringSync('in the way');
 
       await IrLibLocalRepo.recoverInterrupted(root);
 
-      expect(
-        Directory(superseded.path).existsSync(),
-        isTrue,
-        reason: 'the last copy of the library must survive a failed restore',
-      );
-      expect(markerIn(superseded), 'the only copy');
-    });
-
-    // Deleting the library first leaves root missing while .superseded stands,
-    // which is indistinguishable from an interrupted swap - so an interrupted
-    // delete used to hand the previous library back.
-    test('a part-finished delete cannot resurrect the old library', () async {
-      treeAt(root, 'current');
-      treeAt(superseded, 'previous');
-      IrLibLocalRepo.debugUseRoot(root);
-      addTearDown(() => IrLibLocalRepo.debugUseRoot(null));
-
-      await IrLibLocalRepo().deleteAll();
-      await IrLibLocalRepo.recoverInterrupted(root);
-
-      expect(root.existsSync(), isFalse, reason: 'the delete stays done');
-      expect(superseded.existsSync(), isFalse);
+      expect(stub.existsSync(), isTrue);
+      expect(_markerIn(stub), 'the only copy');
     });
   });
 
   group('what a refresh does before it fetches anything', () {
     // #62 in one assertion. download() reaches getTemporaryDirectory, which
-    // has no plugin in a unit test, so it fails in the window the old code
-    // had already deleted the library in.
+    // has no plugin in a unit test, so it fails in the window the old code had
+    // already deleted the library in.
     test('a refresh that fails early leaves the library standing', () async {
-      treeAt(root, 'old');
-      IrLibLocalRepo.debugUseRoot(root);
-      addTearDown(() => IrLibLocalRepo.debugUseRoot(null));
+      _treeAt(root, 'old');
+      useRoot(root);
 
       await expectLater(
         IrLibLocalRepo().download(owner: 'o', repo: 'r', branch: 'b'),
         throwsA(anything),
       );
 
-      expect(
-        markerIn(root),
-        'old',
-        reason: 'the library is untouched until there is a replacement',
-      );
+      expect(_markerIn(root), 'old');
       expect(
         incoming.existsSync(),
         isTrue,
@@ -210,9 +220,8 @@ void main() {
     });
 
     test('the staging tree is cleared by the next recovery', () async {
-      treeAt(root, 'old');
-      IrLibLocalRepo.debugUseRoot(root);
-      addTearDown(() => IrLibLocalRepo.debugUseRoot(null));
+      _treeAt(root, 'old');
+      useRoot(root);
 
       await expectLater(
         IrLibLocalRepo().download(owner: 'o', repo: 'r', branch: 'b'),
@@ -221,7 +230,48 @@ void main() {
       await IrLibLocalRepo.recoverInterrupted(root);
 
       expect(incoming.existsSync(), isFalse);
-      expect(markerIn(root), 'old');
+      expect(_markerIn(root), 'old');
+    });
+
+    // Deleting the library first leaves root missing while a superseded tree
+    // stands, which is indistinguishable from an interrupted swap — so an
+    // interrupted delete used to hand the previous library back.
+    test('a delete cannot resurrect the previous library', () async {
+      _treeAt(root, 'current');
+      stubSuperseded('previous');
+      useRoot(root);
+
+      await IrLibLocalRepo().deleteAll();
+      await IrLibLocalRepo.recoverInterrupted(root);
+
+      expect(root.existsSync(), isFalse, reason: 'the delete stays done');
+      expect(supersededTrees(), isEmpty);
+    });
+
+    // Two pages mean two repos over one set of process-wide directories.
+    // Queued, the second refresh cannot delete the staging tree the first is
+    // unpacking into.
+    test('two refreshes queue rather than collide', () async {
+      _treeAt(root, 'old');
+      useRoot(root);
+
+      final outcomes = await Future.wait([
+        IrLibLocalRepo()
+            .download(owner: 'a', repo: 'r', branch: 'b')
+            .then<Object?>((d) => d)
+            .onError<Object>((e, _) => e),
+        IrLibLocalRepo()
+            .download(owner: 'b', repo: 'r', branch: 'b')
+            .then<Object?>((d) => d)
+            .onError<Object>((e, _) => e),
+      ]);
+
+      expect(
+        outcomes.whereType<Directory>(),
+        isEmpty,
+        reason: 'both failed on their own, neither on the other',
+      );
+      expect(_markerIn(root), 'old');
     });
   });
 }

--- a/test/ir_library_swap_test.dart
+++ b/test/ir_library_swap_test.dart
@@ -1,0 +1,142 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qunleashed/pages/tools/infrared/local_repo.dart';
+
+final String sep = Platform.pathSeparator;
+
+void main() {
+  late Directory base;
+  late Directory root;
+  late Directory incoming;
+  late Directory superseded;
+
+  setUp(() {
+    base = Directory.systemTemp.createTempSync('ir_swap_test');
+    root = Directory('${base.path}${sep}irlib');
+    incoming = Directory('${root.path}.incoming');
+    superseded = Directory('${root.path}.superseded');
+  });
+
+  tearDown(() {
+    if (base.existsSync()) base.deleteSync(recursive: true);
+  });
+
+  /// A tree with one marker file, so which tree ended up where is visible.
+  Directory treeAt(Directory dir, String marker) {
+    dir.createSync(recursive: true);
+    Directory('${dir.path}${sep}Brand').createSync(recursive: true);
+    File('${dir.path}${sep}Brand${sep}tv.ir').writeAsStringSync(marker);
+    return dir;
+  }
+
+  String markerIn(Directory dir) =>
+      File('${dir.path}${sep}Brand${sep}tv.ir').readAsStringSync();
+
+  /// The delete of the superseded tree is deliberately not awaited, so give it
+  /// a turn before asserting it is gone.
+  Future<void> settle() =>
+      Future<void>.delayed(const Duration(milliseconds: 50));
+
+  group('swapping a new library in', () {
+    test('the new tree replaces the old one', () async {
+      treeAt(root, 'old');
+      treeAt(incoming, 'new');
+
+      await IrLibLocalRepo.swapIn(root, incoming);
+      await settle();
+
+      expect(markerIn(root), 'new');
+      expect(incoming.existsSync(), isFalse);
+      expect(superseded.existsSync(), isFalse, reason: 'cleared afterwards');
+    });
+
+    test('works when there was no library to replace', () async {
+      treeAt(incoming, 'new');
+
+      await IrLibLocalRepo.swapIn(root, incoming);
+      await settle();
+
+      expect(markerIn(root), 'new');
+    });
+
+    test('a leftover superseded tree does not block the swap', () async {
+      treeAt(root, 'old');
+      treeAt(incoming, 'new');
+      treeAt(superseded, 'older still');
+
+      await IrLibLocalRepo.swapIn(root, incoming);
+      await settle();
+
+      expect(markerIn(root), 'new');
+    });
+
+    test('the old library is put back if the new one cannot move in', () async {
+      treeAt(root, 'old');
+      // No incoming at all: the second rename fails, and the library has
+      // already been moved aside by then.
+      await expectLater(
+        IrLibLocalRepo.swapIn(root, incoming),
+        throwsA(isA<FileSystemException>()),
+      );
+
+      expect(root.existsSync(), isTrue, reason: 'not left with nothing');
+      expect(markerIn(root), 'old');
+    });
+  });
+
+  group('recovering an interrupted refresh', () {
+    test('an unpack that never finished is cleared', () async {
+      treeAt(root, 'old');
+      treeAt(incoming, 'half done');
+
+      await IrLibLocalRepo.recoverInterrupted(root);
+
+      expect(incoming.existsSync(), isFalse);
+      expect(markerIn(root), 'old', reason: 'the library is untouched');
+    });
+
+    // The one window that loses data: the old tree has been moved aside and
+    // the new one is not in place yet.
+    test(
+      'a swap that died between the two renames puts the library back',
+      () async {
+        treeAt(superseded, 'old');
+        expect(root.existsSync(), isFalse);
+
+        await IrLibLocalRepo.recoverInterrupted(root);
+
+        expect(root.existsSync(), isTrue);
+        expect(markerIn(root), 'old');
+        expect(superseded.existsSync(), isFalse);
+      },
+    );
+
+    test(
+      'a delete that never finished is cleared, library left alone',
+      () async {
+        treeAt(root, 'current');
+        treeAt(superseded, 'stale');
+
+        await IrLibLocalRepo.recoverInterrupted(root);
+
+        expect(markerIn(root), 'current');
+        expect(superseded.existsSync(), isFalse);
+      },
+    );
+
+    test('does nothing when there is nothing to repair', () async {
+      treeAt(root, 'current');
+
+      await IrLibLocalRepo.recoverInterrupted(root);
+
+      expect(markerIn(root), 'current');
+    });
+
+    test('is safe when there is no library at all', () async {
+      await IrLibLocalRepo.recoverInterrupted(root);
+
+      expect(root.existsSync(), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
`IrLibLocalRepo.download()` opened like this:

```dart
final root = await resolveRoot();
if (await root.exists()) {
  await root.delete(recursive: true);   // the user's library, gone
}
await root.create(recursive: true);
// ...only now does it parse the URL and start fetching
```

The library was destroyed **before a single byte was fetched**. Anything that went wrong afterwards — no network, a truncated response, a server error — left the user with nothing, having started with a complete library. The delete was also on the critical path: ~1,578 ms for 14,800 files, every refresh, before the progress bar could move.

The new tree is now built beside the old one and swapped in at the end, so the library the user has stays whole and usable until there is a complete replacement to put in its place.

## The issue's plan did not survive contact

#62 proposed "rename it over the old root — O(1) on the same volume." That does not work on **any** platform, which I probed rather than assumed:

```
platform: windows
onto missing dest      : ok
onto non-empty dest    : THREW PathExistsException
onto empty dest        : THREW PathExistsException
aside-then-rename      : ok
```

POSIX `rename(2)` replaces only an *empty* directory and fails `ENOTEMPTY` otherwise — exactly the old library's state. So the swap moves the old tree aside first. Still all metadata operations, so the expensive delete leaves the path the user waits on and runs afterwards.

That introduces a window the issue did not describe — between the two renames there is no library — and it is the one state that loses data. `swapIn` rolls back if the second rename fails, and `recoverInterrupted` puts it back on the next run if the process died in between.

## Review found the recovery could be the thing that lost the library

Three rounds of review, each finding something the previous had not. The ones worth knowing:

**The cleanup deleted the last copy.** When the restore failed, the code logged and then deleted `.superseded` unconditionally — at the one moment it held the only copy of the library, which is why the restore was being attempted. And a failed recursive delete is not a no-op: on Windows one locked file stops it *having already removed what it reached*. So the outcome was a half-destroyed tree, not an intact one with a log line.

**`deleteAll()` resurrected what it deleted.** It took the library first and the sidecars after, leaving root-missing-plus-superseded — precisely the signature recovery reads as an interrupted swap. Interrupt it, or let one locked file throw, and the next `exists()` swore the previous generation back in as the library.

**One fixed `.superseded` name wedged refresh permanently.** The tree being deleted in the background and the destination the next swap renamed onto were the same path. A delete that stopped part way left something standing there, and every later refresh died on it — for good, until someone found a hidden directory by hand. It also meant the tree recovery had deliberately *kept* as the last copy was deleted by the very next download. Each swap now names its own, so a leftover can only be swept up, never collided with.

**The guard was one level too shallow.** `_refreshing` gated recovery but not `download()` or `deleteAll()`, both of which cleared the staging tree unconditionally. A second page builds its own controller and therefore its own repo over the same process-wide directories, so a refresh started from one page could delete the tree another was unpacking into — and the unpack does not notice, because its created-directory cache will not re-make a parent it has already seen. Entries land in `skipped`, and few enough clear the tolerance that a truncated library is sworn in as whole. That is the failure #61 exists to prevent, through a door the flag did not cover. Refreshes and deletes now queue on one lock; recovery declines while it is held rather than waiting out a download.

## The tests were a layer too low

Everything reachable by calling the statics was well covered. Everything behind `download()`'s first three statements was not tested **at all** — the unpack could be pointed back at the library root, or `swapIn` deleted outright, and the whole suite stayed green.

They run offline now. `PathProviderPlatform` stands in for the temp directory — the only seam that works on Windows, where `path_provider` is pure Dart over FFI and never touches a method channel — and `HttpOverrides` serves a `ZipEncoder`-built archive to `AppHttp`'s lazily-built static client. Six tests drive a real refresh end to end, including the one this issue is about, and the page-open repair through `exists()`, which had no test despite being the most travelled route into recovery.

**21 tests. The three mutations that survived every earlier round are all caught**, along with restoring the original delete-first, the fixed superseded name, the dropped rollback, and `deleteAll`'s ordering.

## Known gaps

Two mutations still survive, and I would rather say so than imply coverage I do not have:

- **Removing the lock** leaves the suite green. Both queued refreshes fail at the same early point in the test harness, so nothing observes the serialisation. The lock is a standard async mutex and was reviewed, but it is not pinned by a test.
- **`deleteAll`'s ordering** is unmutated-caught. Discriminating it needs a delete that fails part way, which needs an open handle — and that only blocks deletion on Windows, so the test would do nothing on the Linux runner. The ordering is documented with its reason instead.

Also deliberately not done here: `recoverInterrupted` runs from `exists()` and `download()` rather than at app startup, so a swap interrupted by a kill is repaired when the user next opens the IR library rather than on launch. And a failed restore is reported only through `LogService`, which is compiled out of release builds — at the one moment the app knows the library is one rename away, it currently says nothing. Both are worth their own issues rather than widening this one.

Closes #62.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
