### PR TITLE
Bump dartufbt to the atomic SDK and toolchain deploy

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -4,6 +4,10 @@ analyzer:
   exclude:
     - build/**
     - lib/modules/flipperlib/lib/src/proto/generated/**
+    # Another package's tests, with their own dev dependencies. The app
+    # never resolves those, so analysing them here reports every matcher
+    # as undefined.
+    - lib/modules/*/test/**
     - android/**
     - ios/**
     - web/**


### PR DESCRIPTION
The fix lands in the submodule ([DarkFlippers/dart-ufbt#1](https://github.com/DarkFlippers/dart-ufbt/pull/1), merged as `4e3f512`); this is only the pointer.

## What the upstream PR fixes

#83 reported the SDK deployer. There were **three** paths with the same bug, and the worst was not the one filed:

| | |
|---|---|
| `UfbtSdkDeployer.deploy` | deletes the installed SDK, then extracts into the space it left |
| `_deployUnix` | deletes the toolchain, then unpacks |
| `_deployWindows` | **deletes the toolchain before it starts downloading** |

A truncated download, a full disk, or one bad entry, and the user has no SDK — and the way back is a fresh ~340 MB fetch. Fixing only the one named would have left two live.

Each now builds beside what it replaces and swaps at the end, so what is installed keeps working until there is a complete replacement. The reasoning is the same as #62's, including the parts that are easy to get wrong — no platform renames a directory onto a populated one, the aside tree needs a unique name or a part-finished delete wedges every later deploy, and the window between the two renames needs both a rollback and a recovery on the next run.

It lives in `dartufbt` rather than here because the dependency runs app → dartufbt and never back — the same constraint #29 records for the path helpers.

## The one that only shows up from this side

Review traced the call path the package cannot see: `AssemblerController.downloadSdk` → `installer.installSdk` → `deploy()`, awaited directly, no `compute` and no `Isolate.run`. It runs on the isolate that draws the app.

That matters because the deploy is careful about it everywhere else — the toolchain unpacks in a subprocess, `_extractZip` yields between entries, and the UI stays live through the download and the extract. A synchronous delete of the replaced tree would then have frozen the app solid at the moment the deploy was otherwise finished: several hundred megabytes of small files, on the root isolate. It is awaited now, so dart:io runs it on its own thread pool.

Dropping one of those awaits is invisible to the tests — a two-file tree finishes inside the turn that abandoned it — so `unawaited_futures` is on upstream and its CI analyzes with `--fatal-infos`.

## State of this branch

The pointer is `4e3f512` on `DarkFlippers/dart-ufbt` `main`, resolving through the submodule's own remote. The tree is identical to the fork branch this was verified against.

Upstream CI ran on the merge and is green on **Linux, Windows and macOS** — the matrix is not decoration there, since renaming directories onto one another is exactly where the platforms part ways.

One real change came out of the earlier run here. The submodule gained its first tests, and `flutter analyze` walks them — where `package:test` is not in this app's dependency tree, because it is a dev dependency of *that* package. Every matcher came back undefined. It passed locally only because `dart pub get` had been run inside the submodule at some point, leaving a `package_config` there that resolved it; CI has no such thing. `lib/modules/*/test/**` is now excluded, alongside the existing exclude for flipperlib's generated protos.

Closes #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
