### PR TITLE
Say where an interrupted IR refresh left the library, and repair it at launch

### DIFF
--- a/lib/app/bootstrap.dart
+++ b/lib/app/bootstrap.dart
@@ -4,6 +4,7 @@ import 'dart:io' show Platform;
 import 'package:flipperlib/flipperlib.dart';
 import 'package:flutter/material.dart';
 
+import '../pages/tools/infrared/local_repo.dart';
 import '../services/connection/device_info_watch.dart';
 import '../services/connection/foreground_service.dart';
 import '../services/connection/notification_service.dart';
@@ -51,6 +52,13 @@ void bootstrapAmbientServices() {
   WidgetsBinding.instance.addObserver(_WatchLifecycleObserver());
 
   unawaited(_guard('push notifications', () => PushService.instance.start()));
+
+  // A refresh killed mid-swap leaves the IR library under a name only recovery
+  // looks for. Repairing it here rather than when the IR page opens means the
+  // library is not absent to the rest of the app until the user happens to go
+  // there — Settings → Storage reported its size as zero in the meantime — and
+  // it lets exists() go back to being a plain read.
+  unawaited(_guard('ir library recovery', IrLibLocalRepo.recoverStranded));
 }
 
 class _WatchLifecycleObserver with WidgetsBindingObserver {

--- a/lib/pages/tools/infrared/controller.dart
+++ b/lib/pages/tools/infrared/controller.dart
@@ -56,13 +56,6 @@ class IrLibController extends ChangeNotifier {
   IrLibDownloadProgress? get downloadProgress => _downloadProgress;
   bool get downloading => _downloading;
   bool get localAvailable => _localAvailable;
-
-  /// Where an interrupted refresh left the library when the app could not move
-  /// it back, or null.
-  ///
-  /// Read live rather than captured: recovery runs at startup, but a download
-  /// runs it again and can clear this.
-  String? get strandedLibraryPath => IrLibLocalRepo.strandedLibrary?.path;
   String get path => _path;
   bool get loading => _loading;
   String? get error => _error;
@@ -86,6 +79,13 @@ class IrLibController extends ChangeNotifier {
     _deviceName = _client.getName() ?? '';
     _settings = await _settingsStorage.load();
     final root = await _localRepo.resolveRoot();
+    // Before asking, not after. The launch pass is unawaited, so without this
+    // the answer can be read while the library is still sitting under the name
+    // an interrupted swap gave it — and this result is latched for the life of
+    // the controller, so losing that race offers DOWNLOAD for the whole
+    // session over a library that is on disk. Memoised, so this awaits the
+    // pass already running rather than starting a second one.
+    await IrLibLocalRepo.recoverStranded();
     _localAvailable = await _localRepo.exists();
     if (_settings.localPath != root.path) {
       _settings = _settings.copyWith(localPath: root.path);

--- a/lib/pages/tools/infrared/controller.dart
+++ b/lib/pages/tools/infrared/controller.dart
@@ -56,6 +56,13 @@ class IrLibController extends ChangeNotifier {
   IrLibDownloadProgress? get downloadProgress => _downloadProgress;
   bool get downloading => _downloading;
   bool get localAvailable => _localAvailable;
+
+  /// Where an interrupted refresh left the library when the app could not move
+  /// it back, or null.
+  ///
+  /// Read live rather than captured: recovery runs at startup, but a download
+  /// runs it again and can clear this.
+  String? get strandedLibraryPath => IrLibLocalRepo.strandedLibrary?.path;
   String get path => _path;
   bool get loading => _loading;
   String? get error => _error;

--- a/lib/pages/tools/infrared/local_repo.dart
+++ b/lib/pages/tools/infrared/local_repo.dart
@@ -45,24 +45,6 @@ class IrLibDownloadProgress {
   }
 }
 
-/// What one pass of [IrLibLocalRepo.recoverInterrupted] found and could do.
-///
-/// [strandedAt] is the outcome worth telling someone about. It names a
-/// directory holding the user's only copy of the library, under a name nothing
-/// else in the app looks for, inside a folder hidden everywhere but Windows.
-/// Unless something says so, the library reads as gone, and downloading it
-/// again is the obvious move — safe, but several hundred megabytes the user
-/// did not need to spend.
-class IrLibRecovery {
-  const IrLibRecovery({this.repaired = false, this.strandedAt});
-
-  /// The library had been moved aside by an interrupted swap, and went back.
-  final bool repaired;
-
-  /// Where the library is, when it could not be moved back.
-  final io.Directory? strandedAt;
-}
-
 class IrLibLocalRepo {
   IrLibLocalRepo();
 
@@ -83,35 +65,22 @@ class IrLibLocalRepo {
   /// interleave.
   static Future<void> _chain = Future<void>.value();
 
-  /// True while [_exclusive] is running something, so recovery can decline
-  /// rather than queue behind a download it would otherwise wait out.
-  static bool _busy = false;
-
   static Future<T> _exclusive<T>(Future<T> Function() body) {
     final previous = _chain;
     final released = Completer<void>();
     _chain = released.future;
-    return previous
-        .then((_) async {
-          _busy = true;
-          try {
-            return await body();
-          } finally {
-            _busy = false;
-          }
-        })
-        .whenComplete(released.complete);
+    return previous.then((_) => body()).whenComplete(released.complete);
   }
 
   /// Points the library at [dir] for the duration of a test, and clears the
-  /// process-wide state so one test cannot strand the next — the refresh flag,
-  /// the queue, and the stranded path a recovery may have recorded.
+  /// process-wide state so one test cannot strand the next — the queue, the
+  /// memoised startup pass, and the stranded path a recovery recorded.
   @visibleForTesting
   static void debugUseRoot(io.Directory? dir) {
     _cachedRoot = dir;
-    _busy = false;
     _chain = Future<void>.value();
-    _stranded = null;
+    _startupPass = null;
+    _stranded.value = null;
   }
 
   Future<io.Directory> resolveRoot() async {
@@ -173,6 +142,10 @@ class IrLibLocalRepo {
         continue;
       }
     }
+    // The stranded tree is one of the sidecars above, so the record now names
+    // a directory this just removed. Leaving it would have the dialog tell the
+    // user their library is safe somewhere, moments after they deleted it.
+    _stranded.value = null;
   }
 
   Future<io.Directory> download({
@@ -355,10 +328,22 @@ class IrLibLocalRepo {
       // rather than leave the user with nothing, and let the original failure
       // be the one that surfaces.
       if (hadLibrary && !await root.exists()) {
-        await _restoreSuperseded(root, superseded);
+        // Records it here too, not only in recovery. This is the moment the
+        // library is stranded, and nothing retries until the next launch —
+        // the log line that used to be the only signal is compiled out of a
+        // release build.
+        if (!await _restoreSuperseded(root, superseded)) {
+          _stranded.value = superseded;
+        }
       }
       rethrow;
     }
+
+    // The library is demonstrably back where it belongs, so whatever an
+    // earlier pass stranded is no longer where the user should look. Cleared
+    // here rather than by re-running recovery, which would race the delete
+    // below over this swap's own superseded tree.
+    _stranded.value = null;
 
     if (!hadLibrary) return;
     unawaited(
@@ -379,23 +364,33 @@ class IrLibLocalRepo {
 
   /// Repairs an interrupted refresh wherever the library actually lives.
   ///
-  /// The startup entry point. [recoverInterrupted] takes a root so the swap
-  /// helpers stay testable against a temp directory; this resolves the real
-  /// one. Called once at launch rather than when the IR page opens, so a
-  /// refresh killed mid-swap is put right before anything reads the library
-  /// as absent — Settings → Storage included, which otherwise reports its size
-  /// as zero.
-  static Future<IrLibRecovery> recoverStranded() async =>
+  /// The startup entry point: called from `bootstrapAmbientServices`, so a
+  /// refresh killed mid-swap is put right before anything reads the library as
+  /// absent — Settings → Storage included, which otherwise reports its size as
+  /// zero. [recoverInterrupted] takes a root so the swap helpers stay testable
+  /// against a temp directory; this resolves the real one.
+  ///
+  /// Memoised, and awaited by [IrLibController.initialize] as well as fired at
+  /// launch. The launch call is unawaited and reaches the Android storage
+  /// permission on its way to the root, which can sit on a full-screen settings
+  /// page until the user answers — so "startup already did it" is not something
+  /// a page opening can assume. Anyone who needs the answer awaits the same
+  /// future rather than starting a second pass.
+  static Future<io.Directory?> recoverStranded() =>
+      _startupPass ??= _recoverStranded();
+  static Future<io.Directory?>? _startupPass;
+
+  static Future<io.Directory?> _recoverStranded() async =>
       recoverInterrupted(await IrLibLocalRepo().resolveRoot());
 
   /// Where an interrupted refresh left the library when it could not be put
   /// back, or null when there is nothing to report.
   ///
-  /// Static because the pass that finds it runs at startup, long before there
-  /// is a page to tell. Every completed [recoverInterrupted] sets it, so a
-  /// later run that succeeds clears it.
-  static io.Directory? get strandedLibrary => _stranded;
-  static io.Directory? _stranded;
+  /// Process-wide and observable. The pass that finds it runs at startup, long
+  /// before there is a page to tell, and a refresh can strand one while the
+  /// dialog showing it is already open.
+  static ValueListenable<io.Directory?> get strandedLibrary => _stranded;
+  static final ValueNotifier<io.Directory?> _stranded = ValueNotifier(null);
 
   /// Repairs whatever a process that died mid-refresh left behind.
   ///
@@ -403,24 +398,28 @@ class IrLibLocalRepo {
   /// window — short, but not nothing — where the library has been moved aside
   /// and its replacement is not yet in place. Dying there is the one case that
   /// loses data, so it is the one checked first.
-  static Future<IrLibRecovery> recoverInterrupted(io.Directory root) async {
-    // Nothing beside the library is leftover while something is using it.
-    // Reports the last pass's finding rather than a clean sheet: this one did
-    // not look, and saying nothing is wrong would clear a warning that still
-    // stands.
-    if (_busy) return IrLibRecovery(strandedAt: _stranded);
+  /// Returns where the library was left when it could not be put back, so a
+  /// caller can act on it without reading the shared record.
+  ///
+  /// Under the lock, where it used to decline if a refresh held it. Declining
+  /// meant two passes could run at once — the startup one against a download's
+  /// own — and the loser would record a strand the winner had already repaired,
+  /// leaving the dialog pointing at a directory that no longer exists.
+  /// Queueing instead also means the staging tree it sweeps is genuinely
+  /// leftover rather than one a refresh is still unpacking into.
+  static Future<io.Directory?> recoverInterrupted(io.Directory root) =>
+      _exclusive(() => _recoverInterrupted(root));
 
+  static Future<io.Directory?> _recoverInterrupted(io.Directory root) async {
     final incoming = _sidecar(root, _kIncomingSuffix);
     final superseded = await _supersededTrees(root);
 
     // The newest is the one the interrupted swap set aside; anything older is
     // a background delete that never finished.
     io.Directory? kept;
-    var repaired = false;
     if (!await root.exists() && superseded.isNotEmpty) {
       final live = superseded.first;
       if (await _restoreSuperseded(root, live)) {
-        repaired = true;
         LogService.log(
           '[IrLib] put the library back after an interrupted swap',
         );
@@ -451,8 +450,8 @@ class IrLibLocalRepo {
       }
     }
 
-    _stranded = kept;
-    return IrLibRecovery(repaired: repaired, strandedAt: kept);
+    _stranded.value = kept;
+    return kept;
   }
 
   /// Inflates the IR database zip and writes every entry to disk inside a

--- a/lib/pages/tools/infrared/local_repo.dart
+++ b/lib/pages/tools/infrared/local_repo.dart
@@ -45,6 +45,24 @@ class IrLibDownloadProgress {
   }
 }
 
+/// What one pass of [IrLibLocalRepo.recoverInterrupted] found and could do.
+///
+/// [strandedAt] is the outcome worth telling someone about. It names a
+/// directory holding the user's only copy of the library, under a name nothing
+/// else in the app looks for, inside a folder hidden everywhere but Windows.
+/// Unless something says so, the library reads as gone, and downloading it
+/// again is the obvious move — safe, but several hundred megabytes the user
+/// did not need to spend.
+class IrLibRecovery {
+  const IrLibRecovery({this.repaired = false, this.strandedAt});
+
+  /// The library had been moved aside by an interrupted swap, and went back.
+  final bool repaired;
+
+  /// Where the library is, when it could not be moved back.
+  final io.Directory? strandedAt;
+}
+
 class IrLibLocalRepo {
   IrLibLocalRepo();
 
@@ -86,12 +104,14 @@ class IrLibLocalRepo {
   }
 
   /// Points the library at [dir] for the duration of a test, and clears the
-  /// refresh flag so one test cannot strand the next.
+  /// process-wide state so one test cannot strand the next — the refresh flag,
+  /// the queue, and the stranded path a recovery may have recorded.
   @visibleForTesting
   static void debugUseRoot(io.Directory? dir) {
     _cachedRoot = dir;
     _busy = false;
     _chain = Future<void>.value();
+    _stranded = null;
   }
 
   Future<io.Directory> resolveRoot() async {
@@ -102,9 +122,14 @@ class IrLibLocalRepo {
     return dir;
   }
 
+  /// Whether there is a library on disk. A plain read, and worth keeping one.
+  ///
+  /// It used to repair an interrupted refresh on the way past, which meant a
+  /// method that reads as a query renamed trees and ran recursive deletes.
+  /// [recoverStranded] runs at startup instead, so by the time anything asks
+  /// this, the repair has already happened.
   Future<bool> exists() async {
     final dir = await resolveRoot();
-    await recoverInterrupted(dir);
     if (!await dir.exists()) return false;
     await for (final _ in dir.list(followLinks: false)) {
       return true;
@@ -352,25 +377,50 @@ class IrLibLocalRepo {
     );
   }
 
+  /// Repairs an interrupted refresh wherever the library actually lives.
+  ///
+  /// The startup entry point. [recoverInterrupted] takes a root so the swap
+  /// helpers stay testable against a temp directory; this resolves the real
+  /// one. Called once at launch rather than when the IR page opens, so a
+  /// refresh killed mid-swap is put right before anything reads the library
+  /// as absent — Settings → Storage included, which otherwise reports its size
+  /// as zero.
+  static Future<IrLibRecovery> recoverStranded() async =>
+      recoverInterrupted(await IrLibLocalRepo().resolveRoot());
+
+  /// Where an interrupted refresh left the library when it could not be put
+  /// back, or null when there is nothing to report.
+  ///
+  /// Static because the pass that finds it runs at startup, long before there
+  /// is a page to tell. Every completed [recoverInterrupted] sets it, so a
+  /// later run that succeeds clears it.
+  static io.Directory? get strandedLibrary => _stranded;
+  static io.Directory? _stranded;
+
   /// Repairs whatever a process that died mid-refresh left behind.
   ///
   /// The swap is only as atomic as two renames back to back, so there is a
   /// window — short, but not nothing — where the library has been moved aside
   /// and its replacement is not yet in place. Dying there is the one case that
   /// loses data, so it is the one checked first.
-  static Future<void> recoverInterrupted(io.Directory root) async {
+  static Future<IrLibRecovery> recoverInterrupted(io.Directory root) async {
     // Nothing beside the library is leftover while something is using it.
-    if (_busy) return;
+    // Reports the last pass's finding rather than a clean sheet: this one did
+    // not look, and saying nothing is wrong would clear a warning that still
+    // stands.
+    if (_busy) return IrLibRecovery(strandedAt: _stranded);
 
     final incoming = _sidecar(root, _kIncomingSuffix);
     final superseded = await _supersededTrees(root);
 
     // The newest is the one the interrupted swap set aside; anything older is
     // a background delete that never finished.
-    var kept = <io.Directory>[];
+    io.Directory? kept;
+    var repaired = false;
     if (!await root.exists() && superseded.isNotEmpty) {
       final live = superseded.first;
       if (await _restoreSuperseded(root, live)) {
+        repaired = true;
         LogService.log(
           '[IrLib] put the library back after an interrupted swap',
         );
@@ -381,14 +431,14 @@ class IrLibLocalRepo {
         // must never do - and a failed recursive delete is not a no-op either,
         // since one locked file stops it having already removed what it
         // reached first.
-        kept = [live];
+        kept = live;
       }
     }
 
     final leftovers = [
       incoming,
       for (final tree in superseded)
-        if (!kept.contains(tree)) tree,
+        if (tree.path != kept?.path) tree,
     ];
 
     // A restore consumes the tree it moved, so it is gone by now.
@@ -400,6 +450,9 @@ class IrLibLocalRepo {
         LogService.error('[IrLib] could not clear ${leftover.path}: $e');
       }
     }
+
+    _stranded = kept;
+    return IrLibRecovery(repaired: repaired, strandedAt: kept);
   }
 
   /// Inflates the IR database zip and writes every entry to disk inside a

--- a/lib/pages/tools/infrared/settings_dialog.dart
+++ b/lib/pages/tools/infrared/settings_dialog.dart
@@ -1,3 +1,5 @@
+import 'dart:io' as io;
+
 import 'package:flutter/material.dart';
 
 import '../../../services/localization/l10n.dart';
@@ -135,7 +137,6 @@ class _IrLibSettingsDialogState extends State<IrLibSettingsDialog> {
     final colors = context.appColors;
     final downloading = widget.controller.downloading;
     final localAvailable = widget.controller.localAvailable;
-    final stranded = widget.controller.strandedLibraryPath;
     return AlertDialog(
       backgroundColor: colors.card,
       title: Text('IRDB', style: TextStyle(color: colors.textPrimary)),
@@ -169,10 +170,7 @@ class _IrLibSettingsDialogState extends State<IrLibSettingsDialog> {
                   onPressed: () => setState(() => _showToken = !_showToken),
                 ),
               ),
-              if (stranded != null) ...[
-                const SizedBox(height: 14),
-                _StrandedNotice(colors: colors, path: stranded),
-              ],
+              const _StrandedNotice(),
               const SizedBox(height: 14),
               _PrimaryActionButton(
                 colors: colors,
@@ -265,14 +263,27 @@ class _IrLibSettingsDialogState extends State<IrLibSettingsDialog> {
 /// reads that as no library at all, and this dialog is where the user decides
 /// whether to spend the download again — so it is the one place saying so
 /// changes what they do.
+///
+/// Listens rather than reads: a refresh can strand the library while this
+/// dialog is the thing on screen, and recovery notifies no controller.
 class _StrandedNotice extends StatelessWidget {
-  const _StrandedNotice({required this.colors, required this.path});
-
-  final QAppColors colors;
-  final String path;
+  const _StrandedNotice();
 
   @override
   Widget build(BuildContext context) {
+    return ValueListenableBuilder<io.Directory?>(
+      valueListenable: IrLibLocalRepo.strandedLibrary,
+      builder: (context, stranded, _) => stranded == null
+          ? const SizedBox.shrink()
+          : Padding(
+              padding: const EdgeInsets.only(top: 14),
+              child: _body(context, stranded.path),
+            ),
+    );
+  }
+
+  Widget _body(BuildContext context, String path) {
+    final colors = context.appColors;
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(

--- a/lib/pages/tools/infrared/settings_dialog.dart
+++ b/lib/pages/tools/infrared/settings_dialog.dart
@@ -135,6 +135,7 @@ class _IrLibSettingsDialogState extends State<IrLibSettingsDialog> {
     final colors = context.appColors;
     final downloading = widget.controller.downloading;
     final localAvailable = widget.controller.localAvailable;
+    final stranded = widget.controller.strandedLibraryPath;
     return AlertDialog(
       backgroundColor: colors.card,
       title: Text('IRDB', style: TextStyle(color: colors.textPrimary)),
@@ -168,6 +169,10 @@ class _IrLibSettingsDialogState extends State<IrLibSettingsDialog> {
                   onPressed: () => setState(() => _showToken = !_showToken),
                 ),
               ),
+              if (stranded != null) ...[
+                const SizedBox(height: 14),
+                _StrandedNotice(colors: colors, path: stranded),
+              ],
               const SizedBox(height: 14),
               _PrimaryActionButton(
                 colors: colors,
@@ -247,6 +252,46 @@ class _IrLibSettingsDialogState extends State<IrLibSettingsDialog> {
           borderRadius: BorderRadius.circular(8),
           borderSide: BorderSide(color: colors.accent),
         ),
+      ),
+    );
+  }
+}
+
+/// Says the library still exists, and where.
+///
+/// The one state the app knows about and the user cannot see: an interrupted
+/// refresh left the library beside where it belongs, the restore did not land,
+/// and the recovery kept it rather than delete the only copy. Everything else
+/// reads that as no library at all, and this dialog is where the user decides
+/// whether to spend the download again — so it is the one place saying so
+/// changes what they do.
+class _StrandedNotice extends StatelessWidget {
+  const _StrandedNotice({required this.colors, required this.path});
+
+  final QAppColors colors;
+  final String path;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.info.withValues(alpha: 0.12),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: colors.info.withValues(alpha: 0.4)),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(Icons.info_outline, size: 18, color: colors.info),
+          const SizedBox(width: 10),
+          Expanded(
+            child: SelectableText(
+              context.l10n.irLibraryStranded(path),
+              style: TextStyle(color: colors.textSecondary, fontSize: 13),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/test/ir_library_refresh_test.dart
+++ b/test/ir_library_refresh_test.dart
@@ -137,6 +137,28 @@ void main() {
     '${root.path}$sep${relative.replaceAll('/', sep)}',
   ).readAsStringSync();
 
+  List<Directory> supersededTrees() => base
+      .listSync()
+      .whereType<Directory>()
+      .where((d) => d.path.startsWith('${root.path}.superseded'))
+      .toList();
+
+  /// The library where a swap that died between its two renames left it.
+  Directory asideLibrary() {
+    final aside = Directory('${root.path}.superseded.1000')
+      ..createSync(recursive: true);
+    Directory('${aside.path}${sep}TVs').createSync(recursive: true);
+    File('${aside.path}${sep}TVs${sep}Old.ir').writeAsStringSync('old remote');
+    return aside;
+  }
+
+  /// Stops the restore the way a stray file at the library path would: the
+  /// rename has nowhere to land, and the tree beside it is the only copy.
+  Directory blockRestore(Directory aside) {
+    File(root.path).writeAsStringSync('in the way');
+    return aside;
+  }
+
   test('a refresh unpacks the library and puts it in place', () async {
     _FakeHttpOverrides.body = irdbZip({'TVs/Sony.ir': 'sony remote'});
 
@@ -200,27 +222,39 @@ void main() {
   // open the IR page. Until it did, the library read as absent to everything
   // else — Settings → Storage reported its size as zero.
   test('startup repairs a swap that was interrupted', () async {
-    final aside = Directory('${root.path}.superseded.1000')
-      ..createSync(recursive: true);
-    Directory('${aside.path}${sep}TVs').createSync(recursive: true);
-    File('${aside.path}${sep}TVs${sep}Old.ir').writeAsStringSync('old remote');
+    asideLibrary();
 
-    final report = await IrLibLocalRepo.recoverStranded();
+    final stranded = await IrLibLocalRepo.recoverStranded();
 
-    expect(report.repaired, isTrue);
-    expect(report.strandedAt, isNull);
+    expect(stranded, isNull);
     expect(read('TVs/Old.ir'), 'old remote');
     expect(await IrLibLocalRepo().exists(), isTrue);
   });
+
+  // The launch call is unawaited and reaches the Android storage permission on
+  // its way to the root, which can sit on a settings page until the user
+  // answers. IrLibController.initialize() awaits this before asking exists(),
+  // and it must join the pass already running rather than start a second one —
+  // two passes at once is how a repaired library gets recorded as stranded.
+  test(
+    'a second caller joins the launch pass rather than starting one',
+    () async {
+      asideLibrary();
+
+      final first = IrLibLocalRepo.recoverStranded();
+      final second = IrLibLocalRepo.recoverStranded();
+
+      expect(identical(first, second), isTrue);
+      await Future.wait([first, second]);
+      expect(read('TVs/Old.ir'), 'old remote', reason: 'and one pass ran');
+    },
+  );
 
   // The point of taking the repair out of exists(): a method that reads as a
   // query was renaming trees and running recursive deletes, so any caller
   // added later that treated it as a cheap check got those side effects.
   test('asking whether the library exists does not move anything', () async {
-    final aside = Directory('${root.path}.superseded.1000')
-      ..createSync(recursive: true);
-    Directory('${aside.path}${sep}TVs').createSync(recursive: true);
-    File('${aside.path}${sep}TVs${sep}Old.ir').writeAsStringSync('old remote');
+    final aside = asideLibrary();
 
     final present = await IrLibLocalRepo().exists();
 
@@ -229,26 +263,12 @@ void main() {
   });
 
   group('when the library cannot be put back', () {
-    /// Blocks the restore the way a stray file at the library path would: the
-    /// rename has nowhere to land, and the tree beside it is the only copy.
-    Directory blockedRestore() {
-      final aside = Directory('${root.path}.superseded.1000')
-        ..createSync(recursive: true);
-      Directory('${aside.path}${sep}TVs').createSync(recursive: true);
-      File(
-        '${aside.path}${sep}TVs${sep}Old.ir',
-      ).writeAsStringSync('old remote');
-      File(root.path).writeAsStringSync('in the way');
-      return aside;
-    }
-
     test('recovery says where it is instead of only logging it', () async {
-      final aside = blockedRestore();
+      final aside = blockRestore(asideLibrary());
 
-      final report = await IrLibLocalRepo.recoverStranded();
+      final stranded = await IrLibLocalRepo.recoverStranded();
 
-      expect(report.strandedAt?.path, aside.path);
-      expect(report.repaired, isFalse);
+      expect(stranded?.path, aside.path);
       expect(
         File('${aside.path}${sep}TVs${sep}Old.ir').readAsStringSync(),
         'old remote',
@@ -261,23 +281,74 @@ void main() {
     // has to survive the pass that found it, or the one moment the app knows
     // the library is one rename away is the moment it says nothing.
     test('the path outlives the pass, for the UI to read', () async {
-      final aside = blockedRestore();
+      final aside = blockRestore(asideLibrary());
 
       await IrLibLocalRepo.recoverStranded();
 
-      expect(IrLibLocalRepo.strandedLibrary?.path, aside.path);
+      expect(IrLibLocalRepo.strandedLibrary.value?.path, aside.path);
     });
 
     test('a later run that succeeds clears it', () async {
-      blockedRestore();
+      blockRestore(asideLibrary());
       await IrLibLocalRepo.recoverStranded();
-      expect(IrLibLocalRepo.strandedLibrary, isNotNull);
+      expect(IrLibLocalRepo.strandedLibrary.value, isNotNull);
 
       File(root.path).deleteSync();
-      final report = await IrLibLocalRepo.recoverStranded();
+      await IrLibLocalRepo.recoverInterrupted(root);
 
-      expect(report.repaired, isTrue);
-      expect(IrLibLocalRepo.strandedLibrary, isNull);
+      expect(IrLibLocalRepo.strandedLibrary.value, isNull);
+      expect(read('TVs/Old.ir'), 'old remote');
+    });
+
+    // The notice's only job is to be trustworthy about where the user's data
+    // is. Saying it is safe at a path the app removed a moment ago is the one
+    // way it can be wrong that costs something.
+    test('deleting the library takes the notice with it', () async {
+      blockRestore(asideLibrary());
+      await IrLibLocalRepo.recoverStranded();
+      expect(IrLibLocalRepo.strandedLibrary.value, isNotNull);
+
+      File(root.path).deleteSync();
+      await IrLibLocalRepo().deleteAll();
+
+      expect(IrLibLocalRepo.strandedLibrary.value, isNull);
+      expect(supersededTrees(), isEmpty);
+    });
+
+    // The recovery inside download() runs before the swap, so it can never see
+    // the state the swap creates. Without the swap clearing it, the notice sat
+    // under a button that now read DELETE, still advising a download.
+    test('a refresh that lands clears the notice', () async {
+      blockRestore(asideLibrary());
+      await IrLibLocalRepo.recoverStranded();
+      expect(IrLibLocalRepo.strandedLibrary.value, isNotNull);
+
+      File(root.path).deleteSync();
+      _FakeHttpOverrides.body = irdbZip({'TVs/Sony.ir': 'sony remote'});
+      await refresh();
+
+      expect(IrLibLocalRepo.strandedLibrary.value, isNull);
+      expect(read('TVs/Sony.ir'), 'sony remote');
+    });
+
+    // Two passes at once, which the startup call made possible against a
+    // download's own. The loser used to record a strand the winner had already
+    // repaired, leaving the notice pointing at a directory that was gone.
+    //
+    // Asserts the invariant, not the mechanism: with the lock taken away this
+    // passes or fails depending on how the two passes interleave, so it will
+    // not reliably catch a regression. The guarantee is that recovery now goes
+    // through the same _exclusive queue as every other operation that moves
+    // these trees; this only checks the outcome that queue is there to give.
+    test('two passes at once do not invent a strand', () async {
+      asideLibrary();
+
+      await Future.wait([
+        IrLibLocalRepo.recoverInterrupted(root),
+        IrLibLocalRepo.recoverInterrupted(root),
+      ]);
+
+      expect(IrLibLocalRepo.strandedLibrary.value, isNull);
       expect(read('TVs/Old.ir'), 'old remote');
     });
   });

--- a/test/ir_library_refresh_test.dart
+++ b/test/ir_library_refresh_test.dart
@@ -196,9 +196,27 @@ void main() {
     expect(Directory('${root.path}.incoming').existsSync(), isFalse);
   });
 
-  // exists() repairs on the way past, and is the most-travelled route into
-  // recovery — it runs whenever the library page opens.
-  test('opening the library repairs a swap that was interrupted', () async {
+  // Recovery runs at startup now, so the repair does not wait for the user to
+  // open the IR page. Until it did, the library read as absent to everything
+  // else — Settings → Storage reported its size as zero.
+  test('startup repairs a swap that was interrupted', () async {
+    final aside = Directory('${root.path}.superseded.1000')
+      ..createSync(recursive: true);
+    Directory('${aside.path}${sep}TVs').createSync(recursive: true);
+    File('${aside.path}${sep}TVs${sep}Old.ir').writeAsStringSync('old remote');
+
+    final report = await IrLibLocalRepo.recoverStranded();
+
+    expect(report.repaired, isTrue);
+    expect(report.strandedAt, isNull);
+    expect(read('TVs/Old.ir'), 'old remote');
+    expect(await IrLibLocalRepo().exists(), isTrue);
+  });
+
+  // The point of taking the repair out of exists(): a method that reads as a
+  // query was renaming trees and running recursive deletes, so any caller
+  // added later that treated it as a cheap check got those side effects.
+  test('asking whether the library exists does not move anything', () async {
     final aside = Directory('${root.path}.superseded.1000')
       ..createSync(recursive: true);
     Directory('${aside.path}${sep}TVs').createSync(recursive: true);
@@ -206,7 +224,61 @@ void main() {
 
     final present = await IrLibLocalRepo().exists();
 
-    expect(present, isTrue);
-    expect(read('TVs/Old.ir'), 'old remote');
+    expect(present, isFalse, reason: 'it reports, it does not repair');
+    expect(aside.existsSync(), isTrue, reason: 'and leaves the tree alone');
+  });
+
+  group('when the library cannot be put back', () {
+    /// Blocks the restore the way a stray file at the library path would: the
+    /// rename has nowhere to land, and the tree beside it is the only copy.
+    Directory blockedRestore() {
+      final aside = Directory('${root.path}.superseded.1000')
+        ..createSync(recursive: true);
+      Directory('${aside.path}${sep}TVs').createSync(recursive: true);
+      File(
+        '${aside.path}${sep}TVs${sep}Old.ir',
+      ).writeAsStringSync('old remote');
+      File(root.path).writeAsStringSync('in the way');
+      return aside;
+    }
+
+    test('recovery says where it is instead of only logging it', () async {
+      final aside = blockedRestore();
+
+      final report = await IrLibLocalRepo.recoverStranded();
+
+      expect(report.strandedAt?.path, aside.path);
+      expect(report.repaired, isFalse);
+      expect(
+        File('${aside.path}${sep}TVs${sep}Old.ir').readAsStringSync(),
+        'old remote',
+        reason: 'kept, because it is the only copy there is',
+      );
+    });
+
+    // LogService.enabled is bool.fromEnvironment('QLOG', kDebugMode), so the
+    // log line this used to be is compiled out of a release build. The path
+    // has to survive the pass that found it, or the one moment the app knows
+    // the library is one rename away is the moment it says nothing.
+    test('the path outlives the pass, for the UI to read', () async {
+      final aside = blockedRestore();
+
+      await IrLibLocalRepo.recoverStranded();
+
+      expect(IrLibLocalRepo.strandedLibrary?.path, aside.path);
+    });
+
+    test('a later run that succeeds clears it', () async {
+      blockedRestore();
+      await IrLibLocalRepo.recoverStranded();
+      expect(IrLibLocalRepo.strandedLibrary, isNotNull);
+
+      File(root.path).deleteSync();
+      final report = await IrLibLocalRepo.recoverStranded();
+
+      expect(report.repaired, isTrue);
+      expect(IrLibLocalRepo.strandedLibrary, isNull);
+      expect(read('TVs/Old.ir'), 'old remote');
+    });
   });
 }

--- a/test/ir_library_stranded_notice_test.dart
+++ b/test/ir_library_stranded_notice_test.dart
@@ -1,0 +1,102 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:qunleashed/pages/tools/infrared/controller.dart';
+import 'package:qunleashed/pages/tools/infrared/local_repo.dart';
+import 'package:qunleashed/pages/tools/infrared/settings_dialog.dart';
+import 'package:qunleashed/services/localization/l10n.dart';
+import 'package:qunleashed/theme/theme.dart';
+
+final String sep = Platform.pathSeparator;
+
+Widget wrap(Widget child) => MaterialApp(
+  theme: buildAppTheme(Brightness.dark, const Color(0xFFCC241D)),
+  home: Scaffold(body: child),
+);
+
+void main() {
+  late Directory base;
+  late Directory root;
+
+  setUp(() {
+    base = Directory.systemTemp.createTempSync('ir_stranded_test');
+    root = Directory('${base.path}${sep}irlib');
+    IrLibLocalRepo.debugUseRoot(root);
+    addTearDown(() => IrLibLocalRepo.debugUseRoot(null));
+  });
+
+  tearDown(() {
+    if (base.existsSync()) base.deleteSync(recursive: true);
+  });
+
+  /// The notice's own wording, minus the path it names.
+  ///
+  /// Derived rather than pasted, so the check follows the copy in app_en.arb
+  /// instead of pinning a second copy of it here - and so "no notice" is a
+  /// claim about the notice itself rather than about the path it would have
+  /// named.
+  Finder noticeFinder() {
+    const marker = '<<PATH>>';
+    final wording = l10nGlobal.irLibraryStranded(marker).split(marker).first;
+    return find.textContaining(wording, findRichText: true);
+  }
+
+  /// Leaves the library where an interrupted swap put it, with the restore
+  /// blocked the way a stray file at the library path would block it.
+  Directory strandTheLibrary() {
+    final aside = Directory('${root.path}.superseded.1000')
+      ..createSync(recursive: true);
+    Directory('${aside.path}${sep}TVs').createSync(recursive: true);
+    File('${aside.path}${sep}TVs${sep}Old.ir').writeAsStringSync('old remote');
+    File(root.path).writeAsStringSync('in the way');
+    return aside;
+  }
+
+  // The whole point of #85. Recovery keeps the tree because it is the only
+  // copy of the library there is, and in a release build the log line saying
+  // so is compiled out — LogService.enabled is const-folded to false. This
+  // dialog is where the user decides whether to spend the download again, so
+  // it is the one place saying so changes what they do.
+  testWidgets('the IRDB dialog says where a stranded library is', (
+    tester,
+  ) async {
+    final aside = strandTheLibrary();
+    // Through runAsync: testWidgets drives a fake clock, and real filesystem
+    // work never completes under it.
+    await tester.runAsync(IrLibLocalRepo.recoverStranded);
+
+    await tester.pumpWidget(
+      wrap(IrLibSettingsDialog(controller: IrLibController())),
+    );
+    await tester.pump();
+
+    expect(noticeFinder(), findsOneWidget);
+    expect(
+      find.textContaining(aside.path, findRichText: true),
+      findsOneWidget,
+      reason: 'naming the path is the actionable part',
+    );
+  });
+
+  testWidgets('and says nothing when there is nothing to say', (tester) async {
+    Directory('${root.path}${sep}TVs').createSync(recursive: true);
+    File('${root.path}${sep}TVs${sep}Sony.ir').writeAsStringSync('sony');
+    await tester.runAsync(IrLibLocalRepo.recoverStranded);
+
+    await tester.pumpWidget(
+      wrap(IrLibSettingsDialog(controller: IrLibController())),
+    );
+    await tester.pump();
+
+    expect(IrLibLocalRepo.strandedLibrary, isNull);
+    expect(noticeFinder(), findsNothing);
+  });
+
+  test('the controller reports the path the recovery recorded', () async {
+    final aside = strandTheLibrary();
+    await IrLibLocalRepo.recoverStranded();
+
+    expect(IrLibController().strandedLibraryPath, aside.path);
+  });
+}

--- a/test/ir_library_stranded_notice_test.dart
+++ b/test/ir_library_stranded_notice_test.dart
@@ -89,14 +89,28 @@ void main() {
     );
     await tester.pump();
 
-    expect(IrLibLocalRepo.strandedLibrary, isNull);
+    expect(IrLibLocalRepo.strandedLibrary.value, isNull);
     expect(noticeFinder(), findsNothing);
   });
 
-  test('the controller reports the path the recovery recorded', () async {
+  // The notice listens rather than reads: recovery notifies no controller, so
+  // a refresh that strands the library while this dialog is the thing on
+  // screen would otherwise leave it showing nothing.
+  testWidgets('a strand recorded while the dialog is open shows up', (
+    tester,
+  ) async {
     final aside = strandTheLibrary();
-    await IrLibLocalRepo.recoverStranded();
 
-    expect(IrLibController().strandedLibraryPath, aside.path);
+    await tester.pumpWidget(
+      wrap(IrLibSettingsDialog(controller: IrLibController())),
+    );
+    await tester.pump();
+    expect(noticeFinder(), findsNothing);
+
+    await tester.runAsync(IrLibLocalRepo.recoverStranded);
+    await tester.pump();
+
+    expect(noticeFinder(), findsOneWidget);
+    expect(find.textContaining(aside.path, findRichText: true), findsOneWidget);
   });
 }

--- a/test/ir_library_swap_test.dart
+++ b/test/ir_library_swap_test.dart
@@ -118,6 +118,37 @@ void main() {
       expect(root.existsSync(), isTrue, reason: 'not left with nothing');
       expect(_markerIn(root), 'old');
     });
+
+    // Not covered: the rollback inside swapIn failing, which is the moment a
+    // strand is created mid-session. Reaching it needs something to occupy the
+    // library path between the failed rename and the rollback, and there is no
+    // await between them to hook — only a seam in the production code would
+    // do it, which is a worse trade than the three lines it would cover.
+    // download() recovers before it swaps, so it can never see the state the
+    // swap creates. Without the swap clearing the record itself, the notice
+    // sat under a button that by then read DELETE, still advising a download.
+    test('a swap that lands clears a strand an earlier one left', () async {
+      useRoot(root);
+      final aside = stubSuperseded('stranded earlier');
+      // A file where the library goes: the restore has nowhere to land, so
+      // recovery keeps the tree and records it.
+      File(root.path).writeAsStringSync('in the way');
+      await IrLibLocalRepo.recoverInterrupted(root);
+      expect(
+        IrLibLocalRepo.strandedLibrary.value?.path,
+        aside.path,
+        reason: 'the strand this test is about',
+      );
+
+      // Cleared before the swap, so nothing recovers on the way past - the
+      // swap itself is the only thing that can clear the record here.
+      File(root.path).deleteSync();
+      _treeAt(incoming, 'new');
+      await IrLibLocalRepo.swapIn(root, incoming);
+
+      expect(_markerIn(root), 'new');
+      expect(IrLibLocalRepo.strandedLibrary.value, isNull);
+    });
   });
 
   group('recovering an interrupted refresh', () {

--- a/translations/app_en.arb
+++ b/translations/app_en.arb
@@ -4685,9 +4685,9 @@
     "description": "Toast shown when a remote file could not be fetched."
   },
 
-  "irLibraryStranded": "Your library is not lost. An interrupted download left it at {path}, where the app could not move it back. Downloading again is safe and replaces it.",
+  "irLibraryStranded": "Your library is not lost. An interrupted download left it at {path}, and the app could not move it back — it will try again next time it starts.",
   "@irLibraryStranded": {
-    "description": "Shown in the IRDB dialog when recovery could not move the library back to its usual place. Tells the user their copy still exists, and where, before they decide to download several hundred megabytes again.",
+    "description": "Shown in the IRDB dialog when recovery could not move the library back to its usual place. Tells the user their copy still exists, and where, before they decide to download several hundred megabytes again. Deliberately does not promise that downloading again will work: whatever blocks the restore may block the new library from landing too.",
     "placeholders": {
       "path": {
         "type": "String"

--- a/translations/app_en.arb
+++ b/translations/app_en.arb
@@ -4685,6 +4685,16 @@
     "description": "Toast shown when a remote file could not be fetched."
   },
 
+  "irLibraryStranded": "Your library is not lost. An interrupted download left it at {path}, where the app could not move it back. Downloading again is safe and replaces it.",
+  "@irLibraryStranded": {
+    "description": "Shown in the IRDB dialog when recovery could not move the library back to its usual place. Tells the user their copy still exists, and where, before they decide to download several hundred megabytes again.",
+    "placeholders": {
+      "path": {
+        "type": "String"
+      }
+    }
+  },
+
   "irLoadFailed": "Failed to load: {error}",
   "@irLoadFailed": {
     "description": "Shown when the remote list could not be fetched.",


### PR DESCRIPTION
Two gaps #84 left open, recorded rather than widened into it.

## The app knew, and said nothing

`recoverInterrupted` handles the state that loses data: the library has been moved aside and its replacement never landed. When the restore itself fails, the tree is correctly **kept** — at that moment it holds the only copy of the library there is — and the only signal was:

```dart
LogService.error('[IrLib] could not put the library back: $e');
```

`LogService.enabled` is `bool.fromEnvironment('QLOG', defaultValue: kDebugMode)`, so in a release build that call is compiled out. There is no second channel. What the user sees is a library that is simply gone, and downloading several hundred megabytes again is the obvious move.

The stranded path is now recorded in a `ValueNotifier` the IRDB dialog listens to. That dialog is where `Download` lives, so it is the one place saying so changes what the user does.

## Recovery ran only when the IR page opened

Its callers were `exists()` and `download()`, both inside the IR flow. A swap interrupted by a kill was repaired when the user next went there — until then the library read as absent to everything else, including Settings → Storage, which reported its size as zero.

It runs once at launch now. That also lets `exists()` go back to being a plain read: it had been renaming trees and running recursive deletes behind a name that reads as a query, which any caller added later would have inherited.

## What review changed

The first version shipped three ways for the notice to be wrong, all in the direction that matters — telling the user their data is somewhere it is not.

| | |
|---|---|
| `deleteAll()` | swept the stranded tree and left the record pointing at it, so the dialog said "your library is safe at `<path>`" for a directory the user had just deleted. Deterministic, not racy. |
| a successful re-download | never cleared it. `download()` recovers *before* it swaps, so it cannot see the state the swap creates — the notice stayed under a button that by then read **DELETE**, still advising a download, until the next launch. |
| two recovery passes at once | recovery never took the lock, it only read the flag the lock sets, and declined. The startup call made a second racer possible against `download()`'s own, and the loser recorded a strand the winner had already repaired. |

`swapIn` now maintains the record in both directions, including when its *own* rollback fails — that is the moment a strand is created mid-session, and nothing retried it for the rest of the session. Recovery goes through `_exclusive` like every other operation that moves these trees, which also means the staging tree it sweeps is genuinely leftover rather than one a refresh is still unpacking into.

The startup pass is memoised and `IrLibController.initialize` awaits it before asking `exists()`. That answer is latched for the life of the controller, so losing the race offered DOWNLOAD for the whole session over a library sitting on disk. The launch call is unawaited and reaches the Android storage permission on its way to the root, so "startup already did it" was never safe to assume. (The prompt itself is not new — `AppShell` already reaches it via `ArchiveController.initialize()`.)

The copy no longer promises that downloading again will work. Whatever blocks the restore can block the new library from landing too, which is exactly what happens in the fixture the tests use.

## Tests

429 pass. Mutation-tested: not recording the path, `exists()` repairing again, the notice showing always or never, the delete leaving a stale record, and a landed swap leaving one are each caught.

Two that are not, stated rather than papered over:

- **The rollback inside `swapIn` failing.** Reaching it needs something to occupy the library path between the failed rename and the rollback, and there is no await between them to hook — only a seam in production code would do it, which is a worse trade than the three lines it covers.
- **The serialisation itself.** With the lock removed the concurrency test passes or fails depending on interleaving, so it asserts the invariant rather than guarding the mechanism.

One test in the first round was vacuous: the pre-swap recovery cleared the strand before `swapIn` could, so it proved nothing about the line it named.

## Not in this PR

Review raised two things bigger than #85, both worth their own issue:

- `_guard` in `bootstrap.dart` reports through `LogService` too, so if `recoverStranded` throws, recovery fails silently *and* the notice never appears — the fix has a failure mode on the exact channel it was written to escape. The same applies to the other handlers added in #21 and #84. Giving `_guard` a real sink covers all of them at once.
- Settings → Storage still reports 0 bytes for a stranded library: it sizes `irlib`, and the stranded tree is a sibling.

Closes #85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)