### PR TITLE
CLI: say in the terminal when a write did not arrive

### DIFF
--- a/lib/pages/tools/remote/cli/page.dart
+++ b/lib/pages/tools/remote/cli/page.dart
@@ -42,6 +42,24 @@ class _CliPageState extends State<CliPage> {
   bool _busy = false;
   bool _awaitingInterrupt = false;
 
+  /// Whether the terminal has already said that a write did not arrive.
+  ///
+  /// One line, not one per keystroke. Clearing [_ready] instead would stop new
+  /// input but not the writes already in flight — on Android a write can sit
+  /// for ten seconds before it rejects, so a whole burst fails at once — and it
+  /// would not be safe anyway: Android USB fails a single write on a
+  /// PlatformException without raising a transport fault, so one transient
+  /// error would leave the page permanently dead with nothing on screen saying
+  /// how to revive it. A session that has really gone raises a disconnect, and
+  /// [_onConnectionState] is what acts on that.
+  ///
+  /// Cleared when the device says anything, since that proves the link works
+  /// and makes the next failure news again.
+  bool _writeFailureShown = false;
+
+  static final Uint8List _ctrlC = Uint8List.fromList(const [0x03]);
+  static final Uint8List _cliNudge = Uint8List.fromList(const [0x01]);
+
   @override
   void initState() {
     super.initState();
@@ -70,12 +88,16 @@ class _CliPageState extends State<CliPage> {
     Future<void> Function() send,
     String what, {
     Duration? timeout,
+    void Function(Object error)? onFailure,
   }) {
     final call = Future.sync(send);
-    return (timeout == null ? call : call.timeout(timeout)).catchError(
-      (Object e, StackTrace st) =>
-          LogService.error('[CLI] $what failed: $e\n$st'),
-    );
+    return (timeout == null ? call : call.timeout(timeout)).catchError((
+      Object e,
+      StackTrace st,
+    ) {
+      LogService.error('[CLI] $what failed: $e\n$st');
+      onFailure?.call(e);
+    });
   }
 
   /// Says something in the terminal itself, on its own line and in red.
@@ -85,26 +107,30 @@ class _CliPageState extends State<CliPage> {
   /// `bool.fromEnvironment('QLOG', defaultValue: kDebugMode)` — so in a release
   /// build a failed write drew nothing at all, and a terminal that silently
   /// eats keystrokes is indistinguishable from a Flipper that has hung.
-  void _notice(String message) =>
-      _terminal.write('\r\n\x1b[31m$message\x1b[0m\r\n');
+  ///
+  /// Not a `QNotification`, which is how the rest of the app reports a failure:
+  /// a toast that dismisses itself after two seconds and closes the one before
+  /// it is the wrong shape here. A terminal's errors belong in the scrollback,
+  /// beside the output they interrupted, for as long as the output lasts.
+  ///
+  /// Control characters are stripped from [message] before it goes in. It
+  /// carries exception text, and that in turn carries driver and OS strings —
+  /// anything holding an escape byte would otherwise break out of the colour
+  /// and drive the emulator.
+  void _notice(String message) => _terminal.write(
+    '\r\n\x1b[31m${message.replaceAll(RegExp(r'[\x00-\x1f\x7f]'), ' ')}'
+    '\x1b[0m\r\n',
+  );
 
   /// Sends something the user is waiting on, and says so when it does not
   /// arrive.
-  ///
-  /// Drops [_ready] as well. Every way `writeCliBytes` fails means the session
-  /// is gone — no transport, or already back in RPC mode — so leaving it set
-  /// gives a terminal that keeps taking keystrokes it cannot deliver and draws
-  /// one more red line for each. Backing out and re-entering the page is how a
-  /// working session is got back, which is what a disconnect already required.
-  void _fireAndShow(Future<void> Function() send, String what) {
-    unawaited(
-      Future.sync(send).catchError((Object e, StackTrace st) {
-        LogService.error('[CLI] $what failed: $e\n$st');
-        if (!mounted) return;
-        _notice(l10n.cliWriteFailed('$e'));
-        if (_ready) setState(() => _ready = false);
-      }),
-    );
+  void _fireAndShow(Future<void> Function() send, String what) =>
+      unawaited(_guarded(send, what, onFailure: _reportWriteFailure));
+
+  void _reportWriteFailure(Object error) {
+    if (!mounted || _writeFailureShown) return;
+    _writeFailureShown = true;
+    _notice(l10n.cliWriteFailed('$error'));
   }
 
   @override
@@ -115,39 +141,51 @@ class _CliPageState extends State<CliPage> {
     // cliExclusive is set, so reordering these two breaks every USB teardown.
     _client.cliExclusive = false;
 
-    // dispose() cannot be async, so there is nowhere to await this and no UI
-    // left to report into if it fails. Best effort, logged.
+    // dispose() cannot be async, so there is nowhere to await either of these
+    // and no UI left to report into if they fail. Best effort, logged.
     //
-    // Chained ahead of the switch rather than fired alongside it. Unsequenced,
-    // the two raced: _doSwitchToRpcMode flips mode partway through, so the
-    // interrupt either arrived after it and died on "Cannot send CLI bytes
-    // while in RPC mode" - logged as though the cable had been pulled - or
-    // landed as a stray 0x03 inside an RPC stream.
+    // The interrupt goes first and the switch waits for it. Unsequenced, the
+    // two raced: _doSwitchToRpcMode flips mode partway through, so the ctrl-c
+    // either arrived after it and died on "Cannot send CLI bytes while in RPC
+    // mode" - logged as though the cable had been pulled - or landed as a
+    // stray 0x03 inside an RPC stream.
     //
-    // The wait is bounded because the write need not ever finish. Desktop USB
+    // The wait is bounded because the write need not ever finish: desktop USB
     // hands it to an isolate and waits on a completer with no timeout of its
-    // own (Android's has ten seconds), so a wedged port would otherwise hold
-    // the RPC restore open for the life of the process.
-    final interrupt = _awaitingInterrupt
-        ? _guarded(
-            () => _client.writeCliBytes(Uint8List.fromList([0x03])),
-            'ctrl-c on dispose',
-            timeout: const Duration(seconds: 2),
-          )
-        : Future<void>.value();
+    // own, where Android's has ten seconds. Bounding it narrows the race
+    // rather than closing it, since a timeout abandons the wait without
+    // cancelling the write - the bytes are still in the transport's pump and
+    // can still land late. Holding the restore open for the life of the
+    // process is the worse trade. Note for tests: a dispose with a write in
+    // flight leaves this timer pending, so they have to pump past it.
+    //
+    // Everything about the client is read here, synchronously, rather than
+    // inside the chain. Read two seconds later, connectedDevice may be null
+    // and the BLE test would invert; and holding _client in the closure keeps
+    // a disposed State alive with it.
+    final client = _client;
+    final device = client.connectedDevice;
+    final restoreRpc = device?.isBle != true;
 
-    if (_client.connectedDevice?.isBle != true) {
+    Future<void> teardown() async {
+      if (_awaitingInterrupt) {
+        await _guarded(
+          () => client.writeCliBytes(_ctrlC),
+          'ctrl-c on dispose',
+          timeout: const Duration(seconds: 2),
+        );
+      }
+      // Not the session this page had, by now: the wait above can span a
+      // couple of seconds, and cliExclusive is re-read from whatever session
+      // is active, so a fresh CLI page would not be protected from this. It
+      // would be switched to RPC mode under itself and its nudge would fail.
+      if (!restoreRpc || !identical(client.connectedDevice, device)) return;
       // enterRpcMode returns quietly when the session is already gone, but the
-      // switch it returns can still reject, and unawaited silences the lint
-      // rather than the error.
-      unawaited(
-        interrupt.then(
-          (_) => _guarded(_client.enterRpcMode, 'leaving cli mode'),
-        ),
-      );
-    } else {
-      unawaited(interrupt);
+      // switch it returns can still reject.
+      await _guarded(client.enterRpcMode, 'leaving cli mode');
     }
+
+    unawaited(teardown());
     _terminalController.dispose();
     _terminalFocusNode.dispose();
     super.dispose();
@@ -165,7 +203,9 @@ class _CliPageState extends State<CliPage> {
 
   void _onTerminalOutput(String data) {
     if (!_ready) return;
-    final bytes = Uint8List.fromList(utf8.encode(data));
+    // utf8.encode returns a Uint8List already; wrapping it in
+    // Uint8List.fromList copied the buffer once per keystroke.
+    final bytes = utf8.encode(data);
     _fireAndShow(() => _client.writeCliBytes(bytes), 'write');
   }
 
@@ -216,8 +256,12 @@ class _CliPageState extends State<CliPage> {
     }
     try {
       await _client.connect(selected, autoRpc: false);
-    } catch (e) {
-      LogService.log('[CLI] connect failed: $e');
+    } catch (e, st) {
+      LogService.error('[CLI] connect failed: $e\n$st');
+      // Into the terminal before the dialog, not after: if the dialog itself
+      // throws, this is the only place the real reason survives - the outer
+      // catch would otherwise draw the dialog's failure instead.
+      if (mounted) _notice(l10n.cliStartFailed('$e'));
       await _showConnectionFailedDialog(selected, e);
       if (mounted) {
         Navigator.of(context).maybePop();
@@ -231,8 +275,11 @@ class _CliPageState extends State<CliPage> {
     try {
       await _client.disconnect();
       await _client.connect(device, autoRpc: false);
-    } catch (e) {
-      LogService.log('[CLI] reconnect failed: $e');
+    } catch (e, st) {
+      LogService.error('[CLI] reconnect failed: $e\n$st');
+      // As above: the reason reaches the scrollback before anything that could
+      // throw on the way to showing it.
+      if (mounted) _notice(l10n.cliStartFailed('$e'));
       await _showConnectionFailedDialog(device, e);
       if (mounted) {
         Navigator.of(context).maybePop();
@@ -252,24 +299,32 @@ class _CliPageState extends State<CliPage> {
 
   Future<void> _enterCliReady() async {
     if (!mounted) return;
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (!mounted) return;
-      _terminalFocusNode.requestFocus();
-    });
     await Future<void>.delayed(const Duration(milliseconds: 500));
     if (!mounted) return;
     try {
-      await _client.writeCliBytes(Uint8List.fromList([0x01]));
+      await _client.writeCliBytes(_cliNudge);
     } catch (e, st) {
       // Ready is claimed after the nudge lands, not before it is sent. Claimed
       // first, a nudge that failed left a black terminal that took every
       // keystroke and posted it into a session that had never been opened.
       LogService.error('[CLI] init nudge failed: $e\n$st');
-      _notice(l10n.cliStartFailed('$e'));
+      if (mounted) _notice(l10n.cliStartFailed('$e'));
       return;
     }
+    // The write is a second suspension point, and the page can be backed out
+    // of while it is in flight. Without this the setState below throws
+    // "called after dispose()", which unwinds all the way to _bootstrap's
+    // catch and is reported there as a bootstrap failure.
+    if (!mounted) return;
     setState(() {
       _ready = true;
+    });
+    // After the session is known good, not before it is opened: registered
+    // ahead of any setState, this asked for focus on a terminal that might
+    // never accept anything.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _terminalFocusNode.requestFocus();
     });
   }
 
@@ -287,6 +342,9 @@ class _CliPageState extends State<CliPage> {
 
   void _onText(String text) {
     _awaitingInterrupt = !text.contains('>:');
+    // The device answered, so the link works and the next write that does not
+    // arrive is news again rather than more of the same failure.
+    _writeFailureShown = false;
     _terminal.write(text);
   }
 
@@ -297,10 +355,7 @@ class _CliPageState extends State<CliPage> {
 
   void _sendCtrlC() {
     if (!_ready) return;
-    _fireAndShow(
-      () => _client.writeCliBytes(Uint8List.fromList([0x03])),
-      'ctrl-c',
-    );
+    _fireAndShow(() => _client.writeCliBytes(_ctrlC), 'ctrl-c');
     _terminalFocusNode.requestFocus();
   }
 

--- a/lib/pages/tools/remote/cli/page.dart
+++ b/lib/pages/tools/remote/cli/page.dart
@@ -57,9 +57,8 @@ class _CliPageState extends State<CliPage> {
     WidgetsBinding.instance.addPostFrameCallback((_) => _bootstrap());
   }
 
-  /// Sends something to the device that nobody can be told about — teardown,
-  /// or a keystroke the terminal has already echoed — and records why it did
-  /// not arrive.
+  /// Runs [send] and puts whatever it throws in the log, so the future it
+  /// returns never rejects and something else can be chained behind it.
   ///
   /// [Future.sync] is the point. `FlipperClient.writeCliBytes` is not async,
   /// so a session that is gone throws before there is a future to attach a
@@ -67,12 +66,44 @@ class _CliPageState extends State<CliPage> {
   /// already back in RPC mode, and the write itself all reject instead. Both
   /// StateErrors read "No active transport", so the difference is easy to
   /// miss; running the call inside Future.sync puts both in the same place.
-  void _fireAndLog(Future<void> Function() send, String what) {
+  static Future<void> _guarded(
+    Future<void> Function() send,
+    String what, {
+    Duration? timeout,
+  }) {
+    final call = Future.sync(send);
+    return (timeout == null ? call : call.timeout(timeout)).catchError(
+      (Object e, StackTrace st) =>
+          LogService.error('[CLI] $what failed: $e\n$st'),
+    );
+  }
+
+  /// Says something in the terminal itself, on its own line and in red.
+  ///
+  /// The one surface the user is actually looking at. Everything below used to
+  /// reach `LogService` only, and `LogService.enabled` is
+  /// `bool.fromEnvironment('QLOG', defaultValue: kDebugMode)` — so in a release
+  /// build a failed write drew nothing at all, and a terminal that silently
+  /// eats keystrokes is indistinguishable from a Flipper that has hung.
+  void _notice(String message) =>
+      _terminal.write('\r\n\x1b[31m$message\x1b[0m\r\n');
+
+  /// Sends something the user is waiting on, and says so when it does not
+  /// arrive.
+  ///
+  /// Drops [_ready] as well. Every way `writeCliBytes` fails means the session
+  /// is gone — no transport, or already back in RPC mode — so leaving it set
+  /// gives a terminal that keeps taking keystrokes it cannot deliver and draws
+  /// one more red line for each. Backing out and re-entering the page is how a
+  /// working session is got back, which is what a disconnect already required.
+  void _fireAndShow(Future<void> Function() send, String what) {
     unawaited(
-      Future.sync(send).catchError(
-        (Object e, StackTrace st) =>
-            LogService.error('[CLI] $what failed: $e\n$st'),
-      ),
+      Future.sync(send).catchError((Object e, StackTrace st) {
+        LogService.error('[CLI] $what failed: $e\n$st');
+        if (!mounted) return;
+        _notice(l10n.cliWriteFailed('$e'));
+        if (_ready) setState(() => _ready = false);
+      }),
     );
   }
 
@@ -80,22 +111,42 @@ class _CliPageState extends State<CliPage> {
   void dispose() {
     _textSub?.cancel();
     _connSub?.cancel();
-    if (_awaitingInterrupt) {
-      // dispose() cannot be async, so there is nowhere to await this and no
-      // UI left to report into if it fails. Best effort, logged.
-      _fireAndLog(
-        () => _client.writeCliBytes(Uint8List.fromList([0x03])),
-        'ctrl-c on dispose',
-      );
-    }
     // Stays ahead of enterRpcMode: switchToRpcMode refuses outright while
     // cliExclusive is set, so reordering these two breaks every USB teardown.
     _client.cliExclusive = false;
+
+    // dispose() cannot be async, so there is nowhere to await this and no UI
+    // left to report into if it fails. Best effort, logged.
+    //
+    // Chained ahead of the switch rather than fired alongside it. Unsequenced,
+    // the two raced: _doSwitchToRpcMode flips mode partway through, so the
+    // interrupt either arrived after it and died on "Cannot send CLI bytes
+    // while in RPC mode" - logged as though the cable had been pulled - or
+    // landed as a stray 0x03 inside an RPC stream.
+    //
+    // The wait is bounded because the write need not ever finish. Desktop USB
+    // hands it to an isolate and waits on a completer with no timeout of its
+    // own (Android's has ten seconds), so a wedged port would otherwise hold
+    // the RPC restore open for the life of the process.
+    final interrupt = _awaitingInterrupt
+        ? _guarded(
+            () => _client.writeCliBytes(Uint8List.fromList([0x03])),
+            'ctrl-c on dispose',
+            timeout: const Duration(seconds: 2),
+          )
+        : Future<void>.value();
+
     if (_client.connectedDevice?.isBle != true) {
       // enterRpcMode returns quietly when the session is already gone, but the
       // switch it returns can still reject, and unawaited silences the lint
       // rather than the error.
-      _fireAndLog(_client.enterRpcMode, 'leaving cli mode');
+      unawaited(
+        interrupt.then(
+          (_) => _guarded(_client.enterRpcMode, 'leaving cli mode'),
+        ),
+      );
+    } else {
+      unawaited(interrupt);
     }
     _terminalController.dispose();
     _terminalFocusNode.dispose();
@@ -115,7 +166,7 @@ class _CliPageState extends State<CliPage> {
   void _onTerminalOutput(String data) {
     if (!_ready) return;
     final bytes = Uint8List.fromList(utf8.encode(data));
-    _fireAndLog(() => _client.writeCliBytes(bytes), 'write');
+    _fireAndShow(() => _client.writeCliBytes(bytes), 'write');
   }
 
   Future<void> _bootstrap() async {
@@ -134,8 +185,15 @@ class _CliPageState extends State<CliPage> {
         return;
       }
       await _resetUsbCliSession(device);
-    } catch (e) {
-      LogService.log('[CLI] bootstrap failed: $e');
+    } catch (e, st) {
+      // Everything the inner handlers do not already report: a throw out of
+      // the connection dialog, a Navigator error, setState on a dead element -
+      // or _showConnectionFailedDialog itself failing, which is the bad one.
+      // That downgrades a connection error the user never saw to a log line
+      // and leaves the page mounted, black and not ready, with nothing to do
+      // but back out. The stack is what separates those from one another.
+      LogService.error('[CLI] bootstrap failed: $e\n$st');
+      if (mounted) _notice(l10n.cliStartFailed('$e'));
     } finally {
       _busy = false;
     }
@@ -194,24 +252,33 @@ class _CliPageState extends State<CliPage> {
 
   Future<void> _enterCliReady() async {
     if (!mounted) return;
-    setState(() {
-      _ready = true;
-    });
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       _terminalFocusNode.requestFocus();
     });
     await Future<void>.delayed(const Duration(milliseconds: 500));
+    if (!mounted) return;
     try {
       await _client.writeCliBytes(Uint8List.fromList([0x01]));
-    } catch (e) {
-      LogService.log('[CLI] init nudge failed: $e');
+    } catch (e, st) {
+      // Ready is claimed after the nudge lands, not before it is sent. Claimed
+      // first, a nudge that failed left a black terminal that took every
+      // keystroke and posted it into a session that had never been opened.
+      LogService.error('[CLI] init nudge failed: $e\n$st');
+      _notice(l10n.cliStartFailed('$e'));
+      return;
     }
+    setState(() {
+      _ready = true;
+    });
   }
 
   void _onConnectionState(FlipperConnectionState state) {
     if (!mounted) return;
     if (!state.connected && _ready) {
+      // One line here explains every failure that would otherwise follow it,
+      // and without it the terminal simply stops answering.
+      _notice(l10n.cliDisconnected);
       setState(() {
         _ready = false;
       });
@@ -230,7 +297,7 @@ class _CliPageState extends State<CliPage> {
 
   void _sendCtrlC() {
     if (!_ready) return;
-    _fireAndLog(
+    _fireAndShow(
       () => _client.writeCliBytes(Uint8List.fromList([0x03])),
       'ctrl-c',
     );

--- a/test/cli_teardown_test.dart
+++ b/test/cli_teardown_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:qunleashed/pages/tools/remote/cli/page.dart';
 import 'package:qunleashed/theme/theme.dart';
+import 'package:xterm/xterm.dart';
 
 class _FakeDiscovered implements DiscoveredDevice {
   _FakeDiscovered(this.transport);
@@ -42,6 +43,11 @@ class _FakeClient implements FlipperClient {
   _WriteFailure writeFailure = _WriteFailure.none;
   bool enterRpcModeRejects = false;
 
+  /// Holds a write open, so a test can see what happens while one is still in
+  /// flight. Desktop USB waits on a completer with no timeout of its own, so
+  /// "never finishes" is a real state, not a contrived one.
+  Completer<void>? heldWrite;
+
   int writeCalls = 0;
   int enterRpcModeCalls = 0;
 
@@ -66,6 +72,8 @@ class _FakeClient implements FlipperClient {
   Future<void> writeCliBytes(Uint8List bytes) {
     writeCalls += 1;
     events.add('write');
+    final held = heldWrite;
+    if (held != null) return held.future;
     switch (writeFailure) {
       case _WriteFailure.throwsSynchronously:
         throw StateError('No active transport');
@@ -95,6 +103,34 @@ class _FakeClient implements FlipperClient {
   @override
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
+
+/// Everything the terminal has drawn.
+///
+/// Read off the rendered TerminalView rather than through a seam in the page:
+/// the notices are the user-facing half of this fix, and the buffer is what
+/// the user is actually looking at.
+String _terminalText(WidgetTester tester) {
+  final buffer = _terminalOf(tester).buffer;
+  return [
+    for (var i = 0; i < buffer.lines.length; i++) buffer.lines[i].toString(),
+  ].join('\n');
+}
+
+Terminal _terminalOf(WidgetTester tester) =>
+    tester.widget<TerminalView>(find.byType(TerminalView)).terminal;
+
+/// Whether the page still believes it has a session. `_ready` is private, and
+/// this is what it actually controls that a user can see.
+bool _acceptsInput(WidgetTester tester) =>
+    tester
+        .widget<IconButton>(
+          find.ancestor(
+            of: find.byIcon(Icons.stop_circle_outlined),
+            matching: find.byType(IconButton),
+          ),
+        )
+        .onPressed !=
+    null;
 
 Widget _wrap(Widget child) => MaterialApp(
   theme: buildAppTheme(Brightness.dark, const Color(0xFFCC241D)),
@@ -261,5 +297,162 @@ void main() {
 
     expect(client.writeCalls, before + 1, reason: 'the button is live');
     expect(logs.where((l) => l.contains('ctrl-c failed')), isNotEmpty);
+  });
+  // #80. A keystroke that never reached the device drew nothing at all, and
+  // LogService.enabled is bool.fromEnvironment('QLOG', kDebugMode) - so in a
+  // release build the only evidence was gone too. What the user saw was a
+  // terminal that had stopped echoing, which reads as a Flipper that has hung.
+  testWidgets('a keystroke that cannot be delivered says so in the terminal', (
+    tester,
+  ) async {
+    final client = _FakeClient(link: FlipperLink.usb);
+    addTearDown(client.text.close);
+    await tester.pumpWidget(_wrap(CliPage(client: client)));
+    await tester.pump(const Duration(milliseconds: 600));
+
+    client.writeFailure = _WriteFailure.rejects;
+    await recordingLogs(() async {
+      _terminalOf(tester).textInput('ls');
+      await tester.pump();
+    });
+
+    expect(_terminalText(tester), contains('not sent'));
+  });
+
+  // The same failure, from the synchronous side: resolving a session that is
+  // gone throws before there is a future to attach a handler to.
+  testWidgets('a keystroke refused before it is sent says so too', (
+    tester,
+  ) async {
+    final client = _FakeClient(link: FlipperLink.usb);
+    addTearDown(client.text.close);
+    await tester.pumpWidget(_wrap(CliPage(client: client)));
+    await tester.pump(const Duration(milliseconds: 600));
+
+    client.writeFailure = _WriteFailure.throwsSynchronously;
+    await recordingLogs(() async {
+      _terminalOf(tester).textInput('ls');
+      await tester.pump();
+    });
+
+    expect(_terminalText(tester), contains('not sent'));
+  });
+
+  // Every way writeCliBytes fails means the session is gone, so a terminal
+  // that kept accepting input would draw one more red line per keystroke and
+  // deliver none of them.
+  testWidgets('a failed write stops the page taking more input', (
+    tester,
+  ) async {
+    final client = _FakeClient(link: FlipperLink.usb);
+    addTearDown(client.text.close);
+    await tester.pumpWidget(_wrap(CliPage(client: client)));
+    await tester.pump(const Duration(milliseconds: 600));
+    expect(_acceptsInput(tester), isTrue, reason: 'live to begin with');
+
+    client.writeFailure = _WriteFailure.rejects;
+    await recordingLogs(() async {
+      _terminalOf(tester).textInput('ls');
+      await tester.pump();
+    });
+
+    expect(_acceptsInput(tester), isFalse);
+  });
+
+  // _enterCliReady set _ready before sending the nudge, so a nudge that failed
+  // left a black terminal taking every keystroke and posting it into a session
+  // that had never been opened.
+  testWidgets('the page does not claim ready when the nudge fails', (
+    tester,
+  ) async {
+    final client = _FakeClient(link: FlipperLink.usb)
+      ..writeFailure = _WriteFailure.rejects;
+    addTearDown(client.text.close);
+
+    await recordingLogs(() async {
+      await tester.pumpWidget(_wrap(CliPage(client: client)));
+      await tester.pump(const Duration(milliseconds: 600));
+    });
+
+    expect(_acceptsInput(tester), isFalse);
+    expect(_terminalText(tester), contains('could not open'));
+  });
+
+  testWidgets('the terminal says when the device goes away', (tester) async {
+    final client = _FakeClient(link: FlipperLink.usb);
+    addTearDown(client.text.close);
+    addTearDown(client.connection.close);
+    await tester.pumpWidget(_wrap(CliPage(client: client)));
+    await tester.pump(const Duration(milliseconds: 600));
+
+    client.connection.add(
+      const FlipperConnectionState(
+        mode: FlipperMode.cli,
+        device: null,
+        connected: false,
+      ),
+    );
+    await tester.pump();
+
+    expect(_terminalText(tester), contains('disconnected'));
+    expect(_acceptsInput(tester), isFalse);
+  });
+
+  // The teardown race. _doSwitchToRpcMode flips mode partway through, so an
+  // interrupt still in flight either died on "Cannot send CLI bytes while in
+  // RPC mode" - logged as though the cable had been pulled - or landed as a
+  // stray 0x03 inside an RPC stream. Counting calls cannot see it; holding the
+  // write open can.
+  testWidgets('the interrupt finishes before the switch back to RPC', (
+    tester,
+  ) async {
+    final client = _FakeClient(link: FlipperLink.usb);
+    addTearDown(client.text.close);
+    await tester.pumpWidget(_wrap(CliPage(client: client)));
+    await tester.pump(const Duration(milliseconds: 600));
+    client.text.add('doing something long');
+    await tester.pump();
+
+    final held = Completer<void>();
+    client.heldWrite = held;
+    await tester.pumpWidget(_wrap(const SizedBox.shrink()));
+    await tester.pump();
+
+    expect(client.writeCalls, greaterThan(0), reason: 'the interrupt went');
+    expect(
+      client.enterRpcModeCalls,
+      0,
+      reason: 'and the switch is waiting on it',
+    );
+
+    held.complete();
+    await tester.pump();
+
+    expect(client.enterRpcModeCalls, 1);
+  });
+
+  // Sequencing them is only safe because the wait is bounded. Desktop USB
+  // hands the write to an isolate and waits on a completer with no timeout of
+  // its own, so a wedged port must not hold the RPC restore open for the life
+  // of the process.
+  testWidgets('a write that never finishes does not strand the RPC restore', (
+    tester,
+  ) async {
+    final client = _FakeClient(link: FlipperLink.usb);
+    addTearDown(client.text.close);
+    await tester.pumpWidget(_wrap(CliPage(client: client)));
+    await tester.pump(const Duration(milliseconds: 600));
+    client.text.add('doing something long');
+    await tester.pump();
+
+    client.heldWrite = Completer<void>();
+    await recordingLogs(() async {
+      await tester.pumpWidget(_wrap(const SizedBox.shrink()));
+      await tester.pump();
+      expect(client.enterRpcModeCalls, 0);
+      await tester.pump(const Duration(seconds: 3));
+    });
+
+    expect(client.enterRpcModeCalls, 1);
   });
 }

--- a/test/cli_teardown_test.dart
+++ b/test/cli_teardown_test.dart
@@ -31,10 +31,21 @@ FlipperDevice _device(FlipperLink link) => FlipperDevice(
 /// resolving a session that is gone throws before any future exists, while the
 /// session's own write is async and rejects. They are one field rather than
 /// two booleans so "both at once", which cannot happen, cannot be written.
-enum _WriteFailure { none, throwsSynchronously, rejects }
+enum _WriteFailure {
+  none,
+  throwsSynchronously,
+  rejects,
+
+  /// An error whose text carries an escape sequence, as a driver or OS
+  /// message can. Here a clear-screen, so a notice that passed it through
+  /// would visibly wipe the scrollback.
+  escapeInMessage,
+}
 
 class _FakeClient implements FlipperClient {
-  _FakeClient({this.link = FlipperLink.ble});
+  _FakeClient({this.link = FlipperLink.ble}) {
+    _current = _device(link);
+  }
 
   final FlipperLink link;
   final text = StreamController<String>.broadcast();
@@ -56,14 +67,28 @@ class _FakeClient implements FlipperClient {
   /// fake that only counted calls could not tell.
   final List<String> events = [];
 
+  /// Lets a test count what the terminal drew, where `contains` cannot tell
+  /// one notice from fifteen.
+  static int occurrences(String haystack, String needle) =>
+      needle.allMatches(haystack).length;
+
   @override
   Stream<String> get textStream => text.stream;
 
   @override
   Stream<FlipperConnectionState> get connectionStream => connection.stream;
 
+  /// One instance for the life of a session, as the real client does -
+  /// FlipperSession.device is final and connectedDevice returns it, so
+  /// identity is what tells one session from the next.
+  FlipperDevice _current = _device(FlipperLink.usb);
+
   @override
-  FlipperDevice? get connectedDevice => _device(link);
+  FlipperDevice? get connectedDevice => _current;
+
+  /// Stands in for a reconnect: connect() builds a fresh session carrying a
+  /// fresh device.
+  void startNewSession() => _current = _device(link);
 
   @override
   set cliExclusive(bool value) => events.add('cliExclusive=$value');
@@ -79,6 +104,10 @@ class _FakeClient implements FlipperClient {
         throw StateError('No active transport');
       case _WriteFailure.rejects:
         return Future<void>.error(StateError('transport is gone'));
+      case _WriteFailure.escapeInMessage:
+        return Future<void>.error(
+          StateError('write failed [2J[H and then some'),
+        );
       case _WriteFailure.none:
         return Future<void>.value();
     }
@@ -338,17 +367,16 @@ void main() {
     expect(_terminalText(tester), contains('not sent'));
   });
 
-  // Every way writeCliBytes fails means the session is gone, so a terminal
-  // that kept accepting input would draw one more red line per keystroke and
-  // deliver none of them.
-  testWidgets('a failed write stops the page taking more input', (
-    tester,
-  ) async {
+  // A failed write does not mean the session is gone. Android USB fails one
+  // write on a PlatformException without raising a transport fault, so the
+  // transport stays usable - and a page that shut itself down on the first
+  // failure would be dead for good, with nothing on screen saying how to
+  // revive it. A session that has really gone raises a disconnect instead.
+  testWidgets('a failed write leaves a still-live page usable', (tester) async {
     final client = _FakeClient(link: FlipperLink.usb);
     addTearDown(client.text.close);
     await tester.pumpWidget(_wrap(CliPage(client: client)));
     await tester.pump(const Duration(milliseconds: 600));
-    expect(_acceptsInput(tester), isTrue, reason: 'live to begin with');
 
     client.writeFailure = _WriteFailure.rejects;
     await recordingLogs(() async {
@@ -356,7 +384,80 @@ void main() {
       await tester.pump();
     });
 
-    expect(_acceptsInput(tester), isFalse);
+    expect(_acceptsInput(tester), isTrue);
+    client.writeFailure = _WriteFailure.none;
+    final before = client.writeCalls;
+    _terminalOf(tester).textInput('ls');
+    await tester.pump();
+    expect(client.writeCalls, before + 1, reason: 'and still delivering');
+  });
+
+  // Clearing _ready would have stopped new keystrokes but not the writes
+  // already in flight, and on Android a write can sit for ten seconds before
+  // it rejects - so a burst all fails at once, each one drawing a line.
+  testWidgets('a burst of failed writes draws one line, not one each', (
+    tester,
+  ) async {
+    final client = _FakeClient(link: FlipperLink.usb);
+    addTearDown(client.text.close);
+    await tester.pumpWidget(_wrap(CliPage(client: client)));
+    await tester.pump(const Duration(milliseconds: 600));
+
+    client.writeFailure = _WriteFailure.rejects;
+    await recordingLogs(() async {
+      final terminal = _terminalOf(tester);
+      terminal.textInput('l');
+      terminal.textInput('s');
+      terminal.textInput('\r');
+      await tester.pump();
+    });
+
+    expect(_FakeClient.occurrences(_terminalText(tester), 'not sent'), 1);
+  });
+
+  testWidgets('the device answering makes the next failure news again', (
+    tester,
+  ) async {
+    final client = _FakeClient(link: FlipperLink.usb);
+    addTearDown(client.text.close);
+    await tester.pumpWidget(_wrap(CliPage(client: client)));
+    await tester.pump(const Duration(milliseconds: 600));
+
+    await recordingLogs(() async {
+      client.writeFailure = _WriteFailure.rejects;
+      _terminalOf(tester).textInput('ls');
+      await tester.pump();
+
+      client.text.add('the link is fine');
+      await tester.pump();
+
+      _terminalOf(tester).textInput('ls');
+      await tester.pump();
+    });
+
+    expect(_FakeClient.occurrences(_terminalText(tester), 'not sent'), 2);
+  });
+
+  // Exception text carries driver and OS strings. An escape byte in one would
+  // otherwise be handed straight to the emulator - here, a clear-screen that
+  // would wipe the output the notice is meant to sit beside.
+  testWidgets('an error carrying escape codes cannot drive the terminal', (
+    tester,
+  ) async {
+    final client = _FakeClient(link: FlipperLink.usb);
+    addTearDown(client.text.close);
+    await tester.pumpWidget(_wrap(CliPage(client: client)));
+    await tester.pump(const Duration(milliseconds: 600));
+    client.text.add('output worth keeping');
+    await tester.pump();
+
+    client.writeFailure = _WriteFailure.escapeInMessage;
+    await recordingLogs(() async {
+      _terminalOf(tester).textInput('ls');
+      await tester.pump();
+    });
+
+    expect(_terminalText(tester), contains('output worth keeping'));
   });
 
   // _enterCliReady set _ready before sending the nudge, so a nudge that failed
@@ -454,5 +555,58 @@ void main() {
     });
 
     expect(client.enterRpcModeCalls, 1);
+  });
+
+  // The nudge is a second suspension point, and the page can be backed out of
+  // while it is in flight. Without a mounted recheck the setState after it
+  // throws "called after dispose()", which unwinds into _bootstrap's catch and
+  // is reported there as a bootstrap failure - the exact misattribution the
+  // stack trace was added to prevent.
+  testWidgets('backing out while the nudge is in flight is not an error', (
+    tester,
+  ) async {
+    final client = _FakeClient(link: FlipperLink.usb);
+    addTearDown(client.text.close);
+    final held = Completer<void>();
+    client.heldWrite = held;
+
+    final logs = await recordingLogs(() async {
+      await tester.pumpWidget(_wrap(CliPage(client: client)));
+      await tester.pump(const Duration(milliseconds: 600));
+      await tester.pumpWidget(_wrap(const SizedBox.shrink()));
+      await tester.pump();
+
+      held.complete();
+      await tester.pump();
+    });
+
+    expect(logs.where((l) => l.contains('bootstrap failed')), isEmpty);
+    expect(logs.where((l) => l.contains('setState')), isEmpty);
+  });
+
+  // Chaining the switch behind the interrupt put up to two seconds between
+  // dispose and the switch, and cliExclusive is re-read from whatever session
+  // is active - so a CLI page opened in the meantime would be switched to RPC
+  // mode under itself, and its own nudge would then fail.
+  testWidgets('a teardown that outlives its session leaves the next alone', (
+    tester,
+  ) async {
+    final client = _FakeClient(link: FlipperLink.usb);
+    addTearDown(client.text.close);
+    await tester.pumpWidget(_wrap(CliPage(client: client)));
+    await tester.pump(const Duration(milliseconds: 600));
+    client.text.add('doing something long');
+    await tester.pump();
+
+    client.heldWrite = Completer<void>();
+    await recordingLogs(() async {
+      await tester.pumpWidget(_wrap(const SizedBox.shrink()));
+      await tester.pump();
+      // A new page connects while the old interrupt is still outstanding.
+      client.startNewSession();
+      await tester.pump(const Duration(seconds: 3));
+    });
+
+    expect(client.enterRpcModeCalls, 0);
   });
 }

--- a/translations/app_en.arb
+++ b/translations/app_en.arb
@@ -3428,6 +3428,31 @@
     }
   },
 
+  "cliWriteFailed": "[not sent: {error}]",
+  "@cliWriteFailed": {
+    "description": "Written into the CLI terminal, in red, when a keystroke or Ctrl-C could not be delivered to the device. Keep it short and bracketed: it sits inline among the device's own output. {error} is the untranslated exception text.",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+
+  "cliStartFailed": "[could not open the CLI session: {error}]",
+  "@cliStartFailed": {
+    "description": "Written into the CLI terminal, in red, when the session could not be opened at all - the initial nudge failed, or the page could not get as far as connecting. The terminal stays black and accepts nothing after this. {error} is the untranslated exception text.",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+
+  "cliDisconnected": "[disconnected]",
+  "@cliDisconnected": {
+    "description": "Written into the CLI terminal, in red, when the device goes away. Explains why the terminal has stopped responding to input."
+  },
+
   "cliSendCtrlC": "Send Ctrl+C",
   "@cliSendCtrlC": {
     "description": "Button that interrupts the running command in the terminal. Ctrl+C is a literal key combination."


### PR DESCRIPTION
#21 fixed the *reporting* side of CLI write failures — every fire-and-forget write got an error handler. This is the user-facing side, which was untouched.

## A failed keystroke looked like a hung Flipper

Every failure on this page reported through `LogService` only, and `LogService.enabled` is `bool.fromEnvironment('QLOG', defaultValue: kDebugMode)` — a compile-time `const`, so `LogService.error`'s body is tree-shaken out of release builds entirely. The user types, nothing echoes, and the only available conclusion is that the device has hung.

The terminal is right there and can say so. It now does, for a failed write, a failed init nudge, a disconnect, and a bootstrap failure.

## The checkbox that needed a decision, not code

> *Chaining them would settle it, but only if the write cannot hang — worth checking whether `transport.write` has a timeout before making the RPC restore wait on it.*

It doesn't, on desktop. `usb/link.dart:114` hands the bytes to an isolate and waits on a completer settled only by an ack or a detected fault; a wedged native write produces neither. Android's `rawWrite` has an explicit 10s timeout with a comment saying exactly why.

So: chained, with a 2s bound. That narrows the race rather than closing it — a timeout abandons the wait without cancelling the write, so the bytes are still in the transport's pump and can land late. Holding the RPC restore open for the life of the process is the worse trade, and the comment says so rather than claiming more.

## What review changed

Both halves of the first version were wrong about what a failed write means.

**Clearing `_ready` assumed every `writeCliBytes` failure means the session is gone.** True on desktop USB and BLE, which escalate a failed chunk into a full `onTransportFault`. Not true on Android: `usb/android.dart:105` catches only `TimeoutException`, so a `PlatformException` out of the plugin fails that one write and leaves `isActive == true`. The page shut itself down permanently over a transient error, and nothing re-arms `_ready` short of backing out.

**It didn't even stop the flooding it existed to stop.** Clearing `_ready` blocks new keystrokes, not the writes already in flight — and on Android those can sit ten seconds before rejecting. A probe confirmed three keystrokes in one turn drew three lines, while both my comment and my commit message claimed one. The notice is once-only now, re-armed when the device says anything, since that proves the link works. A session that really went raises a disconnect, which is what `_onConnectionState` is for.

**The teardown chain wasn't scoped to its session.** Putting up to two seconds between `dispose` and `enterRpcMode` opened a window for a *new* CLI page — and `_cliExclusive` is re-read from whichever session is active (`client.dart:783`; a fresh `FlipperSession` defaults to `false`), so the guard the old comment leaned on doesn't protect a live page. The stale switch would flip the new page's session to RPC mode under it. The chain now checks it's still the same session by device identity, `FlipperSession.device` being final.

**And moving `_ready` after the nudge introduced a `setState` across a second suspension point.** Backing out while the nudge was in flight threw `setState() called after dispose()`, which unwound into `_bootstrap`'s catch and was reported there as a *bootstrap* failure — the exact misattribution the new stack trace was added to prevent.

Smaller: exception text goes into an escape-sequence interpreter and carries driver and OS strings, so control characters are stripped; the two connect failures kept `LogService.log` with no stack while everything else moved to `error`, and their reason now reaches the scrollback *before* the dialog that might throw instead of it; `utf8.encode` has returned `Uint8List` since Dart 3, so wrapping it copied the buffer per keystroke.

## Why not a `QNotification`

The app has a real user-facing error channel — `context.showNotification(...)`, 114 call sites — and the immediate sibling page (`remote/desktop/page.dart`) uses it for failed device operations. It's the wrong shape here: it dismisses itself after two seconds and closes the one before it, where a terminal's errors belong in the scrollback beside the output they interrupted. That reasoning is now in the code, so the next person can tell "deliberately not a toast" from "didn't know there was one".

## Tests

429 pass. The tests read the rendered `TerminalView`'s buffer — the surface the user actually looks at — rather than a seam in the page, and `_ready` through the Ctrl-C button it controls. The fake gained a held-write completer, which is what makes the teardown race visible at all: counting calls cannot tell "chained" from "fired alongside", but holding the write open can.

Ten mutations, all caught, across two rounds: log-only writes, ready before the nudge, no disconnect notice, the teardown calls unsequenced, an unbounded wait, no `mounted` recheck, no once-only guard, no re-arm on device output, escape codes passed through, and the session identity check removed.

## Not in this PR

Review made an altitude point worth its own issue: `LogService.error` is a no-op in every shipped build, and there's no in-app log viewer, so even `--dart-define=QLOG=true` has nowhere to show what it captured. That is the class-level fix behind #21, #84, #85 and this one alike — one change instead of four page-local ones.

Also raised and left alone: raw exception strings reach users here and in `remote/desktop/page.dart` alike, so the house style shows people `StateError: No active transport`.

Closes #80.

🤖 Generated with [Claude Code](https://claude.com/claude-code)